### PR TITLE
Modify: Removing info section for translated pages

### DIFF
--- a/docs_source_files/content/getting_started_with_webdriver/locating_elements.fr.md
+++ b/docs_source_files/content/getting_started_with_webdriver/locating_elements.fr.md
@@ -3,12 +3,6 @@ title: "Localiser des éléments"
 weight: 3
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to French. Do you speak French? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
-
 ### Localiser des éléments
 
 Une des techniques fondamentales à maîtriser lorsque l'on utilise WebDriver 

--- a/docs_source_files/content/getting_started_with_webdriver/third_party_drivers_and_plugins.fr.md
+++ b/docs_source_files/content/getting_started_with_webdriver/third_party_drivers_and_plugins.fr.md
@@ -3,12 +3,6 @@ title: "Driver tiers et plugins"
 weight: 2
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to French. Do you speak French? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
-
 Selenium peut être étendu à travers l'utilisation de plugins. Vous trouverez
 ici un certain nombre de plugins créés et maintenus par des tierces parties. 
 Pour de plus amples information sur la création de plugin ou pour en ajouter à la liste,


### PR DESCRIPTION

### Description
Documents are translated to french already, info bar can be removed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
