### PR TITLE
Add: Adding note section for sameSite cookie as the feature is only landed in chrome 

### DIFF
--- a/docs_source_files/content/support_packages/working_with_cookies.de.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.de.md
@@ -619,6 +619,8 @@ When you set a cookie sameSite attribute to **Lax**,
 the cookie will be sent along with the GET 
 request initiated by third party website.
 
+**Note**: **As of now this feature is landed in chrome(80+version) and works with Selenium 4 and later versions.**
+
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 // Code sample

--- a/docs_source_files/content/support_packages/working_with_cookies.en.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.en.md
@@ -613,6 +613,8 @@ When you set a cookie sameSite attribute to **Lax**,
 the cookie will be sent along with the GET 
 request initiated by third party website.
 
+**Note**: **As of now this feature is landed in chrome(80+version) and works with Selenium 4 and later versions.**
+
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 // Code sample

--- a/docs_source_files/content/support_packages/working_with_cookies.es.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.es.md
@@ -620,6 +620,8 @@ When you set a cookie sameSite attribute to **Lax**,
 the cookie will be sent along with the GET 
 request initiated by third party website.
 
+**Note**: **As of now this feature is landed in chrome(80+version) and works with Selenium 4 and later versions.**
+
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 // Code sample

--- a/docs_source_files/content/support_packages/working_with_cookies.fr.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.fr.md
@@ -620,6 +620,8 @@ When you set a cookie sameSite attribute to **Lax**,
 the cookie will be sent along with the GET 
 request initiated by third party website.
 
+**Note**: **As of now this feature is landed in chrome(80+version) and works with Selenium 4 and later versions.**
+
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 // Code sample

--- a/docs_source_files/content/support_packages/working_with_cookies.ja.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.ja.md
@@ -611,6 +611,8 @@ When you set a cookie sameSite attribute to **Lax**,
 the cookie will be sent along with the GET 
 request initiated by third party website.
 
+**Note**: **As of now this feature is landed in chrome(80+version) and works with Selenium 4 and later versions.**
+
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 // Code sample

--- a/docs_source_files/content/support_packages/working_with_cookies.ko.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.ko.md
@@ -619,6 +619,8 @@ When you set a cookie sameSite attribute to **Lax**,
 the cookie will be sent along with the GET 
 request initiated by third party website.
 
+**Note**: **As of now this feature is landed in chrome(80+version) and works with Selenium 4 and later versions.**
+
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 // Code sample

--- a/docs_source_files/content/support_packages/working_with_cookies.nl.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.nl.md
@@ -619,6 +619,8 @@ When you set a cookie sameSite attribute to **Lax**,
 the cookie will be sent along with the GET 
 request initiated by third party website.
 
+**Note**: **As of now this feature is landed in chrome(80+version) and works with Selenium 4 and later versions.**
+
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 // Code sample

--- a/docs_source_files/content/support_packages/working_with_cookies.zh-cn.md
+++ b/docs_source_files/content/support_packages/working_with_cookies.zh-cn.md
@@ -608,6 +608,8 @@ When you set a cookie sameSite attribute to **Lax**,
 the cookie will be sent along with the GET 
 request initiated by third party website.
 
+**Note**: **As of now this feature is landed in chrome(80+version) and works with Selenium 4 and later versions.**
+
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 // Code sample


### PR DESCRIPTION

### Description
sameSite cookie attribute is implemented in chrome80 + versions. FF and safari browsers still need to implement. 

So adding a note section for sameSite for now. Once feature lands on every browser we can eventually remote/modify the note section accordingly 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
