### PR TITLE
German translation for http proxies

### DIFF
--- a/docs_source_files/content/webdriver/http_proxies.de.md
+++ b/docs_source_files/content/webdriver/http_proxies.de.md
@@ -1,23 +1,25 @@
 ---
-title: "Http proxies"
+title: "Http Proxies"
 weight: 7
 ---
 
-A proxy server acts as an intermediary for requests between a client and a server.
-In simple, the traffic flows through the proxy server on its way to the address you
-requested and back.
+Ein Proxy-Server fungiert als Zwischenstation für Anfragen zwischen
+Client und Server. Simpel erklärt werden die Daten über den Proxy zu der
+gewünschten Internetadresse und wieder retour geleitet.
 
-A proxy server for automation scripts with Selenium could be helpful for:
-- Capture network traffic
-- Mock backend calls made by the website
-- Access the required website under complex network topologies or strict
-corporate restrictions/policies.
+Ein Proxy Server für die automatisierten Seleniumskripte kann hilfreich 
+sein bei:
+- Aufzeichnen des Netzwerkverkehrs
+- Mocken von Backend-Aufrufen die von der Website abgesetzt werden
+- Zugriff auf die gewünschte Website unter komplexen Netzwerkbedingungen oder 
+strengen Einschränkungen.
 
-If you are in a corporate environment, and a browser fails to connect to
-a URL, this is most likely because the environment needs a proxy to be
-accessed.
+Hat man Probleme bei der Verbindung zu einer URL aus einem Unternehmensnetzwerk, 
+deutet das meistens darauf hin, dass es notwendig ist die Verbindung über
+einen Proxy herzustellen.
 
-Selenium WebDriver provides a way to proxy settings
+Der Selenium WebDriver stellt die Möglichkeit zur Verfügung um
+Proxyeinstellungen vorzunehmen:
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}

--- a/docs_source_files/content/webdriver/http_proxies.de.md
+++ b/docs_source_files/content/webdriver/http_proxies.de.md
@@ -7,7 +7,7 @@ Ein Proxy-Server fungiert als Zwischenstation für Anfragen zwischen
 Client und Server. Simpel erklärt werden die Daten über den Proxy zu der
 gewünschten Internetadresse und wieder retour geleitet.
 
-Ein Proxy Server für die automatisierten Seleniumskripte kann hilfreich 
+Ein Proxy Server für die automatisierten Selenium-Skripte kann hilfreich 
 sein bei:
 - Aufzeichnen des Netzwerkverkehrs
 - Mocken von Backend-Aufrufen die von der Website abgesetzt werden

--- a/docs_source_files/content/webdriver/http_proxies.en.md
+++ b/docs_source_files/content/webdriver/http_proxies.en.md
@@ -20,7 +20,7 @@ If you are in a corporate environment, and a
 browser fails to connect to a URL, this is most 
 likely because the environment needs a proxy to be accessed.
 
-Selenium WebDriver provides a way to proxy settings
+Selenium WebDriver provides a way to proxy settings:
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}

--- a/docs_source_files/content/webdriver/http_proxies.fr.md
+++ b/docs_source_files/content/webdriver/http_proxies.fr.md
@@ -21,7 +21,7 @@ le navigateur ne parvient pas à se connecter à une URL, c'est
 très probablement parce que l'environnement a besoin d'un
 proxy à accéder.
 
-Selenium WebDriver permet d'accéder aux paramètres du proxy
+Selenium WebDriver permet d'accéder aux paramètres du proxy:
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}

--- a/docs_source_files/content/webdriver/http_proxies.ko.md
+++ b/docs_source_files/content/webdriver/http_proxies.ko.md
@@ -27,7 +27,7 @@ browser fails to connect to a URL, this is most
 likely because the environment needs a 
 proxy to be accessed.
 
-Selenium WebDriver provides a way to proxy settings
+Selenium WebDriver provides a way to proxy settings:
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}

--- a/docs_source_files/content/webdriver/http_proxies.nl.md
+++ b/docs_source_files/content/webdriver/http_proxies.nl.md
@@ -26,7 +26,7 @@ If you are in a corporate environment, and a
 browser fails to connect to a URL, this is most 
 likely because the environment needs a proxy to be accessed.
 
-Selenium WebDriver provides a way to proxy settings
+Selenium WebDriver provides a way to proxy settings:
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}


### PR DESCRIPTION
### Description
German translation for http proxies
Also added a missing : in the english version and non translated pages

### Motivation and Context
Missing german translation for that page

### Types of changes
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

