### PR TITLE
Add Japanese translation of some pages

### DIFF
--- a/docs_source_files/content/driver_idiosyncrasies/shared_capabilities.ja.md
+++ b/docs_source_files/content/driver_idiosyncrasies/shared_capabilities.ja.md
@@ -109,7 +109,6 @@ _幅_ または _高さ_ を設定しても、結果のウィンドウサイズ�
 
 ## strictFileInteractability
 
-The new capabilitiy indicates if strict interactability checks 
-should be applied to _input type=file_ elements. As strict interactability 
-checks are off by default, there is a change in behaviour 
-when using _Element Send Keys_ with hidden file upload controls.
+この新しいcapabilitiyは、厳密な相互作用チェックを _input type = file_ 要素に適用する必要があるかどうかを示します。
+厳密な相互作用チェックはデフォルトでオフになっているため、隠しファイルのアップロードコントロールで _Element Send Keys_ 
+を使用する場合の動作が変更されます。

--- a/docs_source_files/content/grid/grid_4/graphql_support.ja.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.ja.md
@@ -1,29 +1,24 @@
 ---
-title: "GraphQL querying support"
+title: "GraphQLクエリのサポート"
 weight: 1
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from
-English to Japanese. Do you speak Japanese? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
+GraphQLは、APIのクエリ言語であり、既存のデータでこれらのクエリを実行するためのランタイムです。 
+これにより、ユーザーは必要なものだけを正確に要求することができます。
 
-GraphQL is a query language for APIs and a runtime for fulfilling those queries with your existing data. It gives users the power to ask for exactly what they need and nothing more.
+## 列挙型(Enum)
+列挙型は、フィールドの可能な値のセットを表します。
 
-## Enums
-Enums represent possible sets of values for a field.
+たとえば、 `Node` オブジェクトには `status` というフィールドがあります。 
+`UP` 、 `DRAINING` 、または `UNAVAILABLE` の可能性があるため、状態は、 列挙型（具体的には、`Status` タイプ）です。
 
-For example, the `Node` object has a field called `status`. The state is an enum (specifically, of type `Status`) because it may be `UP` , `DRAINING` or `UNAVAILABLE`.
+## スカラー
+スカラーはプリミティブ値です： `Int` 、 `Float` 、 `String` 、 `Boolean` 、または `ID` 。
 
-## Scalars
-Scalars are primitive values: `Int`, `Float`, `String`, `Boolean`, or `ID`.
+GraphQL APIを呼び出すときは、スカラーのみを返すまでネストされたサブフィールドを指定する必要があります。
 
-When calling the GraphQL API, you must specify nested subfield until you return only scalars.
-
-
-## Structure of the Schema
-The structure of grid schema is as follows:
+## スキーマの構造
+グリッドスキーマの構造は次のとおりです。
 
 ```shell
 {
@@ -44,33 +39,34 @@ The structure of grid schema is as follows:
 }
 ```
 
-## Querying GraphQL
+## GraphQLで照会する
 
-The best way to query GraphQL is by using `curl` requests. GraphQL allows you to fetch only the data that you want, nothing more nothing less.
+GraphQLをクエリする最良の方法は、 `curl` リクエストを使用することです。 
+GraphQLを使用すると、必要なデータのみをフェッチできます。それ以上でもそれ以下でもありません。
 
 Some of the example GraphQL queries are given below. You can build your own queries as you like.
 
-### Querying the number of `totalSlots` and `usedSlots` in the grid :
+### グリッド内の `totalSlots`と` usedSlots`の数を照会する
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://localhost:4444/graphql`
+通常、ローカルマシンでは、 `<LINK_TO_GRAPHQL_ENDPOINT>` は `http://localhost:4444/graphql` になります。
 
-### Querying the capabilities of each node in the grid :
+### グリッド内の各ノードのcapabilityを照会する
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### Querying the status of each node in the grid :
+### グリッド内の各ノードのステータスを照会する
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### Querying the URI of each node and the grid :
+### 各ノードとグリッドのURIを照会する
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>

--- a/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.ja.md
+++ b/docs_source_files/content/grid/grid_4/setting_up_your_own_grid.ja.md
@@ -3,94 +3,97 @@ title: "独自のグリッドを設定する"
 weight: 2
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to Japanese. Do you speak Japanese? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
-
-## Different Modes of Grid setup in Selenium 4:
-* Standalone
-* Hub and Node
-* Distributed
+## Selenium4でのグリッド設定のさまざまなモード
+* スタンドアロン
+* ハブとノード
+* 分散
 * Docker
 
-## Standalone Mode:
-The new Selenium Server Jar contains everything you'd need to run a grid. It is also the easiest mode to spin up a Selenium Grid. By default the server will be listening on http://localhost:4444, and that's the URL you should point your RemoteWebDriver tests. The server will detect the available drivers that it can use from the System PATH
+## スタンドアロンモード
+新しいSeleniumServer Jarには、グリッドを実行するために必要なすべてのものが含まれています。 
+Seleniumグリッドを起動するのも最も簡単なモードです。 
+デフォルトでは、サーバーは http://localhost:4444 でリッスンします。
+これは、RemoteWebDriverテストを指定する必要があるURLです。 
+サーバーは、システムパスから使用できる使用可能なドライバーを検出します。
 
 ```shell
 java -jar selenium-server-4.0.0-alpha-6.jar standalone
 ```
 
-## Hub and Node Mode:
+## ハブとノードモード
 
-### Start the Hub:
+### ハブを開始する
 ```shell
 java -jar selenium-server-4.0.0-alpha-6.jar hub
 ```
 
-### Register a Node:
+### ノードを登録する
 
 ```shell
 java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
 ```
 
-### Query Selenium Grid:
+### Seleniumグリッドをクエリする
 
-In Selenium 4, we've added GraphQL, a new way to query the necessary data easily and get exactly the same.
+Selenium 4では、必要なデータを簡単にクエリしてまったく同じものを取得する新しい方法であるGraphQLを追加しました。
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{ "query": "{grid{uri}}" }' -s http://localhost:4444/graphql | jq .
 ```
 <br><br>
 
-## Distributed Mode:
+## 分散モード
 
-* Step 1: Firstly, start the Event Bus, it serves as a communication path to other Grid components in subsequent steps.
+* Step 1: まず、イベントバスを開始します。
+これは、後続のステップで他のグリッドコンポーネントへの通信パスとして機能します。
 
     ```shell
     java -jar selenium-server-4.0.0-alpha-6.jar  event-bus
     ```
 
-* Step 2: Start the session map, which is responsible for mapping session IDs to the node the session is running on:
+* Step 2: セッションマップを開始します。
+これは、セッションIDをセッションが実行されているノードにマッピングする役割を果たします。
         
     ```shell 
         java -jar selenium-server-4.0.0-alpha-6.jar sessions
     ```
 
-* Step 3: Start the new session queuer, it adds the new session request to a local queue. The distributor picks up the request from the queue.
+* Step 3: 新しいセッションキューを起動すると、新しいセッション要求がローカルキューに追加されます。 
+ディストリビューターはキューからリクエストを受け取ります。
         
     ```shell 
         java -jar selenium-server-4.0.0-alpha-6.jar sessionqueuer
     ```
 
-* Step 4: Start the Distributor. All the nodes are attached as part of Distributor process. It is responsible for assigning a node, when a create session request in invoked.
+* Step 4: ディストリビューターを起動します。 
+すべてのノードは、ディストリビュータープロセスの一部として接続されます。 
+セッションの作成要求が呼び出されたときに、ノードを割り当てる必要があります。
 
     ```shell 
         java -jar selenium-server-4.0.0-alpha-6.jar distributor --sessions http://localhost:5556 --sessionqueuer http://localhost:5559 --bind-bus false
     ```
 
-* Step 5: Next step is to start the Router, an address that you'd expose to web
+* Step 5: 次に、Webに公開するアドレスであるルーターを起動します。
 
     ```shell 
         java -jar selenium-server-4.0.0-alpha-6.jar router --sessions http://localhost:5556 --distributor http://localhost:5553 --sessionqueuer http://localhost:5559
     ```
 
-* Step 6: Finally, add a Node
+* Step 6: 最後に、ノードを追加します。
 
     ```shell 
         java -jar selenium-server-4.0.0-alpha-6.jar node --detect-drivers
     ```
 
-## Start Standalone Grid via Docker Images
+## Dockerイメージを介してスタンドアロングリッドを開始する
 
-  You can just start a node by the following command:
+  次のコマンドでノードを起動できます。
       
 ```shell 
     java -jar selenium-server-4.0.0-alpha-1.jar node -D selenium/standalone-firefox:latest '{"browserName": "firefox"}'
 ```
 
-  You can start the Selenium server and delegate it to docker for creating new instances:
+  Seleniumサーバーを起動し、Dockerに新しいインスタンスを作成することを委任できます。
       
 ```shell 
      java -jar selenium-server-4.0.0-alpha-6.jar standalone -D selenium/standalone-firefox:latest '{"browserName": "firefox"}' --detect-drivers false

--- a/docs_source_files/content/worst_practices/file_downloads.ja.md
+++ b/docs_source_files/content/worst_practices/file_downloads.ja.md
@@ -8,10 +8,7 @@ Seleniumの管理下にあるブラウザーでリンクをクリックしてダ
 これは、ファイルのダウンロードは、Webプラットフォームとのユーザーインタラクションをエミュレートする重要な側面とは見なされないためです。
 代わりに、Selenium（および必要なCookie）を使用してリンクを見つけ、 [libcurl](//curl.haxx.se/libcurl/) などのHTTPリクエストライブラリに渡します。
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
-English to Japanese. Do you speak Japanese? Help us to translate
-it by sending us pull requests!
-{{% /notice %}}
-
-The [HtmlUnit driver](https://github.com/SeleniumHQ/htmlunit-driver) can download attachments by accessing them as input streams by implementing the [AttachmentHandler](https://htmlunit.sourceforge.io/apidocs/com/gargoylesoftware/htmlunit/attachment/AttachmentHandler.html) interface. The AttachmentHandler can the be added to the [HtmlUnit](https://htmlunit.sourceforge.io/) WebClient.
+[HtmlUnitドライバー](https://github.com/SeleniumHQ/htmlunit-driver)は、
+[AttachmentHandler](https://htmlunit.sourceforge.io/apidocs/com/gargoylesoftware/htmlunit/attachment/AttachmentHandler.html) インターフェイスを実装することで、
+入力ストリームとして添付ファイルにアクセスすることによって、添付ファイルをダウンロードできます。 
+AttachmentHandlerは、[HtmlUnit](https://htmlunit.sourceforge.io/) に追加できます。


### PR DESCRIPTION
Add Japanese translation of 

- content/driver_idiosyncrasies/shared_capabilities.ja.md
- content/grid/grid_4/graphql_support.ja.md
- content/grid/grid_4/setting_up_your_own_grid.ja.md
- content/worst_practices/file_downloads.ja.md

### Motivation and Context

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [] Improved translation
- [x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
