### PR TITLE
Only a typo fix in english version

### DIFF
--- a/docs_source_files/content/driver_idiosyncrasies/shared_capabilities.en.md
+++ b/docs_source_files/content/driver_idiosyncrasies/shared_capabilities.en.md
@@ -138,7 +138,7 @@ may not equally match the values set to the browser.
 
 ## strictFileInteractability
 
-The new capabilitiy indicates if strict interactability checks 
+The new capability indicates if strict interactability checks 
 should be applied to _input type=file_ elements. As strict interactability 
 checks are off by default, there is a change in behaviour 
 when using _Element Send Keys_ with hidden file upload controls.


### PR DESCRIPTION
### Description
only a typo fix. one single character, also checked non translated pages, they are fine.

### Motivation and Context
to have a correct documentation.

### Types of changes
- [x] Change to the site (only a typo!)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

