### PR TITLE
[grid] Add new session queue contents endpoint and GraphQL commands

### DIFF
--- a/docs_source_files/content/grid/grid_4/graphql_support.de.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.de.md
@@ -46,6 +46,8 @@ The structure of grid schema is as follows:
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -143,4 +145,22 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.en.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.en.md
@@ -40,6 +40,8 @@ The structure of grid schema is as follows:
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -138,3 +140,22 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+

--- a/docs_source_files/content/grid/grid_4/graphql_support.es.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.es.md
@@ -46,6 +46,8 @@ The structure of grid schema is as follows:
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -143,4 +145,22 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.fr.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.fr.md
@@ -46,6 +46,8 @@ The structure of grid schema is as follows:
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -143,4 +145,22 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.ja.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.ja.md
@@ -41,6 +41,8 @@ GraphQL APIを呼び出すときは、スカラーのみを返すまでネスト
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -69,7 +71,6 @@ GraphQL APIを呼び出すときは、スカラーのみを返すまでネスト
     }
 }
 ```
-
 ## GraphQLで照会する
 
 GraphQLをクエリする最良の方法は、 `curl` リクエストを使用することです。 
@@ -139,4 +140,22 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.ko.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.ko.md
@@ -46,6 +46,8 @@ The structure of grid schema is as follows:
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -143,4 +145,22 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.nl.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.nl.md
@@ -46,6 +46,8 @@ The structure of grid schema is as follows:
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -143,4 +145,22 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.pt-br.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.pt-br.md
@@ -40,6 +40,8 @@ A estrutura do esquema de grade é a seguinte:
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -136,3 +138,21 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+``` 

--- a/docs_source_files/content/grid/grid_4/graphql_support.zh-cn.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.zh-cn.md
@@ -41,6 +41,8 @@ GraphQL 是一种用于API的查询语言, 也是用于使用现有数据完成�
         totalSlots,
         usedSlots,
         sessionCount,
+        sessionQueueSize,
+        sessionQueueRequests,
         nodes : [
             {
                 id,
@@ -138,4 +140,22 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nod
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the current requests in the New Session Queue:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue size :
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+```
+
+### Query for getting the New Session Queue info:
+
+```shell
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.de.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.de.md
@@ -155,4 +155,23 @@ In the fully distributed mode, the queuer URL is New Session Queuer server addre
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'
+```
+
 

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.en.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.en.md
@@ -148,3 +148,21 @@ In the fully distributed mode, the queuer URL is New Session Queuer server addre
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'
+```

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.es.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.es.md
@@ -155,3 +155,20 @@ In the fully distributed mode, the queuer URL is New Session Queuer server addre
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.fr.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.fr.md
@@ -155,3 +155,20 @@ In the fully distributed mode, the queuer URL is New Session Queuer server addre
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.ja.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.ja.md
@@ -155,3 +155,20 @@ In the fully distributed mode, the queuer URL is New Session Queuer server addre
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.ko.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.ko.md
@@ -155,3 +155,20 @@ In the fully distributed mode, the queuer URL is New Session Queuer server addre
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.nl.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.nl.md
@@ -155,3 +155,20 @@ In the fully distributed mode, the queuer URL is New Session Queuer server addre
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.pt-br.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.pt-br.md
@@ -147,3 +147,20 @@ No modo totalmente distribuído, a URL do enfileirador é o endereço do servido
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'

--- a/docs_source_files/content/grid/grid_4/grid_endpoints.zh-cn.md
+++ b/docs_source_files/content/grid/grid_4/grid_endpoints.zh-cn.md
@@ -155,3 +155,20 @@ In the fully distributed mode, the queuer URL is New Session Queuer server addre
 cURL --request DELETE 'http://localhost:5559/se/grid/newsessionqueuer/queue'
 ```
 
+### Get New Session Queue Requests
+
+New Session Request Queue holds the new session requests. 
+To get the current requests in the queue, use the cURL command enlisted below. 
+The response returns the total number of requests in the queue and the request payloads.
+
+In the Standalone mode, the queuer URL is the Standalone server address. 
+
+In the Hub-Node mode, the queuer URL is the Hub server address.
+
+```shell
+cURL --request GET 'http://localhost:4444/se/grid/newsessionqueuer/queue'
+```
+
+In the fully distributed mode, the queuer URL is New Session Queuer server address.
+```shell
+cURL --request GET 'http://localhost:5559/se/grid/newsessionqueuer/queue'


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Add new session queue contents endpoint and GraphQL commands

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A new endpoint was introduced in the Grid to retrieve the New Session Queue length and content. GraphQL support was added for the same. The changes add the endpoint and GraphQL commands to get the queue information.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [X] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->

New Session Request queue GraphQL commands 

![image](https://user-images.githubusercontent.com/10705590/105719084-eb4de700-5f47-11eb-8410-80ca903915b3.png)
