### PR TITLE
Adding initial version of Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,95 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project
+and our community a harassment-free experience for everyone, regardless of
+age, body size, disability, ethnicity, gender identity and expression,
+level of experience, nationality, personal appearance, race, religion,
+or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Participate in an authentic and active way. In doing so, you contribute
+to the health and longevity of this community.
+* Exercise consideration and respect in your speech and actions.
+* Attempt collaboration before conflict.
+* Refrain from demeaning, discriminatory, or harassing behavior and speech.
+* Be mindful of your surroundings and of your fellow participants. Alert
+community leaders if you notice a dangerous situation, someone in distress,
+or violations of this Code of Conduct, even if they seem inconsequential.
+* Remember that community event venues may be shared with members of the
+public; please be respectful to all patrons of these locations.
+
+Examples of unacceptable behavior by participants include:
+
+* Violence, threats of violence or violent language directed against another
+person.
+* Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory
+jokes and language.
+* Posting or displaying sexually explicit or violent material.
+* Posting or threatening to post other people’s personally identifying
+information ("doxing").
+* Personal insults, particularly those related to gender, sexual orientation,
+race, religion, or disability.
+* Inappropriate photography or recording.
+* Inappropriate physical contact. You should have someone’s consent before
+touching them.
+* Unwelcome sexual attention. This includes, sexualized comments or jokes;
+inappropriate touching, groping, and unwelcomed sexual advances.
+* Deliberate intimidation, stalking or following (online or in person).
+* Advocating for, or encouraging, any of the above behavior.
+* Sustained disruption of community events, including talks and presentations.
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further details
+of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Contact Info
+
+If you need to report an incident, please contact any of the members of the
+[Project Leadership Committee (PLC)](/GOVERNANCE.md#project-leadership-committee-plc).
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](http://contributor-covenant.org/), version 1.4, available at
+[http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/)
+and also inspired among other things by:
+
+- [Citizen Code of Conduct](http://citizencodeofconduct.org/)
+- [Appium](https://github.com/appium/appium/blob/master/CONDUCT.md)


### PR DESCRIPTION
This PR adds an initial version of the Code of Conduct for the Selenium project.