### PR TITLE
Add Ruby sample code for chrome devtools

### DIFF
--- a/docs_source_files/content/support_packages/chrome_devtools.de.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.de.md
@@ -87,9 +87,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.de.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.de.md
@@ -81,7 +81,20 @@ namespace dotnet_test {
 }
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  

--- a/docs_source_files/content/support_packages/chrome_devtools.en.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.en.md
@@ -81,9 +81,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.en.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.en.md
@@ -75,7 +75,20 @@ namespace dotnet_test {
 }
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  

--- a/docs_source_files/content/support_packages/chrome_devtools.es.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.es.md
@@ -87,9 +87,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.es.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.es.md
@@ -81,7 +81,20 @@ namespace dotnet_test {
 }
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  

--- a/docs_source_files/content/support_packages/chrome_devtools.fr.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.fr.md
@@ -81,7 +81,20 @@ namespace dotnet_test {
 }  
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  

--- a/docs_source_files/content/support_packages/chrome_devtools.fr.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.fr.md
@@ -87,9 +87,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -91,9 +91,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -85,7 +85,20 @@ namespace dotnet_test {
 }
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  

--- a/docs_source_files/content/support_packages/chrome_devtools.ko.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ko.md
@@ -81,7 +81,20 @@ namespace dotnet_test {
 }  
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  

--- a/docs_source_files/content/support_packages/chrome_devtools.ko.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ko.md
@@ -87,9 +87,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.nl.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.nl.md
@@ -87,9 +87,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.nl.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.nl.md
@@ -81,7 +81,20 @@ namespace dotnet_test {
 }
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  

--- a/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
@@ -81,9 +81,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
@@ -75,7 +75,20 @@ namespace dotnet_test {
 }
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  

--- a/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
@@ -81,9 +81,9 @@ driver = Selenium::WebDriver.for :chrome
 
 begin
   # Latitude and longitude of Tokyo, Japan
-  coordinates = { 'latitude': 35.689487,
-                  'longitude': 139.691706,
-                  'accuracy': 100 }
+  coordinates = { latitude: 35.689487,
+                  longitude: 139.691706,
+                  accuracy: 100 }
   driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
   driver.get 'https://www.google.com/search?q=selenium'
 ensure

--- a/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
@@ -75,7 +75,20 @@ namespace dotnet_test {
 }
   {{< / code-panel >}}
   {{< code-panel language="ruby" >}}
-# Please raise a PR to add code sample
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+begin
+  # Latitude and longitude of Tokyo, Japan
+  coordinates = { 'latitude': 35.689487,
+                  'longitude': 139.691706,
+                  'accuracy': 100 }
+  driver.execute_cdp('Emulation.setGeolocationOverride', coordinates)
+  driver.get 'https://www.google.com/search?q=selenium'
+ensure
+  driver.quit
+end
   {{< / code-panel >}}
   {{< code-panel language="javascript" >}}
 // Please raise a PR to add code sample  


### PR DESCRIPTION
Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


### Description
Add Ruby sample code for chrome devtools.
The change has been applied to all translation files.
It has been verified that the added code works.

### Motivation and Context
I think it will be very useful for those who will learn from now on to put the sample code on this page.
This time, I added the code of Ruby, which is the programming I use every day.
I hope my activities are useful.

### Types of changes
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

The screenshot I checked using hugo are attached below. 
![screenshot](https://user-images.githubusercontent.com/821981/110798741-cf1ac500-82bd-11eb-99bf-e201a16ffe6d.png)
