### PR TITLE
fix argument of presence_of_element_located

### DIFF
--- a/docs_source_files/content/_index.de.md
+++ b/docs_source_files/content/_index.de.md
@@ -68,7 +68,7 @@ with webdriver.Firefox() as driver:
     wait = WebDriverWait(driver, 10)
     driver.get("https://google.com/ncr")
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located(By.CSS_SELECTOR, "h3>div"))
+    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>div")))
     print(first_result.get_attribute("textContent"))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}

--- a/docs_source_files/content/_index.en.md
+++ b/docs_source_files/content/_index.en.md
@@ -66,7 +66,7 @@ with webdriver.Firefox() as driver:
     wait = WebDriverWait(driver, 10)
     driver.get("https://google.com/ncr")
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located(By.CSS_SELECTOR, "h3>div"))
+    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>div")))
     print(first_result.get_attribute("textContent"))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}

--- a/docs_source_files/content/_index.es.md
+++ b/docs_source_files/content/_index.es.md
@@ -66,7 +66,7 @@ with webdriver.Firefox() as driver:
     wait = WebDriverWait(driver, 10)
     driver.get("https://google.com/ncr")
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located(By.CSS_SELECTOR, "h3>div"))
+    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>div")))
     print(first_result.get_attribute("textContent"))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}

--- a/docs_source_files/content/_index.fr.md
+++ b/docs_source_files/content/_index.fr.md
@@ -64,7 +64,7 @@ with webdriver.Firefox() as driver:
     wait = WebDriverWait(driver, 10)
     driver.get("https://google.com/ncr")
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located(By.CSS_SELECTOR, "h3>div"))
+    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>div")))
     print(first_result.get_attribute("textContent"))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}

--- a/docs_source_files/content/_index.ja.md
+++ b/docs_source_files/content/_index.ja.md
@@ -54,7 +54,7 @@ with webdriver.Firefox() as driver:
     wait = WebDriverWait(driver, 10)
     driver.get("https://google.com/ncr")
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located(By.CSS_SELECTOR, "h3>div"))
+    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>div")))
     print(first_result.get_attribute("textContent"))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}

--- a/docs_source_files/content/_index.ko.md
+++ b/docs_source_files/content/_index.ko.md
@@ -56,7 +56,7 @@ with webdriver.Firefox() as driver:
     wait = WebDriverWait(driver, 10)
     driver.get("https://google.com/ncr")
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located(By.CSS_SELECTOR, "h3>div"))
+    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>div")))
     print(first_result.get_attribute("textContent"))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}

--- a/docs_source_files/content/_index.nl.md
+++ b/docs_source_files/content/_index.nl.md
@@ -72,7 +72,7 @@ with webdriver.Firefox() as driver:
     wait = WebDriverWait(driver, 10)
     driver.get("https://google.com/ncr")
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located(By.CSS_SELECTOR, "h3>div"))
+    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>div")))
     print(first_result.get_attribute("textContent"))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}

--- a/docs_source_files/content/_index.zh-cn.md
+++ b/docs_source_files/content/_index.zh-cn.md
@@ -55,7 +55,7 @@ with webdriver.Firefox() as driver:
     wait = WebDriverWait(driver, 10)
     driver.get("https://google.com/ncr")
     driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located(By.CSS_SELECTOR, "h3>div"))
+    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3>div")))
     print(first_result.get_attribute("textContent"))
   {{< / code-panel >}}
   {{< code-panel language="csharp" >}}


### PR DESCRIPTION
In Python
presence_of_element_located(By.CSS_SELECTOR, "h3>div")
should be
presence_of_element_located((By.CSS_SELECTOR, "h3>div"))

Because the argument should be a tuple. And the current one does not work.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->
fix argument of presence_of_element_located
### Description
<!--- Describe your changes in detail -->
presence_of_element_located(By.CSS_SELECTOR, "h3>div")
should be
presence_of_element_located((By.CSS_SELECTOR, "h3>div"))

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Because the argument should be a tuple. And the current one does not work.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
