### PR TITLE
Add: Proposing Legacy Capabilities document

### DIFF
--- a/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.de.md
+++ b/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.de.md
@@ -1,0 +1,26 @@
+---
+title: "Legacy capabilities"
+weight: 1
+---
+
+{{% notice info %}}
+<i class="fas fa-language"></i> Diese Seite wird von Englisch 
+auf Deutsch übersetzt. Sprichst Du Deutsch? Hilf uns die Seite 
+zu übersetzen indem Du uns einen Pull Reqeust schickst!
+ {{% /notice %}}
+ 
+In-order to create a new browser session, Selenium WebDriver 
+uses a set of properties in a JSON format describing 
+the features that the user requests for that particular session. 
+We usually call them as `desiredCapabilites` or `requiredCapabilities`.
+
+### Deprecation of Desired Capabilities
+
+Majority of the selenium client uses `desiredCapabilities` and 
+`requiredCapabilities` to configure a new session. Most of the 
+driver vendors support use of this legacy capabilities, but in favour of
+browser specific option classes **desiredCapabilities** and 
+**requiredCapabilities** are deprecated and should be avoided.
+
+One should use the **browser specific capabilities** to set 
+capability for a browser session.

--- a/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.en.md
+++ b/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.en.md
@@ -1,0 +1,20 @@
+---
+title: "Legacy capabilities"
+weight: 1
+---
+ 
+In-order to create a new browser session, Selenium WebDriver 
+uses a set of properties in a JSON format describing 
+the features that the user requests for that particular session. 
+We usually call them as `desiredCapabilites` or `requiredCapabilities`.
+
+### Deprecation of Desired Capabilities
+
+Majority of the selenium client uses `desiredCapabilities` and 
+`requiredCapabilities` to configure a new session. Most of the 
+driver vendors support use of this legacy capabilities, but in favour of
+browser specific option classes **desiredCapabilities** and 
+**requiredCapabilities** are deprecated and should be avoided.
+
+One should use the **browser specific capabilities** to set 
+capability for a browser session.

--- a/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.es.md
+++ b/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.es.md
@@ -1,0 +1,26 @@
+---
+title: "Legacy capabilities"
+weight: 1
+---
+
+{{% notice info %}}
+<i class="fas fa-language"></i> Page being translated from 
+English to Spanish. Do you speak Spanish? Help us to translate
+it by sending us pull requests!
+{{% /notice %}}
+ 
+In-order to create a new browser session, Selenium WebDriver 
+uses a set of properties in a JSON format describing 
+the features that the user requests for that particular session. 
+We usually call them as `desiredCapabilites` or `requiredCapabilities`.
+
+### Deprecation of Desired Capabilities
+
+Majority of the selenium client uses `desiredCapabilities` and 
+`requiredCapabilities` to configure a new session. Most of the 
+driver vendors support use of this legacy capabilities, but in favour of
+browser specific option classes **desiredCapabilities** and 
+**requiredCapabilities** are deprecated and should be avoided.
+
+One should use the **browser specific capabilities** to set 
+capability for a browser session.

--- a/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.fr.md
+++ b/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.fr.md
@@ -1,0 +1,26 @@
+---
+title: "Legacy capabilities"
+weight: 1
+---
+
+{{% notice info %}}
+<i class="fas fa-language"></i> Page being translated from 
+English to French. Do you speak French? Help us to translate
+it by sending us pull requests!
+{{% /notice %}}
+ 
+In-order to create a new browser session, Selenium WebDriver 
+uses a set of properties in a JSON format describing 
+the features that the user requests for that particular session. 
+We usually call them as `desiredCapabilites` or `requiredCapabilities`.
+
+### Deprecation of Desired Capabilities
+
+Majority of the selenium client uses `desiredCapabilities` and 
+`requiredCapabilities` to configure a new session. Most of the 
+driver vendors support use of this legacy capabilities, but in favour of
+browser specific option classes **desiredCapabilities** and 
+**requiredCapabilities** are deprecated and should be avoided.
+
+One should use the **browser specific capabilities** to set 
+capability for a browser session.

--- a/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.ja.md
+++ b/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.ja.md
@@ -1,0 +1,26 @@
+---
+title: "Legacy capabilities"
+weight: 1
+---
+
+{{% notice info %}}
+<i class="fas fa-language"></i> Page being translated from 
+English to japanese. Do you speak japanese? Help us to translate
+it by sending us pull requests!
+{{% /notice %}}
+ 
+In-order to create a new browser session, Selenium WebDriver 
+uses a set of properties in a JSON format describing 
+the features that the user requests for that particular session. 
+We usually call them as `desiredCapabilites` or `requiredCapabilities`.
+
+### Deprecation of Desired Capabilities
+
+Majority of the selenium client uses `desiredCapabilities` and 
+`requiredCapabilities` to configure a new session. Most of the 
+driver vendors support use of this legacy capabilities, but in favour of
+browser specific option classes **desiredCapabilities** and 
+**requiredCapabilities** are deprecated and should be avoided.
+
+One should use the **browser specific capabilities** to set 
+capability for a browser session.

--- a/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.ko.md
+++ b/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.ko.md
@@ -1,0 +1,26 @@
+---
+title: "Legacy capabilities"
+weight: 1
+---
+
+{{% notice info %}}
+<i class="fas fa-language"></i> Page being translated from 
+English to Korean. Do you speak Korean? Help us to translate
+it by sending us pull requests!
+{{% /notice %}}
+ 
+In-order to create a new browser session, Selenium WebDriver 
+uses a set of properties in a JSON format describing 
+the features that the user requests for that particular session. 
+We usually call them as `desiredCapabilites` or `requiredCapabilities`.
+
+### Deprecation of Desired Capabilities
+
+Majority of the selenium client uses `desiredCapabilities` and 
+`requiredCapabilities` to configure a new session. Most of the 
+driver vendors support use of this legacy capabilities, but in favour of
+browser specific option classes **desiredCapabilities** and 
+**requiredCapabilities** are deprecated and should be avoided.
+
+One should use the **browser specific capabilities** to set 
+capability for a browser session.

--- a/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.nl.md
+++ b/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.nl.md
@@ -1,0 +1,26 @@
+---
+title: "Legacy capabilities"
+weight: 1
+---
+
+{{% notice info %}}
+<i class="fas fa-language"></i> Page being translated from 
+English to Dutch. Do you speak Dutch? Help us to translate
+it by sending us pull requests!
+{{% /notice %}}
+ 
+In-order to create a new browser session, Selenium WebDriver 
+uses a set of properties in a JSON format describing 
+the features that the user requests for that particular session. 
+We usually call them as `desiredCapabilites` or `requiredCapabilities`.
+
+### Deprecation of Desired Capabilities
+
+Majority of the selenium client uses `desiredCapabilities` and 
+`requiredCapabilities` to configure a new session. Most of the 
+driver vendors support use of this legacy capabilities, but in favour of
+browser specific option classes **desiredCapabilities** and 
+**requiredCapabilities** are deprecated and should be avoided.
+
+One should use the **browser specific capabilities** to set 
+capability for a browser session.

--- a/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.zh-cn.md
+++ b/docs_source_files/content/driver_idiosyncrasies/legacy_capabilities.zh-cn.md
@@ -1,0 +1,25 @@
+---
+title: "Legacy capabilities"
+weight: 1
+---
+
+{{% notice info %}}
+<i class="fas fa-language"></i> 页面需要从英语翻译为简体中文。
+您熟悉英语与简体中文吗？帮助我们翻译它，通过 pull requests 给我们！
+{{% /notice %}}
+ 
+In-order to create a new browser session, Selenium WebDriver 
+uses a set of properties in a JSON format describing 
+the features that the user requests for that particular session. 
+We usually call them as `desiredCapabilites` or `requiredCapabilities`.
+
+### Deprecation of Desired Capabilities
+
+Majority of the selenium client uses `desiredCapabilities` and 
+`requiredCapabilities` to configure a new session. Most of the 
+driver vendors support use of this legacy capabilities, but in favour of
+browser specific option classes **desiredCapabilities** and 
+**requiredCapabilities** are deprecated and should be avoided.
+
+One should use the **browser specific capabilities** to set 
+capability for a browser session.


### PR DESCRIPTION

### Description
Proposing Legacy Capabilities document, which speaks about deprecation of `desiredCapabilities` and `requiredCapabilities`.

We can also include using of respective [driver]:options with code samples to set capabilities instead of desiredCapabilities

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
