### PR TITLE
Add Japanese translation of "Driver Idiosyncrasies"

### DIFF
--- a/docs_source_files/content/driver_idiosyncrasies/_index.ja.md
+++ b/docs_source_files/content/driver_idiosyncrasies/_index.ja.md
@@ -1,12 +1,8 @@
 ---
-title: "Driver idiosyncrasies"
+title: "ドライバーの特異性"
 chapter: true
 weight: 10
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> ページは英語から日本語へ訳されています。
-日本語は話せますか？プルリクエストをして翻訳を手伝ってください!
-{{% /notice %}}
 
-# Driver idiosyncrasies
+# ドライバーの特異性

--- a/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ja.md
+++ b/docs_source_files/content/driver_idiosyncrasies/driver_specific_capabilities.ja.md
@@ -1,19 +1,13 @@
 ---
-title: "Driver specific capabilities"
+title: "ドライバー固有の機能"
 weight: 2
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> ページは英語から日本語へ訳されています。
-日本語は話せますか？プルリクエストをして翻訳を手伝ってください!
-{{% /notice %}}
-
 ## Firefox
 
-### Define Capabilities using `FirefoxOptions`
+### `FirefoxOptions` を使用してCapabilitiesを定義する
 
-`FirefoxOptions` is the new way to define capabilities for the Firefox
-browser and should generally be used in preference to DesiredCapabilities.
+`FirefoxOptions` は、Firefoxブラウザの機能を定義する新しい方法であり、通常はDesiredCapabilitiesよりも優先して使用する必要があります。
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
@@ -56,9 +50,9 @@ driver = RemoteWebDriver(options)
 {{< / code-tab >}}
 
 
-### Setting a custom profile
+### カスタムプロファイルを設定する
 
-It is possible to create a custom profile for Firefox as demonstrated below.
+以下に示すように、Firefoxのカスタムプロファイルを作成することができます。
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
@@ -110,9 +104,7 @@ driver = RemoteWebDriver(options)
 
 ### fileUploadDialogTimeout
 
-In some environments, Internet Explorer may timeout when opening the
-File Upload dialog. IEDriver has a default timeout of 1000ms, but you
-can increase the timeout using the fileUploadDialogTimeout capability.
+環境によっては、ファイルアップロードダイアログを開くときにInternet Explorerがタイムアウトする場合があります。 IEDriverのデフォルトのタイムアウトは1000ミリ秒ですが、fileUploadDialogTimeout capabilityを使用してタイムアウトを増やすことができます。
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}

--- a/docs_source_files/content/driver_idiosyncrasies/shared_capabilities.ja.md
+++ b/docs_source_files/content/driver_idiosyncrasies/shared_capabilities.ja.md
@@ -1,28 +1,18 @@
 ---
-title: "Shared capabilities"
+title: "共有機能"
 weight: 1
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> ページは英語から日本語へ訳されています。
-日本語は話せますか？プルリクエストをして翻訳を手伝ってください!
-{{% /notice %}}
 
-### pageLoadStrategy
-When navigating to a new page via URL, by default Selenium will wait
-until the page has fully loaded before responding. This works well for
-beginners, but can cause long wait times on pages that load a large
-number of third party resources. Using a non default strategy can make
-test execution faster in cases like this, but can also introduce flakiness
-where elements on the page change position as elements load in and change
-size.
+### ページロード戦略
+URLを介して新しいページに移動する場合、デフォルトでは、Seleniumは応答する前にページが完全にロードされるまで待機します。
+これは初心者には効果的ですが、多数のサードパーティリソースをロードするページで長い待ち時間を引き起こす可能性があります。
+デフォルト以外の戦略を使用すると、このような場合にテストの実行を高速化できますが、ページの要素がロードされてサイズが変更されると、ページ上の要素の位置が変化する不安定さを引き起こします。
 
-The page load strategy queries the
-[document.readyState](//developer.mozilla.org/en-US/docs/Web/API/Document/readyState)
-as described in the table below:
+次の表で説明するように、ページロード戦略は [document.readyState](//developer.mozilla.org/en-US/docs/Web/API/Document/readyState) を問い合わせます。
 
-| Strategy | Ready State | Notes |
+| 戦略 | Ready State | 注釈 |
 | -------- | ----------- | ----- |
-| normal | complete | Used by default, waits for all resources to download |
-| eager | interactive | DOM access is ready, but other resources like images may still be loading |
-| none | Any | Does not block WebDriver at all |
+| normal | complete | デフォルトで使用され、すべてのリソースがダウンロードされるまで待機します |
+| eager | interactive | DOMアクセスの準備はできていますが、画像などの他のリソースがまだ読み込まれている可能性があります |
+| none | Any | WebDriverをまったくブロックしません |


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This PR contains new Japanese translation of Driver Idiosyncrasies:

- driver_idiosyncrasies/_index.ja.md
- driver_idiosyncrasies/driver_specific_capabilities.ja.md
- driver_idiosyncrasies/shared_capabilities.ja.md

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
