### PR TITLE
Fixing invalid assignments in java code

### DIFF
--- a/docs_source_files/content/support_packages/working_with_colours.en.md
+++ b/docs_source_files/content/support_packages/working_with_colours.en.md
@@ -151,22 +151,22 @@ Color loginButtonColour = Color.fromString(driver.findElement(By.id("login")).ge
 Color loginButtonBackgroundColour = Color.fromString(driver.findElement(By.id("login")).getCssValue("background-color"));
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-login_button_colour = driver.find_element_by_id('login').value_of_css_property('color')
-login_button_background_colour = driver.find_element_by_id('login').value_of_css_property('background-color');
+login_button_colour = Color.from_string(driver.find_element_by_id('login').value_of_css_property('color'))
+login_button_background_colour = Color.from_string(driver.find_element_by_id('login').value_of_css_property('background-color'))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 // We don't have a C# code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-login_button_colour = driver.find_element(id: 'login').css_value('color')
-login_button_background_colour = driver.find_element(id: 'login').css_value('background-color');
+login_button_colour = Color.from_string(driver.find_element(id: 'login').css_value('color'))
+login_button_background_colour = Color.from_string(driver.find_element(id: 'login').css_value('background-color'))
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // We don't have a JavaScript code sample yet -  Help us out and raise a PR
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-val loginButtonColour = driver.findElement(By.id("login")).getCssValue("color")
-val loginButtonBackgroundColour = driver.findElement(By.id("login")).getCssValue("background-color")
+val loginButtonColour = Color.fromString(driver.findElement(By.id("login")).getCssValue("color"))
+val loginButtonBackgroundColour = Color.fromString(driver.findElement(By.id("login")).getCssValue("background-color"))
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/working_with_colours.en.md
+++ b/docs_source_files/content/support_packages/working_with_colours.en.md
@@ -147,8 +147,8 @@ and converted into a valid Color object:
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-Color loginButtonColour = driver.findElement(By.id("login")).getCssValue("color");
-Color loginButtonBackgroundColour = driver.findElement(By.id("login")).getCssValue("background-color");
+Color loginButtonColour = Color.fromString(driver.findElement(By.id("login")).getCssValue("color"));
+Color loginButtonBackgroundColour = Color.fromString(driver.findElement(By.id("login")).getCssValue("background-color"));
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 login_button_colour = driver.find_element_by_id('login').value_of_css_property('color')


### PR DESCRIPTION
Color loginButtonColour = driver.findElement(By.id("login")).getCssValue("color");
Assignment like this is wrong, should use static function 'fromString' to get Color out of a string. Probably other language samples require fix too.
