### PR TITLE
Remove static modifier for WebDriver

### DIFF
--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.en.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.en.md
@@ -69,7 +69,7 @@ import org.openqa.selenium.WebDriver;
  * Page Object encapsulates the Sign-in page.
  */
 public class SignInPage {
-  protected static WebDriver driver;
+  protected WebDriver driver;
 
   // <input name="user_name" type="text" value="">
   private By usernameBy = By.name("user_name");
@@ -108,7 +108,7 @@ import org.openqa.selenium.WebDriver;
  * Page Object encapsulates the Home Page
  */
 public class HomePage {
-  protected static WebDriver driver;
+  protected WebDriver driver;
 
   // <h1>Hello userName</h1>
   private By messageBy = By.tagName("h1");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Removed the `static` modifier for WebDriver in the code listings.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The WebDriver must not be `static` as it is later referenced with the `this` keyword (which would be a compile error). Static WebDriver can also pose problems with parallel executions.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
