### PR TITLE
Modify: Use LocalFileDetector in Python

### DIFF
--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.de.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.de.md
@@ -163,9 +163,9 @@ the following way:
 driver.setFileDetector(new LocalFileDetector());
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-driver.file_detector = UselessFileDetector()
+driver.file_detector = LocalFileDetector()
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 var allowsDetection = this.driver as IAllowsFileDetection;

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.en.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.en.md
@@ -157,9 +157,9 @@ the following way:
 driver.setFileDetector(new LocalFileDetector());
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-driver.file_detector = UselessFileDetector()
+driver.file_detector = LocalFileDetector()
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 var allowsDetection = this.driver as IAllowsFileDetection;

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.es.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.es.md
@@ -161,9 +161,9 @@ predeterminada y puede habilitarse en de la siguiente manera:
 driver.setFileDetector(new LocalFileDetector());
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-driver.file_detector = UselessFileDetector()
+driver.file_detector = LocalFileDetector()
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 var allowsDetection = this.driver as IAllowsFileDetection;

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.fr.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.fr.md
@@ -155,9 +155,9 @@ de la manière suivante:
 driver.setFileDetector(new LocalFileDetector());
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-driver.file_detector = UselessFileDetector()
+driver.file_detector = LocalFileDetector()
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 var allowsDetection = this.driver as IAllowsFileDetection;

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.ja.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.ja.md
@@ -149,9 +149,9 @@ driver.quit();
 driver.setFileDetector(new LocalFileDetector());
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-driver.file_detector = UselessFileDetector()
+driver.file_detector = LocalFileDetector()
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 var allowsDetection = this.driver as IAllowsFileDetection;

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.ko.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.ko.md
@@ -163,9 +163,9 @@ the following way:
 driver.setFileDetector(new LocalFileDetector());
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-driver.file_detector = UselessFileDetector()
+driver.file_detector = LocalFileDetector()
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 var allowsDetection = this.driver as IAllowsFileDetection;

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.nl.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.nl.md
@@ -163,9 +163,9 @@ the following way:
 driver.setFileDetector(new LocalFileDetector());
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-driver.file_detector = UselessFileDetector()
+driver.file_detector = LocalFileDetector()
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 var allowsDetection = this.driver as IAllowsFileDetection;

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.zh-cn.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.zh-cn.md
@@ -156,9 +156,9 @@ driver.quit();
 driver.setFileDetector(new LocalFileDetector());
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
-from selenium.webdriver.remote.file_detector import UselessFileDetector
+from selenium.webdriver.remote.file_detector import LocalFileDetector
 
-driver.file_detector = UselessFileDetector()
+driver.file_detector = LocalFileDetector()
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}
 var allowsDetection = this.driver as IAllowsFileDetection;


### PR DESCRIPTION
for remote client, we should use LocalFileDetector instead of UselessFileDetector, the latter do nothing

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
