### PR TITLE
Added .usingServer() to JavaScript Examples

### DIFF
--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.de.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.de.md
@@ -44,6 +44,7 @@ const { Builder, Capabilities } = require("selenium-webdriver");
 var capabilities = Capabilities.firefox();
 (async function helloSelenium() {
     let driver = new Builder()        
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {
@@ -107,6 +108,7 @@ capabilities.set("browserVersion", "67");
 capabilities.set("platformName", "Windows XP");
 (async function helloSelenium() {
     let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.en.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.en.md
@@ -37,7 +37,8 @@ driver.close
 const { Builder, Capabilities } = require("selenium-webdriver");
 var capabilities = Capabilities.firefox();
 (async function helloSelenium() {
-    let driver = new Builder()        
+    let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {
@@ -101,6 +102,7 @@ capabilities.set("browserVersion", "67");
 capabilities.set("platformName", "Windows XP");
 (async function helloSelenium() {
     let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.es.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.es.md
@@ -44,6 +44,7 @@ const { Builder, Capabilities } = require("selenium-webdriver");
 var capabilities = Capabilities.firefox();
 (async function helloSelenium() {
     let driver = new Builder()        
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {
@@ -107,6 +108,7 @@ capabilities.set("browserVersion", "67");
 capabilities.set("platformName", "Windows XP");
 (async function helloSelenium() {
     let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.fr.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.fr.md
@@ -44,6 +44,7 @@ const { Builder, Capabilities } = require("selenium-webdriver");
 var capabilities = Capabilities.firefox();
 (async function helloSelenium() {
     let driver = new Builder()        
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {
@@ -107,6 +108,7 @@ capabilities.set("browserVersion", "67");
 capabilities.set("platformName", "Windows XP");
 (async function helloSelenium() {
     let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.ja.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.ja.md
@@ -43,6 +43,7 @@ const { Builder, Capabilities } = require("selenium-webdriver");
 var capabilities = Capabilities.firefox();
 (async function helloSelenium() {
     let driver = new Builder()        
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {
@@ -106,6 +107,7 @@ capabilities.set("browserVersion", "67");
 capabilities.set("platformName", "Windows XP");
 (async function helloSelenium() {
     let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.ko.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.ko.md
@@ -44,6 +44,7 @@ const { Builder, Capabilities } = require("selenium-webdriver");
 var capabilities = Capabilities.firefox();
 (async function helloSelenium() {
     let driver = new Builder()        
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {
@@ -107,6 +108,7 @@ capabilities.set("browserVersion", "67");
 capabilities.set("platformName", "Windows XP");
 (async function helloSelenium() {
     let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.nl.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.nl.md
@@ -44,6 +44,7 @@ const { Builder, Capabilities } = require("selenium-webdriver");
 var capabilities = Capabilities.firefox();
 (async function helloSelenium() {
     let driver = new Builder()        
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {
@@ -107,6 +108,7 @@ capabilities.set("browserVersion", "67");
 capabilities.set("platformName", "Windows XP");
 (async function helloSelenium() {
     let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.zh-cn.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.zh-cn.md
@@ -43,6 +43,7 @@ const { Builder, Capabilities } = require("selenium-webdriver");
 var capabilities = Capabilities.firefox();
 (async function helloSelenium() {
     let driver = new Builder()        
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {
@@ -106,6 +107,7 @@ capabilities.set("browserVersion", "67");
 capabilities.set("platformName", "Windows XP");
 (async function helloSelenium() {
     let driver = new Builder()
+        .usingServer("http://example.com")   
         .withCapabilities(capabilities)
         .build();
     try {


### PR DESCRIPTION
Without .usingServer() the local browser is started, but it's a remote WebDriver example.

### Types of changes
- [X] fixed a wrong example

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
- [X] I don't want to install hugo, it's only a minor change, test it in your next testcycle, when you don't want to accept the PR, it's ok for me.
<!--- Provide a general summary of your changes in the Title above -->
