### PR TITLE
Add a link to the Helium framework

### DIFF
--- a/site_source_files/content/ecosystem/framwework-helium.md
+++ b/site_source_files/content/ecosystem/framwework-helium.md
@@ -1,0 +1,8 @@
++++
+Description = ""
+Key = "framework"
+BindingName = "Helium"
+Language = "Python"
+BindingLink = "https://github.com/mherrmann/selenium-python-helium"
+Author = "Michael Herrmann"
++++


### PR DESCRIPTION
[Helium](https://github.com/mherrmann/selenium-python-helium) is an open source Python library that wraps around Selenium to offer a more high-level API. This PR adds a link to Helium on the [Ecosystem page](https://www.selenium.dev/ecosystem/). I was [encouraged by Diego Molina](https://twitter.com/diegofmolina/status/1312008437061103616) to create this PR.

### Before:
![before](https://user-images.githubusercontent.com/1076393/94928930-ac8db000-04c4-11eb-8228-6a9761d345ed.png)

### After:
![after](https://user-images.githubusercontent.com/1076393/94928933-ae577380-04c4-11eb-81b9-708b001abfd9.png)

The only thing this PR changes is to add the `framework-helium.md` file. I checked with `hugo` that this produces the expected link on `/ecosystem`. As such it is a pure site change.

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.