### PR TITLE
Fixed C# Screenshot example

### DIFF
--- a/docs_source_files/content/webdriver/browser_manipulation.de.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.de.md
@@ -1150,8 +1150,8 @@ driver.quit()
 
     var driver = new ChromeDriver();
     driver.Navigate().GoToUrl("http://www.example.com");
-    var screenshot = (driver as ITakesScreenshot).GetScreenshot();
-    screenshot.SaveAsFile("screenshot.png");
+    Screenshot screenshot = (driver as ITakesScreenshot).GetScreenshot();
+    screenshot.SaveAsFile("screenshot.png", ScreenshotImageFormat.Png); // Format values are Bmp, Gif, Jpeg, Png, Tiff
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} 
 require 'selenium-webdriver'

--- a/docs_source_files/content/webdriver/browser_manipulation.de.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.de.md
@@ -1251,7 +1251,7 @@ driver.quit()
     var webElement = driver.FindElement(By.CssSelector("h1"));
     
     // Screenshot for the element
-    var elementScreenshot = (lastMessage as ITakesScreenshot).GetScreenshot();
+    var elementScreenshot = (webElement as ITakesScreenshot).GetScreenshot();
     elementScreenshot.SaveAsFile("screenshot_of_element.png");
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} // code sample not available please raise a PR {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.en.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.en.md
@@ -1143,8 +1143,8 @@ driver.quit()
 
   var driver = new ChromeDriver();
   driver.Navigate().GoToUrl("http://www.example.com");
-  var screenshot = (driver as ITakesScreenshot).GetScreenshot();
-  screenshot.SaveAsFile("screenshot.png");
+  Screenshot screenshot = (driver as ITakesScreenshot).GetScreenshot();
+  screenshot.SaveAsFile("screenshot.png", ScreenshotImageFormat.Png); // Format values are Bmp, Gif, Jpeg, Png, Tiff
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} 
 require 'selenium-webdriver'

--- a/docs_source_files/content/webdriver/browser_manipulation.en.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.en.md
@@ -1244,7 +1244,7 @@ driver.quit()
     var webElement = driver.FindElement(By.CssSelector("h1"));
     
     // Screenshot for the element
-    var elementScreenshot = (lastMessage as ITakesScreenshot).GetScreenshot();
+    var elementScreenshot = (webElement as ITakesScreenshot).GetScreenshot();
     elementScreenshot.SaveAsFile("screenshot_of_element.png");
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} // code sample not available please raise a PR {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.es.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.es.md
@@ -1151,8 +1151,8 @@ driver.quit()
 
     var driver = new ChromeDriver();
     driver.Navigate().GoToUrl("http://www.example.com");
-    var screenshot = (driver as ITakesScreenshot).GetScreenshot();
-    screenshot.SaveAsFile("screenshot.png");
+    Screenshot screenshot = (driver as ITakesScreenshot).GetScreenshot();
+    screenshot.SaveAsFile("screenshot.png", ScreenshotImageFormat.Png); // Format values are Bmp, Gif, Jpeg, Png, Tiff
    {{< / code-panel >}}
   {{< code-panel language="ruby" >}} 
 require 'selenium-webdriver'

--- a/docs_source_files/content/webdriver/browser_manipulation.es.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.es.md
@@ -1252,7 +1252,7 @@ driver.quit()
     var webElement = driver.FindElement(By.CssSelector("h1"));
     
     // Screenshot for the element
-    var elementScreenshot = (lastMessage as ITakesScreenshot).GetScreenshot();
+    var elementScreenshot = (webElement as ITakesScreenshot).GetScreenshot();
     elementScreenshot.SaveAsFile("screenshot_of_element.png"); 
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} // code sample not available please raise a PR {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.fr.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.fr.md
@@ -1247,7 +1247,7 @@ driver.quit()
     var webElement = driver.FindElement(By.CssSelector("h1"));
 
     // Screenshot for the element
-    var elementScreenshot = (lastMessage as ITakesScreenshot).GetScreenshot();
+    var elementScreenshot = (webElement as ITakesScreenshot).GetScreenshot();
     elementScreenshot.SaveAsFile("screenshot_of_element.png");
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} // code sample not available please raise a PR {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.fr.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.fr.md
@@ -1146,8 +1146,8 @@ driver.quit()
 
     var driver = new ChromeDriver();
     driver.Navigate().GoToUrl("http://www.example.com");
-    var screenshot = (driver as ITakesScreenshot).GetScreenshot();
-    screenshot.SaveAsFile("screenshot.png");
+    Screenshot screenshot = (driver as ITakesScreenshot).GetScreenshot();
+    screenshot.SaveAsFile("screenshot.png", ScreenshotImageFormat.Png); // Format values are Bmp, Gif, Jpeg, Png, Tiff
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} 
 require 'selenium-webdriver'

--- a/docs_source_files/content/webdriver/browser_manipulation.ja.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.ja.md
@@ -1096,8 +1096,8 @@ driver.quit()
 
   var driver = new ChromeDriver();
   driver.Navigate().GoToUrl("http://www.example.com");
-  var screenshot = (driver as ITakesScreenshot).GetScreenshot();
-  screenshot.SaveAsFile("screenshot.png");
+  Screenshot screenshot = (driver as ITakesScreenshot).GetScreenshot();
+  screenshot.SaveAsFile("screenshot.png", ScreenshotImageFormat.Png); // Format values are Bmp, Gif, Jpeg, Png, Tiff
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} 
 require 'selenium-webdriver'

--- a/docs_source_files/content/webdriver/browser_manipulation.ja.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.ja.md
@@ -1197,7 +1197,7 @@ driver.quit()
     var webElement = driver.FindElement(By.CssSelector("h1"));
 
     // Screenshot for the element
-    var elementScreenshot = (lastMessage as ITakesScreenshot).GetScreenshot();
+    var elementScreenshot = (webElement as ITakesScreenshot).GetScreenshot();
     elementScreenshot.SaveAsFile("screenshot_of_element.png");
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} // code sample not available please raise a PR {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.ko.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.ko.md
@@ -1249,7 +1249,7 @@ driver.quit()
     var webElement = driver.FindElement(By.CssSelector("h1"));
 
     // Screenshot for the element
-    var elementScreenshot = (lastMessage as ITakesScreenshot).GetScreenshot();
+    var elementScreenshot = (webElement as ITakesScreenshot).GetScreenshot();
     elementScreenshot.SaveAsFile("screenshot_of_element.png");
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} // code sample not available please raise a PR {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.ko.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.ko.md
@@ -1148,8 +1148,8 @@ driver.quit()
 
     var driver = new ChromeDriver();
     driver.Navigate().GoToUrl("http://www.example.com");
-    var screenshot = (driver as ITakesScreenshot).GetScreenshot();
-    screenshot.SaveAsFile("screenshot.png");
+    Screenshot screenshot = (driver as ITakesScreenshot).GetScreenshot();
+    screenshot.SaveAsFile("screenshot.png", ScreenshotImageFormat.Png); // Format values are Bmp, Gif, Jpeg, Png, Tiff
    {{< / code-panel >}}
   {{< code-panel language="ruby" >}} 
 require 'selenium-webdriver'

--- a/docs_source_files/content/webdriver/browser_manipulation.nl.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.nl.md
@@ -1247,7 +1247,7 @@ driver.quit()
     var webElement = driver.FindElement(By.CssSelector("h1"));
 
     // Screenshot for the element
-    var elementScreenshot = (lastMessage as ITakesScreenshot).GetScreenshot();
+    var elementScreenshot = (webElement as ITakesScreenshot).GetScreenshot();
     elementScreenshot.SaveAsFile("screenshot_of_element.png");
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} // code sample not available please raise a PR {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.nl.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.nl.md
@@ -1146,8 +1146,8 @@ driver.quit()
 
     var driver = new ChromeDriver();
     driver.Navigate().GoToUrl("http://www.example.com");
-    var screenshot = (driver as ITakesScreenshot).GetScreenshot();
-    screenshot.SaveAsFile("screenshot.png");
+    Screenshot screenshot = (driver as ITakesScreenshot).GetScreenshot();
+    screenshot.SaveAsFile("screenshot.png", ScreenshotImageFormat.Png); // Format values are Bmp, Gif, Jpeg, Png, Tiff
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} 
 require 'selenium-webdriver'

--- a/docs_source_files/content/webdriver/browser_manipulation.zh-cn.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.zh-cn.md
@@ -1078,8 +1078,8 @@ driver.quit()
 
     var driver = new ChromeDriver();
     driver.Navigate().GoToUrl("http://www.example.com");
-    var screenshot = (driver as ITakesScreenshot).GetScreenshot();
-    screenshot.SaveAsFile("screenshot.png");
+    Screenshot screenshot = (driver as ITakesScreenshot).GetScreenshot();
+    screenshot.SaveAsFile("screenshot.png", ScreenshotImageFormat.Png); // Format values are Bmp, Gif, Jpeg, Png, Tiff
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} 
 require 'selenium-webdriver'

--- a/docs_source_files/content/webdriver/browser_manipulation.zh-cn.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.zh-cn.md
@@ -1180,7 +1180,7 @@ driver.quit()
     var webElement = driver.FindElement(By.CssSelector("h1"));
 
     // Screenshot for the element
-    var elementScreenshot = (lastMessage as ITakesScreenshot).GetScreenshot();
+    var elementScreenshot = (webElement as ITakesScreenshot).GetScreenshot();
     elementScreenshot.SaveAsFile("screenshot_of_element.png");
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}} // code sample not available please raise a PR {{< / code-panel >}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Two commits on this branch.
- Replaced var with Screenshot, so that the reader will get a clear idea about the 'Screenshot' class being used.
- lastMessage is an unknown variable present in the example.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
