### PR TITLE
Adding a "ChatRoom" ID on heading for this section

### DIFF
--- a/site_source_files/themes/selenium/layouts/support/section.html
+++ b/site_source_files/themes/selenium/layouts/support/section.html
@@ -26,7 +26,7 @@
 </div>
 
 <div class="section">
-    <h2>Chat Room and Slack</h2>
+    <h2 id="ChatRoom">Chat Room and Slack</h2>
     <p>
         The best place to ask for help is the user group (because they also keep the information accessible for others to read in the future).
         However, if you have a very important (or too simple) issue that needs a solution ASAP, you can always enter the IRC


### PR DESCRIPTION
### Description
Added an ID as a bookmark to facilitate anchor links to this part of the page.

### Motivation and Context
This would allow referencing this section with an anchor tag via a URL like this:
https://www.selenium.dev/support/#ChatRoom

Instead of being directed to the page, users would automatically be scrolled to the point on the page referring to the Chat Room.

This will just make it easier to be specific when directing people to that content on this page.

No screenshot should be required because this is not a visible change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
