### PR TITLE
Fixed small typo in driver_requirements: code-snipped "import ...firefox..."

### DIFF
--- a/docs_source_files/content/webdriver/driver_requirements.de.md
+++ b/docs_source_files/content/webdriver/driver_requirements.de.md
@@ -198,7 +198,7 @@ Selenium 2.
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.Firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 WebDriver driver = new FirefoxDriver();
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/driver_requirements.en.md
+++ b/docs_source_files/content/webdriver/driver_requirements.en.md
@@ -205,7 +205,7 @@ instantiate Firefox in the same way as Selenium 2:
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.Firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 WebDriver driver = new FirefoxDriver();
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/driver_requirements.es.md
+++ b/docs_source_files/content/webdriver/driver_requirements.es.md
@@ -209,7 +209,7 @@ Firefox de la misma forma en Selenium 2:
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.Firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 WebDriver driver = new FirefoxDriver();
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/driver_requirements.fr.md
+++ b/docs_source_files/content/webdriver/driver_requirements.fr.md
@@ -205,7 +205,7 @@ instancier Firefox de la même manière que Selenium 2:
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.Firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 WebDriver driver = new FirefoxDriver();
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/driver_requirements.ja.md
+++ b/docs_source_files/content/webdriver/driver_requirements.ja.md
@@ -174,7 +174,7 @@ Selenium 2と同じ方法でFirefoxをインスタンス化できます。
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.Firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 WebDriver driver = new FirefoxDriver();
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/driver_requirements.ko.md
+++ b/docs_source_files/content/webdriver/driver_requirements.ko.md
@@ -168,7 +168,7 @@ geckodriver은 Firefox를 시작하는 기본적인 방법이기 때문에 Selen
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.Firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 WebDriver driver = new FirefoxDriver();
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/driver_requirements.nl.md
+++ b/docs_source_files/content/webdriver/driver_requirements.nl.md
@@ -211,7 +211,7 @@ instantiate Firefox in the same way as Selenium 2:
 {{< code-tab >}}
   {{< code-panel language="java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.Firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 WebDriver driver = new FirefoxDriver();
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/driver_requirements.zh-cn.md
+++ b/docs_source_files/content/webdriver/driver_requirements.zh-cn.md
@@ -166,7 +166,7 @@ chromedriver 被实现为 WebDriver 远程服务器，该服务器通过公开 C
 {{<code-tab>}}
   {{<code-panel language="java">}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.Firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
 
 WebDriver driver = new FirefoxDriver();
   {{</ code-panel>}}


### PR DESCRIPTION
### Description
There was a small typo in the code snipped of the "Firefox" section of "driver_requirements.XX.md". Using the capital "F" in the import statement made the Java compiler not find the class "org.openqa.selenium.firefox.FirefoxDriver" and the build fails.
This pull-request changes the capital "F" to lowercase "f", so building the projects works again.

### Motivation and Context
Other selenium beginners, copiing the code example might also have trouble following the tutorial if this typo is not fixed.

### Types of changes
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example **fixed** (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.  -> my change is so small, that I am sure it won't break hugo. Setting up hugo just for this pull-request seems to be disproportional to me.

The commits were created using only the GitHub Website. I could not figure out how to put those 8 file changes in one commit. But as I have read, you will squash it anyway.