### PR TITLE
German remotewebdriver

### DIFF
--- a/docs_source_files/content/remote_webdriver/_index.de.md
+++ b/docs_source_files/content/remote_webdriver/_index.de.md
@@ -6,16 +6,12 @@ weight: 6
 
 # Remote WebDriver
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Diese Seite wird von Englisch 
-auf Deutsch übersetzt. Sprichst Du Deutsch? Hilf uns die Seite 
-zu übersetzen indem Du uns einen Pull Reqeust schickst!
- {{% /notice %}}
+Der WebDriver kann über eine Remoteverbindung genau so verwendet werden
+wie bei einer lokalen Verbindung. Der Hauptunterschied ist das der
+remote WebDriver konfiguriert werden muss, sodass die Testdurchführung
+auf einem anderen Rechner gestartet werden kann.
 
-You can use WebDriver remotely the same way you would use it
-locally. The primary difference is that a remote WebDriver needs to be
-configured so that it can run your tests on a separate machine.
-
-A remote WebDriver is composed of two pieces: a client and a
-server. The client is your WebDriver test and the server is simply a
-Java servlet, which can be hosted in any modern JEE app server.
+Der remote WebDriver besteht aus zwei Komponenten: Einem Client und
+einem Server. Der Client besteht aus dem WebDriver-Test und der Server 
+ist ein einfaches Java Servlet, welches auf jedem modernen JEE App Server
+gehostet werden kann.

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_client.de.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_client.de.md
@@ -1,20 +1,14 @@
 ---
-title: "Remote WebDriver client"
+title: "Remote WebDriver Client"
 weight: 2
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Diese Seite wird von Englisch 
-auf Deutsch übersetzt. Sprichst Du Deutsch? Hilf uns die Seite 
-zu übersetzen indem Du uns einen Pull Reqeust schickst!
- {{% /notice %}}
-
-To run a remote WebDriver client, we first need to connect to the RemoteWebDriver.
-We do this by pointing the URL to the address of the server running our tests.
-In order to customize our configuration, we set desired capabilities.
-Below is an example of instantiating a remote WebDriver object
-pointing to our remote web server, _www.example.com_,
-running our tests on Firefox.
+Um einen remote WebDriver Client zu starten, ist es notwendig eine Verbindung
+zum Remote WebDriver aufzubauen. Das geschiet, indem eine Verbindung zu einer
+URL aufgebaut wird, der die Testdurchführung vornimmt. Die gewünschte Konfiguration
+wird mithilfe der Capabilities (= Einstellungen) definiert. Im folgenden Beispiel 
+wird ein remote WebDriver Objekt instanziert, der mit dem remote Webserver, 
+_www.example.com_, verbunden wird, um dort die Tests mit einem Firefox Browser auszuführen.
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
@@ -70,14 +64,14 @@ driver.quit()
   {{< / code-panel >}}
 {{< / code-tab >}}
 
+Um die Testkonfiguration weiter anzupassen, können weitere Einstellungen 
+hinzugefügt werden.
 
-To further customize our test configuration, we can add other desired capabilities.
+## Browser Optionen
 
+Angenommen es ist gewünscht Chrome unter Windows XP in der 
+Version 67 zu verwenden:
 
-## Browser options
-
-For example, suppose you wanted to run Chrome on Windows XP,
-using Chrome version 67:
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
@@ -148,15 +142,16 @@ driver.quit()
 {{< / code-tab >}}
 
 
-## Local file detector
+## Detektor für lokale Dateien
 
-The Local File Detector allows the transfer of files from the client
-machine to the remote server.  For example, if a test needs to upload a
-file to a web application, a remote WebDriver can automatically transfer
-the file from the local machine to the remote web server during
-runtime. This allows the file to be uploaded from the remote machine
-running the test. It is not enabled by default and can be enabled in
-the following way:
+Der Detektor erlaubt Dateien vom Client zum remote Server zu übertragen.
+Es kann z.B. notwendig sein eine Datei in einer Webapplikation hochzuladen.
+Der remote WebDriver kann automatisch die Datei vom lokalen Rechner zum 
+remote Rechner hochladen, während der Testdurchführung. Dadurch ist es möglich
+die Datei vom remote Rechner, der die Tests durchführt, hochzuladen.
+Standardmässig die dies nicht aktiviert, kann jedoch wie folgt aktiviert 
+werden: 
+
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
@@ -190,7 +185,8 @@ driver.fileDetector = LocalFileDetector()
   {{< / code-panel >}}
 {{< / code-tab >}}
 
-Once the above code is defined, you can upload a file in your test in the following way:
+Dieser Programmcode, ermöglicht es eine Datei während den Tests
+hochzuladen, indem der folgende Programmcode verwendet wird:
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}

--- a/docs_source_files/content/remote_webdriver/remote_webdriver_server.de.md
+++ b/docs_source_files/content/remote_webdriver/remote_webdriver_server.de.md
@@ -3,75 +3,69 @@ title: "Remote WebDriver Server"
 weight: 1
 ---
 
-{{% notice info %}}
-<i class="fas fa-language"></i> Diese Seite wird von Englisch 
-auf Deutsch übersetzt. Sprichst Du Deutsch? Hilf uns die Seite 
-zu übersetzen indem Du uns einen Pull Reqeust schickst!
- {{% /notice %}}
+Der Server wird immer auf der Maschine ausgeführt, der den gewünschten 
+Browser installiert hat, der für den Test genutzt werden soll. Der Server
+kann entweder mittels Eingabebeaufforderung oder mittels Programmcode
+gestartet werden.
 
-The server will always run on the machine with the browser you want to
-test. The server can be used either from the command line or through code
-configuration.
+## Starten des Servers über die Eingabebeaufforderung
 
-
-## Starting the server from the command line
-
-Once you have downloaded `selenium-server-standalone-{VERSION}.jar`,
-place it on the computer with the browser you want to test. Then, from
-the directory with the jar, run the following:
+Nachdem `selenium-server-standalone-{VERSION}.jar` heruntergeladen wurde,
+platzieren Sie die Datei auf dem Rechner mit dem entsprechenden Browser.
+Führen Sie folgenden Befehl in dem Order aus, der die jar-Datei beinhaltet:
 
 ```shell
 java -jar selenium-server-standalone-{VERSION}.jar
 ```
 
-## Considerations for running the server
+## Überlegungen zum Betrieb des Servers
 
-The caller is expected to terminate each session properly, calling
-either `Selenium#stop()` or `WebDriver#quit`.
+Vom aufrufenden Programm wird erwartet, dass jede Session ordnungsgemäß
+beendet wird, entweder mit `Selenium#stop()` oder `WebDriver#quit`.
 
-The selenium-server keeps in-memory logs for each ongoing session,
-which are cleared when `Selenium#stop()` or `WebDriver#quit` is called. If
-you forget to terminate these sessions, your server may leak memory. If
-you keep extremely long-running sessions, you will probably need to
-stop/quit every now and then (or increase memory with -Xmx jvm option).
+Der Selenium-Server speichert die Logs für jede laufende Sitzung im 
+Hauptspeicher, diese werden gelöscht sobald `Selenium#stop()` oder `WebDriver#quit` 
+aufgerufen wird. Wenn vergessen wird, die Sitzungen zu schließen, kann dies ein 
+Memoryleak verursachen. Falls extrem lange Testdurchführungen
+geplant sind, kann es notwendig sein, von Zeit zu Zeit den Server zu stoppen und
+erneut zu starten (oder den zugewiesenen Speicher mit der jvm Option -Xmx zu erhöhen).
 
+## Timeouts (ab Version 2.21)
 
-## Timeouts (from version 2.21)
-
-The server has two different timeouts, which can be set as follows:
+Der Server hat zwei unterschiedliche Timeouts, die wie folgt festgelegt werden können:
 
 ```shell
 java -jar selenium-server-standalone-{VERSION}.jar -timeout=20 -browserTimeout=60
 ```
 
 * browserTimeout
-  * Controls how long the browser is allowed to hang (value in seconds).
+  * Legt fest wie lange es dem Browser ermöglicht wird zu reagieren (in Sekunden) 
 * timeout
-  * Controls how long the client is allowed to be gone
-  before the session is reclaimed (value in seconds).
+  * Gibt an wie lange es dem Client erlaubt ist inaktiv zu sein, bevor die Session
+  wieder freigegeben wird. (in Sekunden).
 
-The system property `selenium.server.session.timeout`
-is no longer supported as of 2.21.
+Die Systemeigenschaft (system property) `selenium.server.session.timeout`
+wird ab Version 2.21 nicht mehr unterstützt.
 
-Please note that the `browserTimeout`
-is intended as a backup timeout mechanism
-when the ordinary timeout mechanism fails,
-which should be used mostly in grid/server environments
-to ensure that crashed/lost processes do not stay around for too long,
-polluting the runtime environment.
+Zu Beachten ist, dass das `browserTimeout` als Backup Timeout
+Mechanismus gedacht ist, die hauptsächlich in Grid/Server Umgebungen genutzt 
+werden sollten, falls herkömmliche Timeout-Mechanismen scheitern. Dies dient
+dazu das abgestürzte oder "vergessene" Prozesse nicht ewig aktiv bleiben
+und Prozesse geschlossen werden.
 
+## Konfiguration des Servers mit Programmcode
 
-## Configuring the server programmatically
+Theoretisch muss lediglich das `DriverServlet` auf eine URL verlinkt werden, es 
+ist jedoch auch möglich, dies in einem schlanken Container (z.B. Jetty) zu verwenden,
+der vollständig im Code konfiguriert wird.
 
-In theory, the process is as simple as mapping the `DriverServlet` to
-a URL, but it is also possible to host the page in a lightweight
-container, such as Jetty, configured entirely in code.
+* Downloade `selenium-server.zip` und extrahiere die Datei.
+* Füge die JARs dem CLASSPATH hinzu.
+* Erstelle eine eine Klasse mit dem Namen `AppServer`.
 
-* Download the `selenium-server.zip` and unpack. 
-* Put the JARs on the CLASSPATH. 
-* Create a new class called `AppServer`. 
-Here, we are using Jetty, so you will need to [download](//www.eclipse.org/jetty/download.html) 
-that as well:
+Im folgenden Beispiel wird Jetty verwendet, diesen kann man hier 
+[downloaden](//www.eclipse.org/jetty/download.html).
+ 
 
 ```java
 import org.mortbay.jetty.Connector;


### PR DESCRIPTION
### Description
German translation for Remote WebDriver pages

### Motivation and Context
Missing german translation for the three remote WebDriver pages.

### Types of changes
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

