### PR TITLE
updated sample graphql curl command to get URI

### DIFF
--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.de.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.de.md
@@ -40,7 +40,7 @@ java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 In Selenium 4, we've added GraphQL, a new way to query the necessary data easily and get exactly the same.
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data 'query { grid { url} }' -s http://localhost:4444/graphql | jq .
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 

--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.en.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.en.md
@@ -34,7 +34,7 @@ java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 In Selenium 4, we've also added GraphQL, a new way to query the necessary data easily and get exactly the same.
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data 'query { grid { url} }' -s http://localhost:4444/graphql | jq .
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 

--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.es.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.es.md
@@ -40,7 +40,7 @@ java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 In Selenium 4, we've added GraphQL, a new way to query the necessary data easily and get exactly the same.
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data 'query { grid { url} }' -s http://localhost:4444/graphql | jq .
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 

--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.fr.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.fr.md
@@ -40,7 +40,7 @@ java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 In Selenium 4, we've added GraphQL, a new way to query the necessary data easily and get exactly the same.
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data 'query { grid { url} }' -s http://localhost:4444/graphql | jq .
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 

--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.ja.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.ja.md
@@ -40,7 +40,7 @@ java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 In Selenium 4, we've added GraphQL, a new way to query the necessary data easily and get exactly the same.
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data 'query { grid { url} }' -s http://localhost:4444/graphql | jq .
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 

--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.ko.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.ko.md
@@ -40,7 +40,7 @@ java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 In Selenium 4, we've added GraphQL, a new way to query the necessary data easily and get exactly the same.
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data 'query { grid { url} }' -s http://localhost:4444/graphql | jq .
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 

--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.nl.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.nl.md
@@ -40,7 +40,7 @@ java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 In Selenium 4, we've added GraphQL, a new way to query the necessary data easily and get exactly the same.
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data 'query { grid { url} }' -s http://localhost:4444/graphql | jq .
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 

--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.zh-cn.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.zh-cn.md
@@ -40,7 +40,7 @@ java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 In Selenium 4, we've added GraphQL, a new way to query the necessary data easily and get exactly the same.
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data 'query { grid { url} }' -s http://localhost:4444/graphql | jq .
+curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 


### PR DESCRIPTION
The graphql curl command was not working as there is no resource like "url" under grid so we have to change it to "uri"

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I am attaching a screenshot showing the before and after)
**Before Image:**
![before](https://user-images.githubusercontent.com/358319/94418800-75fa2180-01b4-11eb-9b6b-6426828732f3.png)
**After Image**
![after](https://user-images.githubusercontent.com/358319/94418820-7b576c00-01b4-11eb-9a77-9f060e1a174d.png)

- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
