### PR TITLE
Add Korean Translation of "getting started with webdriver"

### DIFF
--- a/docs_source_files/content/getting_started_with_webdriver/_index.ko.md
+++ b/docs_source_files/content/getting_started_with_webdriver/_index.ko.md
@@ -1,35 +1,21 @@
 ---
-title: "Getting started with WebDriver"
+title: "WebDriver 시작하기"
 chapter: true
 weight: 4
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to Korean. Do you speak Korean? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
+# WebDriver 시작하기
 
-# Getting started with WebDriver
+Selenium은 _WebDriver_ 의 사용을 통해 모든 주요 브라우저의 자동화를 지원합니다.   
+_WebDriver_ 는 웹 브라우저의 동작을 제어하기 위한 언어 중립 인터페이스를 정의하는 API와 프로토콜 입니다.  
+각 브라우저는 *드라이버* 라고 불리는 특정한 웹 드라이버 구현에 의해 뒷받침됩니다.    
+드라이버는 브라우저로의 위임을 담당하는 구성 요소이며, Selenium과 브라우저와의 통신을 처리합니다.  
 
-Selenium supports automation of all the major browsers in the market
-through the use of _WebDriver_.
-WebDriver is an API and protocol that defines a language-neutral interface
-for controlling the behaviour of web browsers.
-Each browser is backed by a specific WebDriver implementation, called a *driver*.
-The driver is the component responsible for delegating down to the browser,
-and handles communication to and from Selenium and the browser.
+이러한 분리는 브라우저 공급 업체가 브라우저 구현을 책임지게하려는 의식적인 노력의 일부입니다.  
+Selenium은 가능한 한 이러한 타사의 드라이버를 사용하지만, 현실적으로 불가능할 경우 프로젝트에서 유지&관리하는 자체 드라이버도 제공합니다.  
 
-This separation is part of a conscious effort to have browser vendors
-take responsibility for the implementation for their browsers.
-Selenium makes use of these third party drivers where possible,
-but also provides its own drivers maintained by the project
-for the cases when this is not a reality.
+Selenium 프레임워크는 이 모든 부분을 하나로 묶습니다.    
+서로 다른 브라우저 백엔드를 투명하게 사용할 수 있는   
+사용자 대면 인터페이스를 통해 브라우저 간 및 플랫폼 간의 자동화가 가능합니다.  
 
-The Selenium framework ties all of these pieces together
-through a user-facing interface that enables the different browser backends
-to be used transparently,
-enabling cross-browser and cross-platform automation.
-
-More details about drivers can be found in 
-[Driver Idiosyncrasies]({{< ref "/driver_idiosyncrasies/_index.md" >}}).
+드라이버에 대한 자세한 내용은 [Driver Idiosyncrasies]({{< ref "/driver_idiosyncrasies/_index.md" >}}) 를 참조하십시오.

--- a/docs_source_files/content/getting_started_with_webdriver/browsers.ko.md
+++ b/docs_source_files/content/getting_started_with_webdriver/browsers.ko.md
@@ -1,33 +1,25 @@
 ---
-title: "Browsers"
+title: "브라우저"
 weight: 1
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to Korean. Do you speak Korean? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
+## 일반적인 브라우저
 
-## Consumer browsers
+Selenium 프레임워크는 공식적으로 다음과 같은 브라우저를 지원합니다.
 
-The Selenium framework officially supports the following browsers:
-
-| Browser | Maintainer | Versions Supported |
+| 브라우저 | 관리자 | 지원 버전 |
 | -------- | ---------- | ------------------ |
-| Chrome | [Chromium](//sites.google.com/a/chromium.org/chromedriver/) | All versions |
-| Firefox | [Mozilla](//github.com/mozilla/geckodriver/) | 54 and newer |
-| Internet Explorer | Selenium | 6 and newer |
-| Opera | [Opera Chromium](//github.com/operasoftware/operachromiumdriver/) / [Presto](//github.com/operasoftware/operaprestodriver) | 10.5 and newer |
-| Safari | [Apple](//webkit.org/blog/6900/webdriver-support-in-safari-10/) | 10 and newer |
+| Chrome | [Chromium](//sites.google.com/a/chromium.org/chromedriver/) | 모든 버전 |
+| Firefox | [Mozilla](//github.com/mozilla/geckodriver/) | 54 이상 |
+| Internet Explorer | Selenium | 6 이상 |
+| Opera | [Opera Chromium](//github.com/operasoftware/operachromiumdriver/) / [Presto](//github.com/operasoftware/operaprestodriver) | 10.5 이상 |
+| Safari | [Apple](//webkit.org/blog/6900/webdriver-support-in-safari-10/) | 10 이상 |
 
-## Specialized browsers
+## 전문화된 브라우저
 
-There is also a set of specialized browsers out there
-typically used in development environments.
-We can make use of some of these browsers for automation purposes also,
-and Selenium ties in support for the following specialized drivers:
+개발 환경에서 전형적으로 사용되는 특수 브라우저 세트도 있습니다.  
+우리는 자동화 목적으로 이러한 브라우저를 사용할 수 있으며, Selenium은 다음과 같은 전문화된 드라이버를 지원합니다.  
 
-| Driver Name | Purpose | Maintainer |
+| 드라이버명 | 목적 | 관리자 |
 | -------- | ---------- | ------------------ |
-| HtmlUnitDriver | Headless browser emulator backed by Rhino | Selenium project |
+| HtmlUnitDriver | Headless browser emulator backed by Rhino | Selenium 프로젝트 |

--- a/docs_source_files/content/getting_started_with_webdriver/third_party_drivers_and_plugins.ko.md
+++ b/docs_source_files/content/getting_started_with_webdriver/third_party_drivers_and_plugins.ko.md
@@ -1,27 +1,18 @@
 ---
-title: "Third party drivers and plugins"
+title: "써드파티 드라이버와 플러그인"
 weight: 2
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to Korean. Do you speak Korean? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
+Selenium은 플러그인의 사용으로 확장될 수 있습니다.  
+다음은 제3자에 의해 생성되고 유지되는 많은 플러그인 입니다.  
+고유한 플러그인을 만들거나 플러그인이 나열되는 자세한 내용은 문서를 참조하세요.  
 
-Selenium can be extended through the use of plugins. Here are a number of 
-plugins created and maintained by third parties. For more information on how 
-to create your own plugin or have it listed, consult the docs.
+이러한 플러그인은 Selenium 프로젝트에서 지원, 유지 관리, 호스팅 또는 보증하지 않는다는 점에서 유의하십시오.  
+또한 아래 나열된 플러그인이 반드시 Apache License v2.0에 따라 라이센스가 부여되지 않는다는 것을 유념하십시오.  
+일부 플러그인은 다른 모료 오픈소스 소프트웨어 라이센스로 사용할 수 있으며, 다른 플러그인은 독점 라이센스로만 사용할 수 있습니다.  
+플러그인과 해당 플러그인의 배포 라이센스에 대한 모든 질문은 해당 개발자와 함께 제기해 주세요.
 
-Please note that these plugins are not supported, maintained, hosted, or 
-endorsed by the Selenium project. In addition, be advised that the plugins 
-listed below are not necessarily licensed under the Apache License v.2.0. 
-Some of the plugins are available under another free and open source software 
-license; others are only available under a proprietary license. Any questions 
-about plugins and their license of distribution need to be raised with their 
-respective developer(s).
-
-| Browser | Latest version | Changelog | Issues | Wiki |
+| 브라우저 | 최신 버전 | 변경 내역 | 이슈 | 위키 |
 | -------- | ---------- | ---------- | ---------- | ---------- |
 | [Google ChromeDriver](//sites.google.com/a/chromium.org/chromedriver/) | [2.29](//chromedriver.storage.googleapis.com/index.html) |  [changelog](//chromedriver.storage.googleapis.com/2.29/notes.txt) | [issues](//bugs.chromium.org/p/chromedriver/issues/list) | [wiki](//github.com/SeleniumHQ/selenium/wiki/ChromeDriver)
 

--- a/docs_source_files/content/selenium_installation/_index.ko.md
+++ b/docs_source_files/content/selenium_installation/_index.ko.md
@@ -1,5 +1,5 @@
 ---
-title: "Selenium installation"
+title: "Selenium 설치"
 chapter: true
 weight: 3
 ---


### PR DESCRIPTION
### Description
- Translate _selenium_installation\_index.ko.md_ to Korean
- Translate _getting_started_with_webdriver\_index.ko.md_ to Korean
- Translate _getting_started_with_webdriver\browsers.md_ to Korean
- Translate _getting_started_with_webdriver\third_party_drivers_and_plugins.ko.md_ to Korean

### Types of changes
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
