### PR TITLE
Add: Added JavaScript example for using FirefoxOptions

### DIFF
--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.de.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.de.md
@@ -36,12 +36,13 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-import * as firefox from 'selenium-webdriver/firefox';
-import { Builder } from 'selenium-webdriver';
+const { Builder } = require("selenium-webdriver");
+const firefox = require('selenium-webdriver/firefox');
 
 const options = new firefox.Options();
+options.headless();
 const driver = new Builder()
-    .withCapabilities({ browserName: 'firefox' })
+    .forBrowser('firefox')
     .setFirefoxOptions(options)
     .build();
   {{< / code-panel >}}

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.de.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.de.md
@@ -36,7 +36,14 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-// We don't have a JavaScript code sample yet -  Help us out and raise a PR  
+import * as firefox from 'selenium-webdriver/firefox';
+import { Builder } from 'selenium-webdriver';
+
+const options = new firefox.Options();
+const driver = new Builder()
+    .withCapabilities({ browserName: 'firefox' })
+    .setFirefoxOptions(options)
+    .build();
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
 val options = new FirefoxOptions()

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.en.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.en.md
@@ -31,12 +31,13 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-import * as firefox from 'selenium-webdriver/firefox';
-import { Builder } from 'selenium-webdriver';
+const { Builder } = require("selenium-webdriver");
+const firefox = require('selenium-webdriver/firefox');
 
 const options = new firefox.Options();
+options.headless();
 const driver = new Builder()
-    .withCapabilities({ browserName: 'firefox' })
+    .forBrowser('firefox')
     .setFirefoxOptions(options)
     .build();
   {{< / code-panel >}}

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.en.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.en.md
@@ -31,7 +31,14 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-// We don't have a JavaScript code sample yet -  Help us out and raise a PR  
+import * as firefox from 'selenium-webdriver/firefox';
+import { Builder } from 'selenium-webdriver';
+
+const options = new firefox.Options();
+const driver = new Builder()
+    .withCapabilities({ browserName: 'firefox' })
+    .setFirefoxOptions(options)
+    .build();
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
 val options = new FirefoxOptions()

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.es.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.es.md
@@ -30,12 +30,13 @@ var driver = new FirefoxDriver(options);
 # Todavía no tenemos una muestra de código Ruby: ayúdenos y genere un PR (_pull request_)
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-import * as firefox from 'selenium-webdriver/firefox';
-import { Builder } from 'selenium-webdriver';
+const { Builder } = require("selenium-webdriver");
+const firefox = require('selenium-webdriver/firefox');
 
 const options = new firefox.Options();
+options.headless();
 const driver = new Builder()
-    .withCapabilities({ browserName: 'firefox' })
+    .forBrowser('firefox')
     .setFirefoxOptions(options)
     .build();
   {{< / code-panel >}}

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.es.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.es.md
@@ -30,7 +30,14 @@ var driver = new FirefoxDriver(options);
 # Todavía no tenemos una muestra de código Ruby: ayúdenos y genere un PR (_pull request_)
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-// Todavía no tenemos una muestra de código JavaScript: ayúdenos y genere un PR (_pull request_)
+import * as firefox from 'selenium-webdriver/firefox';
+import { Builder } from 'selenium-webdriver';
+
+const options = new firefox.Options();
+const driver = new Builder()
+    .withCapabilities({ browserName: 'firefox' })
+    .setFirefoxOptions(options)
+    .build();
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
 val options = new FirefoxOptions()

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.fr.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.fr.md
@@ -37,7 +37,14 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-// We don't have a JavaScript code sample yet -  Help us out and raise a PR  
+import * as firefox from 'selenium-webdriver/firefox';
+import { Builder } from 'selenium-webdriver';
+
+const options = new firefox.Options();
+const driver = new Builder()
+    .withCapabilities({ browserName: 'firefox' })
+    .setFirefoxOptions(options)
+    .build();
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
 val options = new FirefoxOptions()

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.fr.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.fr.md
@@ -37,12 +37,13 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-import * as firefox from 'selenium-webdriver/firefox';
-import { Builder } from 'selenium-webdriver';
+const { Builder } = require("selenium-webdriver");
+const firefox = require('selenium-webdriver/firefox');
 
 const options = new firefox.Options();
+options.headless();
 const driver = new Builder()
-    .withCapabilities({ browserName: 'firefox' })
+    .forBrowser('firefox')
     .setFirefoxOptions(options)
     .build();
   {{< / code-panel >}}

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ja.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ja.md
@@ -36,12 +36,13 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-import * as firefox from 'selenium-webdriver/firefox';
-import { Builder } from 'selenium-webdriver';
+const { Builder } = require("selenium-webdriver");
+const firefox = require('selenium-webdriver/firefox');
 
 const options = new firefox.Options();
+options.headless();
 const driver = new Builder()
-    .withCapabilities({ browserName: 'firefox' })
+    .forBrowser('firefox')
     .setFirefoxOptions(options)
     .build();
   {{< / code-panel >}}

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ja.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ja.md
@@ -36,7 +36,14 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-// We don't have a JavaScript code sample yet -  Help us out and raise a PR  
+import * as firefox from 'selenium-webdriver/firefox';
+import { Builder } from 'selenium-webdriver';
+
+const options = new firefox.Options();
+const driver = new Builder()
+    .withCapabilities({ browserName: 'firefox' })
+    .setFirefoxOptions(options)
+    .build();
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
 val options = new FirefoxOptions()

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ko.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ko.md
@@ -37,7 +37,14 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-// We don't have a JavaScript code sample yet -  Help us out and raise a PR  
+import * as firefox from 'selenium-webdriver/firefox';
+import { Builder } from 'selenium-webdriver';
+
+const options = new firefox.Options();
+const driver = new Builder()
+    .withCapabilities({ browserName: 'firefox' })
+    .setFirefoxOptions(options)
+    .build();
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
 val options = new FirefoxOptions()

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ko.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ko.md
@@ -37,12 +37,13 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-import * as firefox from 'selenium-webdriver/firefox';
-import { Builder } from 'selenium-webdriver';
+const { Builder } = require("selenium-webdriver");
+const firefox = require('selenium-webdriver/firefox');
 
 const options = new firefox.Options();
+options.headless();
 const driver = new Builder()
-    .withCapabilities({ browserName: 'firefox' })
+    .forBrowser('firefox')
     .setFirefoxOptions(options)
     .build();
   {{< / code-panel >}}

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.nl.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.nl.md
@@ -31,12 +31,13 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-import * as firefox from 'selenium-webdriver/firefox';
-import { Builder } from 'selenium-webdriver';
+const { Builder } = require("selenium-webdriver");
+const firefox = require('selenium-webdriver/firefox');
 
 const options = new firefox.Options();
+options.headless();
 const driver = new Builder()
-    .withCapabilities({ browserName: 'firefox' })
+    .forBrowser('firefox')
     .setFirefoxOptions(options)
     .build();
   {{< / code-panel >}}

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.nl.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.nl.md
@@ -31,7 +31,14 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-// We don't have a JavaScript code sample yet -  Help us out and raise a PR  
+import * as firefox from 'selenium-webdriver/firefox';
+import { Builder } from 'selenium-webdriver';
+
+const options = new firefox.Options();
+const driver = new Builder()
+    .withCapabilities({ browserName: 'firefox' })
+    .setFirefoxOptions(options)
+    .build();
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
 val options = new FirefoxOptions()

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.zh-cn.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.zh-cn.md
@@ -36,12 +36,13 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-import * as firefox from 'selenium-webdriver/firefox';
-import { Builder } from 'selenium-webdriver';
+const { Builder } = require("selenium-webdriver");
+const firefox = require('selenium-webdriver/firefox');
 
 const options = new firefox.Options();
+options.headless();
 const driver = new Builder()
-    .withCapabilities({ browserName: 'firefox' })
+    .forBrowser('firefox')
     .setFirefoxOptions(options)
     .build();
   {{< / code-panel >}}

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.zh-cn.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.zh-cn.md
@@ -36,7 +36,14 @@ var driver = new FirefoxDriver(options);
 # We don't have a Ruby code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
-// We don't have a JavaScript code sample yet -  Help us out and raise a PR
+import * as firefox from 'selenium-webdriver/firefox';
+import { Builder } from 'selenium-webdriver';
+
+const options = new firefox.Options();
+const driver = new Builder()
+    .withCapabilities({ browserName: 'firefox' })
+    .setFirefoxOptions(options)
+    .build();
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
 val options = new FirefoxOptions()


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Added JavaScript code example for using FirefoxOptions

### Motivation and Context
Making Selenium Friendlier for JS developers.

### Types of changes

- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

