### PR TITLE
[chrome_devtools] add Basic Auth example in Java

### DIFF
--- a/docs_source_files/content/support_packages/chrome_devtools.de.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.de.md
@@ -125,8 +125,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.de.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.de.md
@@ -125,6 +125,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.de.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.de.md
@@ -123,7 +123,10 @@ With Selenium and devtools integration, you can automate the input of basic auth
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.en.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.en.md
@@ -118,6 +118,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.en.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.en.md
@@ -118,8 +118,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.en.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.en.md
@@ -116,7 +116,10 @@ With Selenium and devtools integration, you can automate the input of basic auth
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.es.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.es.md
@@ -122,7 +122,10 @@ With Selenium and devtools integration, you can automate the input of basic auth
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.es.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.es.md
@@ -124,6 +124,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.es.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.es.md
@@ -124,8 +124,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.fr.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.fr.md
@@ -122,7 +122,10 @@ With Selenium and devtools integration, you can automate the input of basic auth
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.fr.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.fr.md
@@ -124,6 +124,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.fr.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.fr.md
@@ -124,8 +124,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -128,6 +128,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -128,8 +128,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -126,7 +126,10 @@ With Selenium and devtools integration, you can automate the input of basic auth
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.ko.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ko.md
@@ -122,7 +122,10 @@ With Selenium and devtools integration, you can automate the input of basic auth
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.ko.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ko.md
@@ -124,6 +124,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.ko.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ko.md
@@ -124,8 +124,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.nl.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.nl.md
@@ -122,7 +122,10 @@ With Selenium and devtools integration, you can automate the input of basic auth
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.nl.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.nl.md
@@ -124,6 +124,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.nl.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.nl.md
@@ -124,8 +124,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
@@ -118,6 +118,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
@@ -118,8 +118,7 @@ With Selenium and devtools integration, you can automate the input of basic auth
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
@@ -116,7 +116,10 @@ With Selenium and devtools integration, you can automate the input of basic auth
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
@@ -121,6 +121,7 @@ fun main() {
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
+ChromiumDriver driver = new ChromeDriver();
 driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
@@ -119,7 +119,10 @@ fun main() {
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
+
+driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample

--- a/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
@@ -121,8 +121,7 @@ fun main() {
   {{< code-panel language="java" >}}
 Predicate<URI> uriPredicate = uri -> uri.getHost().contains("your-domain.com");
 
-ChromiumDriver driver = new ChromeDriver();
-driver.register(uriPredicate, UsernameAndPassword.of("admin", "password"));
+((HasAuthentication) driver).register(uriPredicate, UsernameAndPassword.of("admin", "password"));
 driver.get("https://your-domain.com/login");
   {{< / code-panel >}}
   {{< code-panel language="python" >}}


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Added Java example of using Basic Auth via chrome dev tools

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
