### PR TITLE
Fix typo (missing one letter)

### DIFF
--- a/docs_source_files/content/webdriver/web_element.en.md
+++ b/docs_source_files/content/webdriver/web_element.en.md
@@ -709,8 +709,8 @@ It is used to fetch the dimensions and coordinates
 of the referenced element.
 
 The fetched data body contain the following details:
-* X-axis position from the top-lef corner of the element
-* y-axis position from the top-lef corner of the element
+* X-axis position from the top-left corner of the element
+* y-axis position from the top-left corner of the element
 * Height of the element
 * Width of the element
 

--- a/docs_source_files/content/webdriver/web_element.es.md
+++ b/docs_source_files/content/webdriver/web_element.es.md
@@ -720,8 +720,8 @@ It is used to fetch the dimensions and coordinates
 of the referenced element.
 
 The fetched data body contain the following details:
-* X-axis position from the top-lef corner of the element
-* y-axis position from the top-lef corner of the element
+* X-axis position from the top-left corner of the element
+* y-axis position from the top-left corner of the element
 * Height of the element
 * Width of the element
 

--- a/docs_source_files/content/webdriver/web_element.fr.md
+++ b/docs_source_files/content/webdriver/web_element.fr.md
@@ -709,8 +709,8 @@ It is used to fetch the dimensions and coordinates
 of the referenced element. 
 
 The fetched data body contain the following details:
-* X-axis position from the top-lef corner of the element
-* y-axis position from the top-lef corner of the element
+* X-axis position from the top-left corner of the element
+* y-axis position from the top-left corner of the element
 * Height of the element
 * Width of the element
 

--- a/docs_source_files/content/webdriver/web_element.ja.md
+++ b/docs_source_files/content/webdriver/web_element.ja.md
@@ -707,8 +707,8 @@ It is used to fetch the dimensions and coordinates
 of the referenced element. 
 
 The fetched data body contain the following details:
-* X-axis position from the top-lef corner of the element
-* y-axis position from the top-lef corner of the element
+* X-axis position from the top-left corner of the element
+* y-axis position from the top-left corner of the element
 * Height of the element
 * Width of the element
 

--- a/docs_source_files/content/webdriver/web_element.ko.md
+++ b/docs_source_files/content/webdriver/web_element.ko.md
@@ -715,8 +715,8 @@ It is used to fetch the dimensions and coordinates
 of the referenced element. 
 
 The fetched data body contain the following details:
-* X-axis position from the top-lef corner of the element
-* y-axis position from the top-lef corner of the element
+* X-axis position from the top-left corner of the element
+* y-axis position from the top-left corner of the element
 * Height of the element
 * Width of the element
 

--- a/docs_source_files/content/webdriver/web_element.nl.md
+++ b/docs_source_files/content/webdriver/web_element.nl.md
@@ -715,8 +715,8 @@ It is used to fetch the dimensions and coordinates
 of the referenced element. 
 
 The fetched data body contain the following details:
-* X-axis position from the top-lef corner of the element
-* y-axis position from the top-lef corner of the element
+* X-axis position from the top-left corner of the element
+* y-axis position from the top-left corner of the element
 * Height of the element
 * Width of the element
 


### PR DESCRIPTION
### Description
missing one letter in the rect-section 
should be top-left (instead of top-lef)

### Motivation and Context
fix an typo for English and non-translated languages

### Types of changes
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.