### PR TITLE
Update GraphQL Queries with Latest Schema

### DIFF
--- a/docs_source_files/content/grid/grid_4/graphql_support.de.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.de.md
@@ -52,29 +52,8 @@ The structure of grid schema is as follows:
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: {
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -87,16 +66,43 @@ The structure of grid schema is as follows:
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.de.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.de.md
@@ -44,35 +44,59 @@ The structure of grid schema is as follows:
     grid: {
         uri,
         totalSlots,
-        usedSlots,
+        nodeCount,
+        maxSession,
         sessionCount,
-        sessionQueueSize,
+        version,
+        sessionQueueSize
+    }
+    sessionsInfo: {
         sessionQueueRequests,
-        nodes : [
-            {
+        sessions: {
+            id,
+            capabilities,
+            startTime,
+            uri,
+            nodeId,
+            nodeUri,
+            sessionDurationMillis
+            slot : {
                 id,
-                uri,
-                status,
-                maxSession,
-                sessions : [
-                       {
-                            id,
-                            capabilities,
-                            startTime,
-                            uri,
-                            nodeId,
-                            nodeUri,
-                            sessionDurationMillis
-                            slot : {
-                                id,
-                                stereotype,
-                                lastStarted
-                            }
-                        }
-                    ]
-               capabilities,
+                stereotype,
+                lastStarted
             }
-        ]
+        }
+    }
+    nodesInfo: {
+        nodes {
+            id,
+            uri,
+            status,
+            maxSession,
+            slotCount,
+            sessions: {
+                id,
+                capabilities,
+                startTime,
+                uri,
+                nodeId,
+                nodeUri,
+                sessionDurationMillis
+                slot : {
+                    id,
+                    stereotype,
+                    lastStarted
+                }
+            },
+            sessionCount,
+            stereotypes,
+            version,
+            osInfo: {
+                arch,
+                name,
+                version
+            }
+        }
     }
 }
 ```
@@ -83,10 +107,10 @@ The best way to query GraphQL is by using `curl` requests. GraphQL allows you to
 
 Some of the example GraphQL queries are given below. You can build your own queries as you like.
 
-### Querying the number of `totalSlots` and `usedSlots` in the grid :
+### Querying the number of `maxSession` and `sessionCount` in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { maxSession, sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://localhost:4444/graphql`
@@ -94,7 +118,7 @@ Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://loc
 ### Querying all details for session, node and the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { id, uri, status, sessions {id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot {id, stereotype, lastStarted } ,uri }, maxSession, capabilities }, uri, totalSlots, usedSlots , sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { uri, maxSession, sessionCount }, nodesInfo { nodes { id, uri, status, sessions { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } }, slotCount, sessionCount }} }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current session count in the Grid :
@@ -105,46 +129,44 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 
 ### Query for getting the max session count in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { maxSession } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { maxSession } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting all session details for all nodes in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query to get slot information for all sessions in each Node in the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, slot { id, stereotype, lastStarted } } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, slot { id, stereotype, lastStarted } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### Query to get session information for a given session: 
+### Query to get session information for a given session:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri , slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the capabilities of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { stereotypes } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the status of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the URI of each node and the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { uri } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current requests in the New Session Queue:

--- a/docs_source_files/content/grid/grid_4/graphql_support.en.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.en.md
@@ -38,35 +38,59 @@ The structure of grid schema is as follows:
     grid: {
         uri,
         totalSlots,
-        usedSlots,
+        nodeCount,
+        maxSession,
         sessionCount,
-        sessionQueueSize,
+        version,
+        sessionQueueSize
+    }
+    sessionsInfo: {
         sessionQueueRequests,
-        nodes : [
-            {
+        sessions: {
+            id,
+            capabilities,
+            startTime,
+            uri,
+            nodeId,
+            nodeUri,
+            sessionDurationMillis
+            slot : {
                 id,
-                uri,
-                status,
-                maxSession,
-                sessions : [
-                       {
-                            id,
-                            capabilities,
-                            startTime,
-                            uri,
-                            nodeId,
-                            nodeUri,
-                            sessionDurationMillis
-                            slot : {
-                                id,
-                                stereotype,
-                                lastStarted
-                            }
-                        }
-                    ]
-               capabilities,
+                stereotype,
+                lastStarted
             }
-        ]
+        }
+    }
+    nodesInfo: {
+        nodes {
+            id,
+            uri,
+            status,
+            maxSession,
+            slotCount,
+            sessions: {
+                id,
+                capabilities,
+                startTime,
+                uri,
+                nodeId,
+                nodeUri,
+                sessionDurationMillis
+                slot : {
+                    id,
+                    stereotype,
+                    lastStarted
+                }
+            },
+            sessionCount,
+            stereotypes,
+            version,
+            osInfo: {
+                arch,
+                name,
+                version
+            }
+        }
     }
 }
 ```
@@ -77,10 +101,10 @@ The best way to query GraphQL is by using `curl` requests. GraphQL allows you to
 
 Some of the example GraphQL queries are given below. You can build your own queries as you like.
 
-### Querying the number of `totalSlots` and `usedSlots` in the grid :
+### Querying the number of `maxSession` and `sessionCount` in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { maxSession, sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://localhost:4444/graphql`
@@ -88,7 +112,7 @@ Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://loc
 ### Querying all details for session, node and the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { id, uri, status, sessions {id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot {id, stereotype, lastStarted } ,uri }, maxSession, capabilities }, uri, totalSlots, usedSlots , sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { uri, maxSession, sessionCount }, nodesInfo { nodes { id, uri, status, sessions { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } }, slotCount, sessionCount }} }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current session count in the Grid :
@@ -99,46 +123,44 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 
 ### Query for getting the max session count in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { maxSession } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { maxSession } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting all session details for all nodes in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query to get slot information for all sessions in each Node in the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, slot { id, stereotype, lastStarted } } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, slot { id, stereotype, lastStarted } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### Query to get session information for a given session: 
+### Query to get session information for a given session:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri , slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the capabilities of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { stereotypes } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the status of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the URI of each node and the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { uri } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current requests in the New Session Queue:
@@ -158,4 +180,3 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
-

--- a/docs_source_files/content/grid/grid_4/graphql_support.en.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.en.md
@@ -46,29 +46,8 @@ The structure of grid schema is as follows:
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: {
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -81,16 +60,43 @@ The structure of grid schema is as follows:
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.es.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.es.md
@@ -52,29 +52,8 @@ The structure of grid schema is as follows:
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: {
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -87,16 +66,43 @@ The structure of grid schema is as follows:
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.es.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.es.md
@@ -44,35 +44,59 @@ The structure of grid schema is as follows:
     grid: {
         uri,
         totalSlots,
-        usedSlots,
+        nodeCount,
+        maxSession,
         sessionCount,
-        sessionQueueSize,
+        version,
+        sessionQueueSize
+    }
+    sessionsInfo: {
         sessionQueueRequests,
-        nodes : [
-            {
+        sessions: {
+            id,
+            capabilities,
+            startTime,
+            uri,
+            nodeId,
+            nodeUri,
+            sessionDurationMillis
+            slot : {
                 id,
-                uri,
-                status,
-                maxSession,
-                sessions : [
-                       {
-                            id,
-                            capabilities,
-                            startTime,
-                            uri,
-                            nodeId,
-                            nodeUri,
-                            sessionDurationMillis
-                            slot : {
-                                id,
-                                stereotype,
-                                lastStarted
-                            }
-                        }
-                    ]
-               capabilities,
+                stereotype,
+                lastStarted
             }
-        ]
+        }
+    }
+    nodesInfo: {
+        nodes {
+            id,
+            uri,
+            status,
+            maxSession,
+            slotCount,
+            sessions: {
+                id,
+                capabilities,
+                startTime,
+                uri,
+                nodeId,
+                nodeUri,
+                sessionDurationMillis
+                slot : {
+                    id,
+                    stereotype,
+                    lastStarted
+                }
+            },
+            sessionCount,
+            stereotypes,
+            version,
+            osInfo: {
+                arch,
+                name,
+                version
+            }
+        }
     }
 }
 ```
@@ -83,10 +107,10 @@ The best way to query GraphQL is by using `curl` requests. GraphQL allows you to
 
 Some of the example GraphQL queries are given below. You can build your own queries as you like.
 
-### Querying the number of `totalSlots` and `usedSlots` in the grid :
+### Querying the number of `maxSession` and `sessionCount` in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { maxSession, sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://localhost:4444/graphql`
@@ -94,7 +118,7 @@ Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://loc
 ### Querying all details for session, node and the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { id, uri, status, sessions {id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot {id, stereotype, lastStarted } ,uri }, maxSession, capabilities }, uri, totalSlots, usedSlots , sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { uri, maxSession, sessionCount }, nodesInfo { nodes { id, uri, status, sessions { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } }, slotCount, sessionCount }} }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current session count in the Grid :
@@ -105,46 +129,44 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 
 ### Query for getting the max session count in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { maxSession } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { maxSession } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting all session details for all nodes in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query to get slot information for all sessions in each Node in the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, slot { id, stereotype, lastStarted } } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, slot { id, stereotype, lastStarted } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### Query to get session information for a given session: 
+### Query to get session information for a given session:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri , slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the capabilities of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { stereotypes } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the status of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the URI of each node and the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { uri } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current requests in the New Session Queue:

--- a/docs_source_files/content/grid/grid_4/graphql_support.fr.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.fr.md
@@ -52,29 +52,8 @@ The structure of grid schema is as follows:
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: {
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -87,16 +66,43 @@ The structure of grid schema is as follows:
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.fr.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.fr.md
@@ -44,35 +44,59 @@ The structure of grid schema is as follows:
     grid: {
         uri,
         totalSlots,
-        usedSlots,
+        nodeCount,
+        maxSession,
         sessionCount,
-        sessionQueueSize,
+        version,
+        sessionQueueSize
+    }
+    sessionsInfo: {
         sessionQueueRequests,
-        nodes : [
-            {
+        sessions: {
+            id,
+            capabilities,
+            startTime,
+            uri,
+            nodeId,
+            nodeUri,
+            sessionDurationMillis
+            slot : {
                 id,
-                uri,
-                status,
-                maxSession,
-                sessions : [
-                       {
-                            id,
-                            capabilities,
-                            startTime,
-                            uri,
-                            nodeId,
-                            nodeUri,
-                            sessionDurationMillis
-                            slot : {
-                                id,
-                                stereotype,
-                                lastStarted
-                            }
-                        }
-                    ]
-               capabilities,
+                stereotype,
+                lastStarted
             }
-        ]
+        }
+    }
+    nodesInfo: {
+        nodes {
+            id,
+            uri,
+            status,
+            maxSession,
+            slotCount,
+            sessions: {
+                id,
+                capabilities,
+                startTime,
+                uri,
+                nodeId,
+                nodeUri,
+                sessionDurationMillis
+                slot : {
+                    id,
+                    stereotype,
+                    lastStarted
+                }
+            },
+            sessionCount,
+            stereotypes,
+            version,
+            osInfo: {
+                arch,
+                name,
+                version
+            }
+        }
     }
 }
 ```
@@ -83,10 +107,10 @@ The best way to query GraphQL is by using `curl` requests. GraphQL allows you to
 
 Some of the example GraphQL queries are given below. You can build your own queries as you like.
 
-### Querying the number of `totalSlots` and `usedSlots` in the grid :
+### Querying the number of `maxSession` and `sessionCount` in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { maxSession, sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://localhost:4444/graphql`
@@ -94,7 +118,7 @@ Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://loc
 ### Querying all details for session, node and the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { id, uri, status, sessions {id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot {id, stereotype, lastStarted } ,uri }, maxSession, capabilities }, uri, totalSlots, usedSlots , sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { uri, maxSession, sessionCount }, nodesInfo { nodes { id, uri, status, sessions { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } }, slotCount, sessionCount }} }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current session count in the Grid :
@@ -105,46 +129,44 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 
 ### Query for getting the max session count in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { maxSession } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { maxSession } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting all session details for all nodes in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query to get slot information for all sessions in each Node in the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, slot { id, stereotype, lastStarted } } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, slot { id, stereotype, lastStarted } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### Query to get session information for a given session: 
+### Query to get session information for a given session:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri , slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the capabilities of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { stereotypes } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the status of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the URI of each node and the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { uri } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current requests in the New Session Queue:

--- a/docs_source_files/content/grid/grid_4/graphql_support.ja.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.ja.md
@@ -47,29 +47,8 @@ GraphQL APIを呼び出すときは、スカラーのみを返すまでネスト
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: { 
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -82,16 +61,43 @@ GraphQL APIを呼び出すときは、スカラーのみを返すまでネスト
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.ko.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.ko.md
@@ -52,29 +52,8 @@ The structure of grid schema is as follows:
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: {
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -87,16 +66,43 @@ The structure of grid schema is as follows:
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.ko.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.ko.md
@@ -44,35 +44,59 @@ The structure of grid schema is as follows:
     grid: {
         uri,
         totalSlots,
-        usedSlots,
+        nodeCount,
+        maxSession,
         sessionCount,
-        sessionQueueSize,
+        version,
+        sessionQueueSize
+    }
+    sessionsInfo: {
         sessionQueueRequests,
-        nodes : [
-            {
+        sessions: {
+            id,
+            capabilities,
+            startTime,
+            uri,
+            nodeId,
+            nodeUri,
+            sessionDurationMillis
+            slot : {
                 id,
-                uri,
-                status,
-                maxSession,
-                sessions : [
-                       {
-                            id,
-                            capabilities,
-                            startTime,
-                            uri,
-                            nodeId,
-                            nodeUri,
-                            sessionDurationMillis
-                            slot : {
-                                id,
-                                stereotype,
-                                lastStarted
-                            }
-                        }
-                    ]
-               capabilities,
+                stereotype,
+                lastStarted
             }
-        ]
+        }
+    }
+    nodesInfo: {
+        nodes {
+            id,
+            uri,
+            status,
+            maxSession,
+            slotCount,
+            sessions: {
+                id,
+                capabilities,
+                startTime,
+                uri,
+                nodeId,
+                nodeUri,
+                sessionDurationMillis
+                slot : {
+                    id,
+                    stereotype,
+                    lastStarted
+                }
+            },
+            sessionCount,
+            stereotypes,
+            version,
+            osInfo: {
+                arch,
+                name,
+                version
+            }
+        }
     }
 }
 ```
@@ -83,10 +107,10 @@ The best way to query GraphQL is by using `curl` requests. GraphQL allows you to
 
 Some of the example GraphQL queries are given below. You can build your own queries as you like.
 
-### Querying the number of `totalSlots` and `usedSlots` in the grid :
+### Querying the number of `maxSession` and `sessionCount` in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { maxSession, sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://localhost:4444/graphql`
@@ -94,7 +118,7 @@ Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://loc
 ### Querying all details for session, node and the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { id, uri, status, sessions {id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot {id, stereotype, lastStarted } ,uri }, maxSession, capabilities }, uri, totalSlots, usedSlots , sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { uri, maxSession, sessionCount }, nodesInfo { nodes { id, uri, status, sessions { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } }, slotCount, sessionCount }} }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current session count in the Grid :
@@ -105,46 +129,44 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 
 ### Query for getting the max session count in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { maxSession } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { maxSession } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting all session details for all nodes in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query to get slot information for all sessions in each Node in the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, slot { id, stereotype, lastStarted } } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, slot { id, stereotype, lastStarted } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### Query to get session information for a given session: 
+### Query to get session information for a given session:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri , slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the capabilities of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { stereotypes } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the status of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the URI of each node and the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { uri } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current requests in the New Session Queue:

--- a/docs_source_files/content/grid/grid_4/graphql_support.nl.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.nl.md
@@ -52,29 +52,8 @@ The structure of grid schema is as follows:
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: {
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -87,16 +66,43 @@ The structure of grid schema is as follows:
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.nl.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.nl.md
@@ -44,35 +44,59 @@ The structure of grid schema is as follows:
     grid: {
         uri,
         totalSlots,
-        usedSlots,
+        nodeCount,
+        maxSession,
         sessionCount,
-        sessionQueueSize,
+        version,
+        sessionQueueSize
+    }
+    sessionsInfo: {
         sessionQueueRequests,
-        nodes : [
-            {
+        sessions: {
+            id,
+            capabilities,
+            startTime,
+            uri,
+            nodeId,
+            nodeUri,
+            sessionDurationMillis
+            slot : {
                 id,
-                uri,
-                status,
-                maxSession,
-                sessions : [
-                       {
-                            id,
-                            capabilities,
-                            startTime,
-                            uri,
-                            nodeId,
-                            nodeUri,
-                            sessionDurationMillis
-                            slot : {
-                                id,
-                                stereotype,
-                                lastStarted
-                            }
-                        }
-                    ]
-               capabilities,
+                stereotype,
+                lastStarted
             }
-        ]
+        }
+    }
+    nodesInfo: {
+        nodes {
+            id,
+            uri,
+            status,
+            maxSession,
+            slotCount,
+            sessions: {
+                id,
+                capabilities,
+                startTime,
+                uri,
+                nodeId,
+                nodeUri,
+                sessionDurationMillis
+                slot : {
+                    id,
+                    stereotype,
+                    lastStarted
+                }
+            },
+            sessionCount,
+            stereotypes,
+            version,
+            osInfo: {
+                arch,
+                name,
+                version
+            }
+        }
     }
 }
 ```
@@ -83,10 +107,10 @@ The best way to query GraphQL is by using `curl` requests. GraphQL allows you to
 
 Some of the example GraphQL queries are given below. You can build your own queries as you like.
 
-### Querying the number of `totalSlots` and `usedSlots` in the grid :
+### Querying the number of `maxSession` and `sessionCount` in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { maxSession, sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://localhost:4444/graphql`
@@ -94,7 +118,7 @@ Generally on local machine the `<LINK_TO_GRAPHQL_ENDPOINT>` would be `http://loc
 ### Querying all details for session, node and the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { id, uri, status, sessions {id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot {id, stereotype, lastStarted } ,uri }, maxSession, capabilities }, uri, totalSlots, usedSlots , sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { uri, maxSession, sessionCount }, nodesInfo { nodes { id, uri, status, sessions { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } }, slotCount, sessionCount }} }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current session count in the Grid :
@@ -105,46 +129,44 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 
 ### Query for getting the max session count in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { maxSession } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { maxSession } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting all session details for all nodes in the Grid :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query to get slot information for all sessions in each Node in the Grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, slot { id, stereotype, lastStarted } } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, slot { id, stereotype, lastStarted } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### Query to get session information for a given session: 
+### Query to get session information for a given session:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri , slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the capabilities of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { stereotypes } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the status of each node in the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Querying the URI of each node and the grid :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { uri } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current requests in the New Session Queue:

--- a/docs_source_files/content/grid/grid_4/graphql_support.pt-br.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.pt-br.md
@@ -46,29 +46,8 @@ A estrutura do esquema de grade é a seguinte:
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: {
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -81,16 +60,43 @@ A estrutura do esquema de grade é a seguinte:
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```

--- a/docs_source_files/content/grid/grid_4/graphql_support.pt-br.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.pt-br.md
@@ -38,35 +38,59 @@ A estrutura do esquema de grade é a seguinte:
     grid: {
         uri,
         totalSlots,
-        usedSlots,
+        nodeCount,
+        maxSession,
         sessionCount,
-        sessionQueueSize,
+        version,
+        sessionQueueSize
+    }
+    sessionsInfo: {
         sessionQueueRequests,
-        nodes : [
-            {
+        sessions: {
+            id,
+            capabilities,
+            startTime,
+            uri,
+            nodeId,
+            nodeUri,
+            sessionDurationMillis
+            slot : {
                 id,
-                uri,
-                status,
-                maxSession,
-                sessions : [
-                       {
-                            id,
-                            capabilities,
-                            startTime,
-                            uri,
-                            nodeId,
-                            nodeUri,
-                            sessionDurationMillis
-                            slot : {
-                                id,
-                                stereotype,
-                                lastStarted
-                            }
-                        }
-                    ]
-               capabilities,
+                stereotype,
+                lastStarted
             }
-        ]
+        }
+    }
+    nodesInfo: {
+        nodes {
+            id,
+            uri,
+            status,
+            maxSession,
+            slotCount,
+            sessions: {
+                id,
+                capabilities,
+                startTime,
+                uri,
+                nodeId,
+                nodeUri,
+                sessionDurationMillis
+                slot : {
+                    id,
+                    stereotype,
+                    lastStarted
+                }
+            },
+            sessionCount,
+            stereotypes,
+            version,
+            osInfo: {
+                arch,
+                name,
+                version
+            }
+        }
     }
 }
 ```
@@ -77,10 +101,10 @@ O melhor jeito de consultar GraphQL é utilizando requisições `curl`. GraphQL 
 
 Alguns exemplos de buscas em GraphQL estão abaixo. Você pode montar as queries como quiser.
 
-### Buscando o número total de slots (`totalSlots`) e slots usados (`usedSlots`) na Grid:
+### Buscando o número total de slots (`maxSession`) e slots usados (`sessionCount`) na Grid:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { maxSession, sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 Geralmente na máquina local o `<LINK_TO_GRAPHQL_ENDPOINT>` será `http://localhost:4444/graphql`
@@ -88,7 +112,7 @@ Geralmente na máquina local o `<LINK_TO_GRAPHQL_ENDPOINT>` será `http://localh
 ### Buscando todos os detalhes da Sessão, Nó e Grid:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { id, uri, status, sessions {id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot {id, stereotype, lastStarted } ,uri }, maxSession, capabilities }, uri, totalSlots, usedSlots , sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { uri, maxSession, sessionCount }, nodesInfo { nodes { id, uri, status, sessions { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } }, slotCount, sessionCount }} }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Buscando o número de sessões atual na Grid:
@@ -100,43 +124,43 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 ### Buscando a contagem máxima de sessões na Grid:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { maxSession } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { maxSession } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Buscando todos os detalhes de todas as sessões de todos os nós na Grid:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Buscando informações dos slots de todas as sessões de cada Nó na Grid:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, slot { id, stereotype, lastStarted } } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, slot { id, stereotype, lastStarted } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Buscando informação da sessão para uma sessão específica:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri , slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Buscando os recursos de cada nó na Grid:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { stereotypes } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Buscando o status de cada Nó na Grid:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Buscando a URI de cada Nó e da Grid:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { uri } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current requests in the New Session Queue:
@@ -155,4 +179,4 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sessionQueueSize, sessionQueueRequests } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
-``` 
+```

--- a/docs_source_files/content/grid/grid_4/graphql_support.zh-cn.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.zh-cn.md
@@ -2,9 +2,9 @@
 title: "GraphQL查询支持"
 weight: 4
 ---
- 
 
-GraphQL 是一种用于API的查询语言, 也是用于使用现有数据完成这些查询的运行时. 其仅仅是使用户能够准确地获取所需. 
+
+GraphQL 是一种用于API的查询语言, 也是用于使用现有数据完成这些查询的运行时. 其仅仅是使用户能够准确地获取所需.
 
 ## 枚举
 枚举是表示字段的可能值的集合.
@@ -39,49 +39,73 @@ GraphQL 是一种用于API的查询语言, 也是用于使用现有数据完成�
     grid: {
         uri,
         totalSlots,
-        usedSlots,
+        nodeCount,
+        maxSession,
         sessionCount,
-        sessionQueueSize,
+        version,
+        sessionQueueSize
+    }
+    sessionsInfo: {
         sessionQueueRequests,
-        nodes : [
-            {
+        sessions: {
+            id,
+            capabilities,
+            startTime,
+            uri,
+            nodeId,
+            nodeUri,
+            sessionDurationMillis
+            slot : {
                 id,
-                uri,
-                status,
-                maxSession,
-                sessions : [
-                       {
-                            id,
-                            capabilities,
-                            startTime,
-                            uri,
-                            nodeId,
-                            nodeUri,
-                            sessionDurationMillis
-                            slot : {
-                                id,
-                                stereotype,
-                                lastStarted
-                            }
-                        }
-                    ]
-               capabilities,
+                stereotype,
+                lastStarted
             }
-        ]
+        }
+    }
+    nodesInfo: {
+        nodes {
+            id,
+            uri,
+            status,
+            maxSession,
+            slotCount,
+            sessions: {
+                id,
+                capabilities,
+                startTime,
+                uri,
+                nodeId,
+                nodeUri,
+                sessionDurationMillis
+                slot : {
+                    id,
+                    stereotype,
+                    lastStarted
+                }
+            },
+            sessionCount,
+            stereotypes,
+            version,
+            osInfo: {
+                arch,
+                name,
+                version
+            }
+        }
     }
 }
 ```
 
 ## 查询 GraphQL
 
-查询GraphQL的最佳方法是使用`curl`请求. GraphQL允许您仅获取所需的数据, 仅此而已. 
+查询GraphQL的最佳方法是使用`curl`请求. GraphQL允许您仅获取所需的数据, 仅此而已.
 
-下面给出了一些GraphQL查询的示例. 您可以根据需要构建自己的查询. 
+下面给出了一些GraphQL查询的示例. 您可以根据需要构建自己的查询.
 
-### 查询网格中 `totalSlots` 和 `usedSlots` 的数量:
+### 查询网格中 `maxSession` 和 `sessionCount` 的数量:
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { totalSlots, usedSlots } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { maxSession, sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 通常在本地机器上 `<LINK_TO_GRAPHQL_ENDPOINT>` 会是 `http://localhost:4444/graphql`
@@ -89,7 +113,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { tot
 ### 查询全部会话、及节点以及网格的详情 :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { id, uri, status, sessions {id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot {id, stereotype, lastStarted } ,uri }, maxSession, capabilities }, uri, totalSlots, usedSlots , sessionCount } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { uri, maxSession, sessionCount }, nodesInfo { nodes { id, uri, status, sessions { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } }, slotCount, sessionCount }} }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### 查询以获取当前网格的会话总数 :
@@ -100,46 +124,44 @@ curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { sess
 
 ### 查询以获取网格中的最大会话数量 :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { maxSession } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { maxSession } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### 查询以获取网格中所有节点的全部会话详情 :
 
-
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, capabilities, startTime, uri, nodeId, nodeId, sessionDurationMillis } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### 查询以获取网格中每个节点中所有会话的插槽信息 :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ grid { nodes { sessions { id, slot { id, stereotype, lastStarted } } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ sessionsInfo { sessions { id, slot { id, stereotype, lastStarted } } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
-### 查询以获取给定会话的会话信息查询以获取给定会话的会话信息 : 
+### 查询以获取给定会话的会话信息查询以获取给定会话的会话信息 :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri , slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query":"{ session (id: "<session-id>") { id, capabilities, startTime, uri, nodeId, nodeUri, sessionDurationMillis, slot { id, stereotype, lastStarted } } } "}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### 查询网格中每个节点的功能 :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { capabilities } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { stereotypes } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### 查询网格中每个节点的状态 :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { status } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### 查询每个节点和网格的 URI :
 
 ```shell
-curl -X POST -H "Content-Type: application/json" --data '{"query": "{ grid { nodes { uri }, uri } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
+curl -X POST -H "Content-Type: application/json" --data '{"query": "{ nodesInfo { nodes { uri } } }"}' -s <LINK_TO_GRAPHQL_ENDPOINT>
 ```
 
 ### Query for getting the current requests in the New Session Queue:

--- a/docs_source_files/content/grid/grid_4/graphql_support.zh-cn.md
+++ b/docs_source_files/content/grid/grid_4/graphql_support.zh-cn.md
@@ -47,29 +47,8 @@ GraphQL 是一种用于API的查询语言, 也是用于使用现有数据完成�
     }
     sessionsInfo: {
         sessionQueueRequests,
-        sessions: {
-            id,
-            capabilities,
-            startTime,
-            uri,
-            nodeId,
-            nodeUri,
-            sessionDurationMillis
-            slot : {
-                id,
-                stereotype,
-                lastStarted
-            }
-        }
-    }
-    nodesInfo: {
-        nodes {
-            id,
-            uri,
-            status,
-            maxSession,
-            slotCount,
-            sessions: {
+        sessions: [
+            {
                 id,
                 capabilities,
                 startTime,
@@ -82,16 +61,43 @@ GraphQL 是一种用于API的查询语言, 也是用于使用现有数据完成�
                     stereotype,
                     lastStarted
                 }
-            },
-            sessionCount,
-            stereotypes,
-            version,
-            osInfo: {
-                arch,
-                name,
-                version
             }
-        }
+        ]
+    }
+    nodesInfo: {
+        nodes : [
+            {
+                id,
+                uri,
+                status,
+                maxSession,
+                slotCount,
+                sessions: [
+                    {
+                        id,
+                        capabilities,
+                        startTime,
+                        uri,
+                        nodeId,
+                        nodeUri,
+                        sessionDurationMillis
+                        slot : {
+                            id,
+                            stereotype,
+                            lastStarted
+                        }
+                    }
+                ],
+                sessionCount,
+                stereotypes,
+                version,
+                osInfo: {
+                    arch,
+                    name,
+                    version
+                }
+            }
+        ]
     }
 }
 ```


### PR DESCRIPTION
### Description
The GraphQL field usedSlots [was removed in this commit](https://github.com/SeleniumHQ/selenium/commit/6eecd00e79893b2abd57a264690241350c178be1#diff-e84380fdf4b55b3beeb746f4392cafa557d1d1b22e1ef30ee0f0a6675b17d067), so this updates the example to use maxSession (replacing totalSlots) and sessionCount (replacing usedSlots).

It also updates other various examples to the latest schema.

Two things to note:
- I don't understand why `totalSlots` is still in the schema. Is there a difference between `maxSession` and `totalSlots` that I should be aware of?
- I couldn't get the example "Query to get session information for a given session" to work. I think I'm having syntax errors with passing the argument session id

### Motivation and Context
The examples no longer worked.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
