### PR TITLE
Fix broken edit links with correct github location

### DIFF
--- a/docs_source_files/config.toml
+++ b/docs_source_files/config.toml
@@ -21,8 +21,8 @@ enableGitInfo = true
 [params]
   # Change default color scheme with a variant one. Can be "red", "blue", "green".
   themeVariant = "selenium"
-  editURL = "https://github.com/SeleniumHQ/site/edit/dev/docs_source_files/content/"
-  ghrepo = "https://github.com/SeleniumHQ/site/"
+  editURL = "https://github.com/SeleniumHQ/seleniumhq.github.io/edit/dev/docs_source_files/content/"
+  ghrepo = "https://github.com/SeleniumHQ/seleniumhq.github.io/"
   description = "Documentation for Selenium"
   showVisitedLinks = true
   disableBreadcrumb = false


### PR DESCRIPTION
### Description
Edit Link is Broken

### Motivation and Context
Want people to be able to easily edit pages

### Types of changes
- [x] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
