### PR TITLE
Add Japanese transration of Chrome Devtools

### DIFF
--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -1,21 +1,25 @@
 ---
-title: "Chrome Devtools"
+title: "Chrome デベロッパーツール"
 weight: 10
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to Japanese. Do you speak Japanese? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
+Selenium 4 alphaバージョンには、"DevTools" インターフェースを介した
+Chrome Dev Protocolのネイティブサポートが待望されています。 
+これにより、アプリケーションキャッシュ、フェッチ、ネットワーク、パフォーマンス、
+プロファイラー、リソースタイミング、セキュリティ、
+ターゲットCDPドメインなどのChrome開発プロパティを取得できます。
 
-Selenium 4 alpha versions have much awaited native support for Chrome Dev Protocol through "DevTools" interface. This helps us getting Chrome Development properties such as Application Cache, Fetch, Network, Performance, Profiler, Resource Timing, Security and Target CDP domains etc.
+Chrome デベロッパーツールは、Google Chromeブラウザに直接組み込まれた一連のWeb開発ツールです。
+DevToolsは、ページをすぐに編集して問題をすばやく診断するのに役立ち、
+最終的にはより優れたWebサイトをより速く構築するのに役立ちます。
 
-Chrome DevTools is a set of web developer tools built directly into the Google Chrome browser. DevTools can help you edit pages on-the-fly and diagnose problems quickly, which ultimately helps you build better websites, faster.
+## ジオロケーションをエミュレート
 
-## Emulate Geo Location:
-
-Some applications have different features and functionalities across different locations. Automating such applications is difficult because it is hard to emulate the geo locations in the browser using Selenium. But with the help of Devtools, we can easily emulate them. Below code snippet demonstrates that.
+一部のアプリケーションには、場所によって特徴や機能性が異なります。
+このようなアプリケーションの自動化は、ブラウザでSeleniumを使用して
+地理的位置をエミュレートすることが難しいため、困難です。
+しかし、デベロッパーツールの助けを借りて、それらを簡単にエミュレートできます。
+以下のコードスニペットはそのことを示しています。
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}


### PR DESCRIPTION
# Description
Translating document "Chrome Devtools"
- content/support_packages/chrome_devtools.ja.md

### Motivation and Context

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
