### PR TITLE
Add clearer POM terminology (component objects)

### DIFF
--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.de.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.de.md
@@ -180,10 +180,16 @@ instantiating the page object. In the examples above, both the SignInPage and
 HomePage constructors check that the expected page is available and ready for
 requests from the test.
 
-A page object does not necessarily need to represent an entire page. The Page
-Object design pattern could be used to represent components on a page. If a
-page in the AUT has multiple components, it may improve maintainability if
-there is a separate page object for each component.
+A page object does not necessarily need to represent all the parts of a
+page itself. The same principles used for page objects can be used to
+create "Page _Component_ Objects" that represent discrete chunks of the
+page and can be used in page objects. These component objects can
+provide references the elements inside those discrete chunks, and
+methods to leverage the functionality provided by them. You can even
+nest component objects inside other component objects for more complex
+pages. If a page in the AUT has multiple components, or common
+components used throughout the site (e.g. a navigation bar), then it
+may improve maintainability and reduce code duplication.
 
 There are other design patterns that also may be used in testing. Some use a
 Page Factory for instantiating their page objects. Discussing all of these is

--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.en.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.en.md
@@ -175,10 +175,16 @@ instantiating the page object. In the examples above, both the SignInPage and
 HomePage constructors check that the expected page is available and ready for
 requests from the test.
 
-A page object does not necessarily need to represent an entire page. The Page
-Object design pattern could be used to represent components on a page. If a
-page in the AUT has multiple components, it may improve maintainability if
-there is a separate page object for each component.
+A page object does not necessarily need to represent all the parts of a
+page itself. The same principles used for page objects can be used to
+create "Page _Component_ Objects" that represent discrete chunks of the
+page and can be used in page objects. These component objects can
+provide references the elements inside those discrete chunks, and
+methods to leverage the functionality provided by them. You can even
+nest component objects inside other component objects for more complex
+pages. If a page in the AUT has multiple components, or common
+components used throughout the site (e.g. a navigation bar), then it
+may improve maintainability and reduce code duplication.
 
 There are other design patterns that also may be used in testing. Some use a
 Page Factory for instantiating their page objects. Discussing all of these is

--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.ko.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.ko.md
@@ -181,10 +181,16 @@ instantiating the page object. In the examples above, both the SignInPage and
 HomePage constructors check that the expected page is available and ready for
 requests from the test.
 
-A page object does not necessarily need to represent an entire page. The Page
-Object design pattern could be used to represent components on a page. If a
-page in the AUT has multiple components, it may improve maintainability if
-there is a separate page object for each component.
+A page object does not necessarily need to represent all the parts of a
+page itself. The same principles used for page objects can be used to
+create "Page _Component_ Objects" that represent discrete chunks of the
+page and can be used in page objects. These component objects can
+provide references the elements inside those discrete chunks, and
+methods to leverage the functionality provided by them. You can even
+nest component objects inside other component objects for more complex
+pages. If a page in the AUT has multiple components, or common
+components used throughout the site (e.g. a navigation bar), then it
+may improve maintainability and reduce code duplication.
 
 There are other design patterns that also may be used in testing. Some use a
 Page Factory for instantiating their page objects. Discussing all of these is

--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.nl.md
@@ -181,10 +181,16 @@ instantiating the page object. In the examples above, both the SignInPage and
 HomePage constructors check that the expected page is available and ready for
 requests from the test.
 
-A page object does not necessarily need to represent an entire page. The Page
-Object design pattern could be used to represent components on a page. If a
-page in the AUT has multiple components, it may improve maintainability if
-there is a separate page object for each component.
+A page object does not necessarily need to represent all the parts of a
+page itself. The same principles used for page objects can be used to
+create "Page _Component_ Objects" that represent discrete chunks of the
+page and can be used in page objects. These component objects can
+provide references the elements inside those discrete chunks, and
+methods to leverage the functionality provided by them. You can even
+nest component objects inside other component objects for more complex
+pages. If a page in the AUT has multiple components, or common
+components used throughout the site (e.g. a navigation bar), then it
+may improve maintainability and reduce code duplication.
 
 There are other design patterns that also may be used in testing. Some use a
 Page Factory for instantiating their page objects. Discussing all of these is


### PR DESCRIPTION
### Description

Differentiate between "page" objects and "component" objects by adding the term "Page Component Object" to describe object representations of components of a page. This simplifies the term "Page Object" so that it only refers to an object that represents the top level API for a page.

### Motivation and Context

Referring to both an abstraction of the page itself and the components
of that page as page objects can cause confusion, in part because it
requires explaining that you can have more than one page object per
page, and some nuances to that can get lost (as it could be taken to
mean you can have more than one page "page" object per page).

It can also be confusing because an object that represents a component
of the page would be referred to as a "page" object, despite it not
representing a page, but an object that represents the page as a whole
would be referred to as a "page" object, and is representing a page.

Differentiating between them by defining a new term for the objects
that represent components (i.e. page component objects) avoids the
confusion.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->

Before:
<img width="1333" alt="Screen Shot 2020-05-19 at 4 54 43 PM" src="https://user-images.githubusercontent.com/13908130/82377398-95f12b80-99f1-11ea-94d2-16e8c709f47f.png">

After:
<img width="1385" alt="Screen Shot 2020-05-19 at 4 54 18 PM" src="https://user-images.githubusercontent.com/13908130/82377391-92f63b00-99f1-11ea-85b2-6da571fcc17e.png">

(second-to-last paragraph was the only one modified)