### PR TITLE
Fix broken edit links

### DIFF
--- a/docs_source_files/config.toml
+++ b/docs_source_files/config.toml
@@ -21,7 +21,7 @@ enableGitInfo = true
 [params]
   # Change default color scheme with a variant one. Can be "red", "blue", "green".
   themeVariant = "selenium"
-  editURL = "https://github.com/SeleniumHQ/site/edit/trunk/docs_source_files/content/"
+  editURL = "https://github.com/SeleniumHQ/site/edit/dev/docs_source_files/content/"
   ghrepo = "https://github.com/SeleniumHQ/site/"
   description = "Documentation for Selenium"
   showVisitedLinks = true


### PR DESCRIPTION
When you click on the edit links they are broken, looks like they are going to the `trunk` branch, but should be going to the `edit` branch. I'm pretty sure this is the fix, but haven't tested it locally. @diemol can you verify for me? Thanks!