### PR TITLE
Translate gmail and facebook page to spanish

### DIFF
--- a/docs_source_files/content/worst_practices/gmail_email_and_facebook_logins.es.md
+++ b/docs_source_files/content/worst_practices/gmail_email_and_facebook_logins.es.md
@@ -27,4 +27,4 @@ son.
 Las implementaciones del WebDriver que son 
 [conformes al W3C](//w3c.github.io/webdriver/webdriver-spec.html)
 también marcan el objecto `navigator` con la propiedad `WebDriver` para que los
-ataques de Denegación de Servicio puedan ser mitigados.
+ataques de denegación de servicio (_DoS_) puedan ser mitigados.

--- a/docs_source_files/content/worst_practices/gmail_email_and_facebook_logins.es.md
+++ b/docs_source_files/content/worst_practices/gmail_email_and_facebook_logins.es.md
@@ -1,38 +1,30 @@
 ---
-title: "Gmail, email y Facebook logins"
+title: "Autenticarse con Gmail, email y Facebook"
 menuTitle: "Gmail, email y Facebook"
 weight: 4
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to Spanish. Do you speak Spanish? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
+Por múltiples razones, autenticarse en sitios como Gmail y Facebook usando el 
+WebDriver no esta recomendado.
+Aparte de estar en contra de los términos y condiciones de estos sitios (te 
+expones a que te cierren la cuenta), es un proceso lento y poco fiable.
 
-For multiple reasons, logging into sites like Gmail and Facebook
-using WebDriver is not recommended.
-Aside from being against the usage terms for these sites
-(where you risk having the account shut down),
-it is slow and unreliable.
+La practica ideal respecto a estos los sitios de emails es usar las APIs que 
+ofrecen, en el caso de Facebook usar las herramientas para desarrolladores las 
+cuales exponen un API para crear cuentas de prueba, amigos, etc.
+A pesar de que usar un API puede parecer como un esfuerzo extra, lo recuperarás 
+en velocidad, fiabilidad y estabilidad.
+Ademas el API tiene muy pocas probabilidades de cambiar mientras que las paginas 
+web y los elementos HTML cambian frecuentemente y requieren actualizar tu 
+_framework_ de pruebas constantemente.
 
-The ideal practice is to use the APIs that email providers offer,
-or in the case of Facebook the developer tools service
-which exposes an API for creating test accounts, friends and so forth.
-Although using an API might seem like a bit of extra hard work,
-you will be paid back in speed, reliability, and stability.
-The API is also unlikely to change
-whereas webpages and HTML locators change often
-and require you to update your test framework.
+Autenticarse en sitios de terceros usando el WebDriver en cualquier punto de tus
+tests incrementa el riesgo de que tus pruebas fallen debido a que aumenta la 
+duración de estas.
+Por regla general cuanto mas largos sean los tests mas frágiles y poco fiables 
+son.
 
-Logging in to third party sites using WebDriver
-at any point of your test increases the risk
-of your test failing because it makes your test longer.
-A general rule of thumb is that longer tests
-are more fragile and unreliable.
-
-WebDriver implementations that are
-[W3C conformant](//w3c.github.io/webdriver/webdriver-spec.html)
-also annotate the `navigator` object
-with a `WebDriver` property
-so that Denial of Service attacks can be mitigated.
+Las implementaciones del WebDriver que son 
+[conformes al W3C](//w3c.github.io/webdriver/webdriver-spec.html)
+también marcan el objecto `navigator` con la propiedad `WebDriver` para que los
+ataques de Denegación de Servicio puedan ser mitigados.


### PR DESCRIPTION
### Description
Add translation to spanish for gmail email and facebook page

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
