### PR TITLE
Add: Adding Samesite cookie capability into cookie document

### DIFF
--- a/docs_source_files/content/support_packages/working_with_cookies.de.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.de.md
@@ -419,3 +419,40 @@ const {Builder} = require('selenium-webdriver');
 // We don't have a Kotlin code sample yet -  Help us out and raise a PR  
   {{< / code-panel >}}
 {{< / code-tab >}}
+
+## Same-Site Cookie Attribute
+
+It allows a user to instruct browsers to control whether cookies 
+are sent along with the request initiated by third party sites. 
+It is introduced to prevent CSRF (Cross-Site Request Forgery) attacks.
+
+Same-Site cookie attribute accepts two parameters as instructions
+
+# Strict:
+When the sameSite attribute is set as ‘Strict’, 
+the cookie will not be sent along with requests initiated by third party websites.
+
+# Lax:
+When you set a cookie' sameSite attribute to ‘Lax’, 
+the cookie will be sent along with the GET request initiated by third party website.
+
+{{< code-tab >}}
+  {{< code-panel language="java" >}}
+// Code sample
+  {{< / code-panel >}}
+ {{< code-panel language="python" >}}
+ # code sample
+  {{< / code-panel >}}
+  {{< code-panel language="csharp" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="ruby" >}}
+# Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="javascript" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="kotlin" >}}
+// We don't have a Kotlin code sample yet -  Help us out and raise a PR  
+  {{< / code-panel >}}
+{{< / code-tab >}}

--- a/docs_source_files/content/support_packages/working_with_cookies.en.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.en.md
@@ -413,3 +413,40 @@ const {Builder} = require('selenium-webdriver');
 // We don't have a Kotlin code sample yet -  Help us out and raise a PR  
   {{< / code-panel >}}
 {{< / code-tab >}}
+
+## Same-Site Cookie Attribute
+
+It allows a user to instruct browsers to control whether cookies 
+are sent along with the request initiated by third party sites. 
+It is introduced to prevent CSRF (Cross-Site Request Forgery) attacks.
+
+Same-Site cookie attribute accepts two parameters as instructions
+
+# Strict:
+When the sameSite attribute is set as ‘Strict’, 
+the cookie will not be sent along with requests initiated by third party websites.
+
+# Lax:
+When you set a cookie' sameSite attribute to ‘Lax’, 
+the cookie will be sent along with the GET request initiated by third party website.
+
+{{< code-tab >}}
+  {{< code-panel language="java" >}}
+// Code sample
+  {{< / code-panel >}}
+ {{< code-panel language="python" >}}
+ # code sample
+  {{< / code-panel >}}
+  {{< code-panel language="csharp" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="ruby" >}}
+# Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="javascript" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="kotlin" >}}
+// We don't have a Kotlin code sample yet -  Help us out and raise a PR  
+  {{< / code-panel >}}
+{{< / code-tab >}}

--- a/docs_source_files/content/support_packages/working_with_cookies.es.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.es.md
@@ -419,3 +419,40 @@ const {Builder} = require('selenium-webdriver');
 // We don't have a Kotlin code sample yet -  Help us out and raise a PR  
   {{< / code-panel >}}
 {{< / code-tab >}}
+
+## Same-Site Cookie Attribute
+
+It allows a user to instruct browsers to control whether cookies 
+are sent along with the request initiated by third party sites. 
+It is introduced to prevent CSRF (Cross-Site Request Forgery) attacks.
+
+Same-Site cookie attribute accepts two parameters as instructions
+
+# Strict:
+When the sameSite attribute is set as ‘Strict’, 
+the cookie will not be sent along with requests initiated by third party websites.
+
+# Lax:
+When you set a cookie' sameSite attribute to ‘Lax’, 
+the cookie will be sent along with the GET request initiated by third party website.
+
+{{< code-tab >}}
+  {{< code-panel language="java" >}}
+// Code sample
+  {{< / code-panel >}}
+ {{< code-panel language="python" >}}
+ # code sample
+  {{< / code-panel >}}
+  {{< code-panel language="csharp" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="ruby" >}}
+# Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="javascript" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="kotlin" >}}
+// We don't have a Kotlin code sample yet -  Help us out and raise a PR  
+  {{< / code-panel >}}
+{{< / code-tab >}}

--- a/docs_source_files/content/support_packages/working_with_cookies.fr.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.fr.md
@@ -419,3 +419,40 @@ const {Builder} = require('selenium-webdriver');
 // We don't have a Kotlin code sample yet -  Help us out and raise a PR  
   {{< / code-panel >}}
 {{< / code-tab >}}
+
+## Same-Site Cookie Attribute
+
+It allows a user to instruct browsers to control whether cookies 
+are sent along with the request initiated by third party sites. 
+It is introduced to prevent CSRF (Cross-Site Request Forgery) attacks.
+
+Same-Site cookie attribute accepts two parameters as instructions
+
+# Strict:
+When the sameSite attribute is set as ‘Strict’, 
+the cookie will not be sent along with requests initiated by third party websites.
+
+# Lax:
+When you set a cookie' sameSite attribute to ‘Lax’, 
+the cookie will be sent along with the GET request initiated by third party website.
+
+{{< code-tab >}}
+  {{< code-panel language="java" >}}
+// Code sample
+  {{< / code-panel >}}
+ {{< code-panel language="python" >}}
+ # code sample
+  {{< / code-panel >}}
+  {{< code-panel language="csharp" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="ruby" >}}
+# Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="javascript" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="kotlin" >}}
+// We don't have a Kotlin code sample yet -  Help us out and raise a PR  
+  {{< / code-panel >}}
+{{< / code-tab >}}

--- a/docs_source_files/content/support_packages/working_with_cookies.ja.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.ja.md
@@ -419,3 +419,40 @@ const {Builder} = require('selenium-webdriver');
 // We don't have a Kotlin code sample yet -  Help us out and raise a PR  
   {{< / code-panel >}}
 {{< / code-tab >}}
+
+## Same-Site Cookie Attribute
+
+It allows a user to instruct browsers to control whether cookies 
+are sent along with the request initiated by third party sites. 
+It is introduced to prevent CSRF (Cross-Site Request Forgery) attacks.
+
+Same-Site cookie attribute accepts two parameters as instructions
+
+# Strict:
+When the sameSite attribute is set as ‘Strict’, 
+the cookie will not be sent along with requests initiated by third party websites.
+
+# Lax:
+When you set a cookie' sameSite attribute to ‘Lax’, 
+the cookie will be sent along with the GET request initiated by third party website.
+
+{{< code-tab >}}
+  {{< code-panel language="java" >}}
+// Code sample
+  {{< / code-panel >}}
+ {{< code-panel language="python" >}}
+ # code sample
+  {{< / code-panel >}}
+  {{< code-panel language="csharp" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="ruby" >}}
+# Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="javascript" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="kotlin" >}}
+// We don't have a Kotlin code sample yet -  Help us out and raise a PR  
+  {{< / code-panel >}}
+{{< / code-tab >}}

--- a/docs_source_files/content/support_packages/working_with_cookies.ko.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.ko.md
@@ -419,3 +419,40 @@ const {Builder} = require('selenium-webdriver');
 // We don't have a Kotlin code sample yet -  Help us out and raise a PR  
   {{< / code-panel >}}
 {{< / code-tab >}}
+
+## Same-Site Cookie Attribute
+
+It allows a user to instruct browsers to control whether cookies 
+are sent along with the request initiated by third party sites. 
+It is introduced to prevent CSRF (Cross-Site Request Forgery) attacks.
+
+Same-Site cookie attribute accepts two parameters as instructions
+
+# Strict:
+When the sameSite attribute is set as ‘Strict’, 
+the cookie will not be sent along with requests initiated by third party websites.
+
+# Lax:
+When you set a cookie' sameSite attribute to ‘Lax’, 
+the cookie will be sent along with the GET request initiated by third party website.
+
+{{< code-tab >}}
+  {{< code-panel language="java" >}}
+// Code sample
+  {{< / code-panel >}}
+ {{< code-panel language="python" >}}
+ # code sample
+  {{< / code-panel >}}
+  {{< code-panel language="csharp" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="ruby" >}}
+# Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="javascript" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="kotlin" >}}
+// We don't have a Kotlin code sample yet -  Help us out and raise a PR  
+  {{< / code-panel >}}
+{{< / code-tab >}}

--- a/docs_source_files/content/support_packages/working_with_cookies.nl.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.nl.md
@@ -419,3 +419,40 @@ const {Builder} = require('selenium-webdriver');
 // We don't have a Kotlin code sample yet -  Help us out and raise a PR  
   {{< / code-panel >}}
 {{< / code-tab >}}
+
+## Same-Site Cookie Attribute
+
+It allows a user to instruct browsers to control whether cookies 
+are sent along with the request initiated by third party sites. 
+It is introduced to prevent CSRF (Cross-Site Request Forgery) attacks.
+
+Same-Site cookie attribute accepts two parameters as instructions
+
+# Strict:
+When the sameSite attribute is set as ‘Strict’, 
+the cookie will not be sent along with requests initiated by third party websites.
+
+# Lax:
+When you set a cookie' sameSite attribute to ‘Lax’, 
+the cookie will be sent along with the GET request initiated by third party website.
+
+{{< code-tab >}}
+  {{< code-panel language="java" >}}
+// Code sample
+  {{< / code-panel >}}
+ {{< code-panel language="python" >}}
+ # code sample
+  {{< / code-panel >}}
+  {{< code-panel language="csharp" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="ruby" >}}
+# Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="javascript" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="kotlin" >}}
+// We don't have a Kotlin code sample yet -  Help us out and raise a PR  
+  {{< / code-panel >}}
+{{< / code-tab >}}

--- a/docs_source_files/content/support_packages/working_with_cookies.zh-cn.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.zh-cn.md
@@ -419,3 +419,40 @@ const {Builder} = require('selenium-webdriver');
 // We don't have a Kotlin code sample yet -  Help us out and raise a PR  
   {{< / code-panel >}}
 {{< / code-tab >}}
+
+## Same-Site Cookie Attribute
+
+It allows a user to instruct browsers to control whether cookies 
+are sent along with the request initiated by third party sites. 
+It is introduced to prevent CSRF (Cross-Site Request Forgery) attacks.
+
+Same-Site cookie attribute accepts two parameters as instructions
+
+# Strict:
+When the sameSite attribute is set as ‘Strict’, 
+the cookie will not be sent along with requests initiated by third party websites.
+
+# Lax:
+When you set a cookie' sameSite attribute to ‘Lax’, 
+the cookie will be sent along with the GET request initiated by third party website.
+
+{{< code-tab >}}
+  {{< code-panel language="java" >}}
+// Code sample
+  {{< / code-panel >}}
+ {{< code-panel language="python" >}}
+ # code sample
+  {{< / code-panel >}}
+  {{< code-panel language="csharp" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="ruby" >}}
+# Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="javascript" >}}
+// Please raise a PR
+  {{< / code-panel >}}
+  {{< code-panel language="kotlin" >}}
+// We don't have a Kotlin code sample yet -  Help us out and raise a PR  
+  {{< / code-panel >}}
+{{< / code-tab >}}


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

### Description
Samesite cookie capability is a new feature in webdriver. Code samples are ready for Java and Javascript, but needs PR's to be merged in selenium repo to test.

Currently this PR has info on same site cookie capability

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
