### PR TITLE
Event Bus is the first component that should be started.

### DIFF
--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.de.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.de.md
@@ -59,13 +59,13 @@ whereas this would not be possible on Linux or Mac.
 The Session Map is a data store that keeps the information of the session id and the Node 
 where the session is running. It serves as a support for the Router in the process of 
 forwarding a request to the Node. The Router will ask the Session Map for the Node 
-associated to a session id. When starting the Grid in its fully distributed mode, the
-Session Map is the first component that should be started.
+associated to a session id.
 
 ## Event Bus
 
 The Event Bus serves as a communication path between the Nodes, Distributor, and Session Map. 
-The Grid does most of its internal communication through messages, avoiding expensive HTTP calls.
+The Grid does most of its internal communication through messages, avoiding expensive HTTP calls. 
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Roles in Grid
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.en.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.en.md
@@ -56,8 +56,7 @@ whereas this would not be possible on Linux or Mac.
 The Session Map is a data store that keeps the information of the session id and the Node 
 where the session is running. It serves as a support for the Router in the process of 
 forwarding a request to the Node. The Router will ask the Session Map for the Node 
-associated to a session id. When starting the Grid in its fully distributed mode, the
-Session Map is the first component that should be started.
+associated to a session id.
 
 ## New Session Queuer, New Session Queue
 
@@ -89,7 +88,8 @@ receives the event.
 ## Event Bus
 
 The Event Bus serves as a communication path between the Nodes, Distributor, New Session Queuer, and Session Map. 
-The Grid does most of its internal communication through messages, avoiding expensive HTTP calls.
+The Grid does most of its internal communication through messages, avoiding expensive HTTP calls. 
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Roles in Grid
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.es.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.es.md
@@ -59,13 +59,13 @@ whereas this would not be possible on Linux or Mac.
 The Session Map is a data store that keeps the information of the session id and the Node 
 where the session is running. It serves as a support for the Router in the process of 
 forwarding a request to the Node. The Router will ask the Session Map for the Node 
-associated to a session id. When starting the Grid in its fully distributed mode, the
-Session Map is the first component that should be started.
+associated to a session id.
 
 ## Event Bus
 
 The Event Bus serves as a communication path between the Nodes, Distributor, and Session Map. 
-The Grid does most of its internal communication through messages, avoiding expensive HTTP calls.
+The Grid does most of its internal communication through messages, avoiding expensive HTTP calls. 
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Roles in Grid
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.fr.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.fr.md
@@ -59,13 +59,13 @@ whereas this would not be possible on Linux or Mac.
 The Session Map is a data store that keeps the information of the session id and the Node 
 where the session is running. It serves as a support for the Router in the process of 
 forwarding a request to the Node. The Router will ask the Session Map for the Node 
-associated to a session id. When starting the Grid in its fully distributed mode, the
-Session Map is the first component that should be started.
+associated to a session id.
 
 ## Event Bus
 
 The Event Bus serves as a communication path between the Nodes, Distributor, and Session Map. 
 The Grid does most of its internal communication through messages, avoiding expensive HTTP calls.
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Roles in Grid
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.ja.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.ja.md
@@ -4,7 +4,7 @@ weight: 1
 ---
 
 {{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
+<i class="fas fa-language"></i> There are certain paragaraphs needs translation from 
 English to Japanese. Do you speak Japanese? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
@@ -52,17 +52,45 @@ SafariおよびInternet Explorerの場合、作成されるスロットは1つ�
 たとえば、WindowsノードにはInternet Explorerをブラウザーオプションとして提供する機能がありますが、
 これはLinuxまたはMacでは不可能です。
 
-## セッションマップ
+## Session Map
 
-セッションマップは、セッションIDとセッションが実行されているノードの情報を保持するデータストアです。 
-これは、リクエストをノードに転送するプロセスにおけるルーターのサポートとして機能します。 
-ルーターは、セッションIDに関連付けられたノードをセッションマップに要求します。 
-完全分散モードでGridを開始する場合、セッションマップは、開始する必要がある最初のコンポーネントです。
+The Session Map is a data store that keeps the information of the session id and the Node 
+where the session is running. It serves as a support for the Router in the process of 
+forwarding a request to the Node. The Router will ask the Session Map for the Node 
+associated to a session id.
 
-## イベントバス
+## New Session Queuer, New Session Queue
 
-イベントバスは、ノード、ディストリビュータ、およびセッションマップ間の通信パスとして機能します。 
-Gridは、メッセージを介して内部通信の大部分を行い、高価なHTTP呼び出しを回避します。
+The New Session Queuer is the only
+component which can communicate with the New Session Queue. It handles all queue operations like
+add to manipulate the queue. It has configurable parameters for setting 
+the request timeout and request retry interval.
+
+The New Session Queuer receives the new session request from the Router and adds it to the queue. 
+The queuer waits until it receives the response for the request. 
+If the request times out, the request is rejected immediately and not added to the queue. 
+
+Upon successfully adding the request to the queue, Event Bus triggers an event. 
+The Distributor picks up this event and polls the queue. It now attempts to create a session.
+
+If the requested capabilities do not exist in any of the registered Nodes, then the request is rejected
+immediately and the client receives a response.
+
+If the requested capabilities match the capabilities of any of Node slots, Distributor attempts to get the
+available slot. If all the slots are busy, the Distributor will ask the queuer to add the request 
+to the front of the queue. The Distributor receives the request again after the request retry interval. 
+It will attempt retries until the request is successful or has timed out. 
+If request times out while retrying or adding to the front of the queue its rejected.
+
+After getting an available slot and session creation, the Distributor passes the new session response 
+to the New Session Queuer via the Event Bus. The New Session Queuer will respond to the client when it
+receives the event.
+
+## Event Bus
+
+The Event Bus serves as a communication path between the Nodes, Distributor, New Session Queuer, and Session Map. 
+The Grid does most of its internal communication through messages, avoiding expensive HTTP calls. 
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Gridの役割
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.ja.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.ja.md
@@ -3,6 +3,12 @@ title: "グリッドのコンポーネント"
 weight: 1
 ---
 
+{{% notice info %}}
+<i class="fas fa-language"></i> Page being translated from 
+English to Japanese. Do you speak Japanese? Help us to translate
+it by sending us pull requests!
+{{% /notice %}}
+
 ![Grid](/images/grid_4.png)
 
 ## ルーター

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.ko.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.ko.md
@@ -59,13 +59,13 @@ whereas this would not be possible on Linux or Mac.
 The Session Map is a data store that keeps the information of the session id and the Node 
 where the session is running. It serves as a support for the Router in the process of 
 forwarding a request to the Node. The Router will ask the Session Map for the Node 
-associated to a session id. When starting the Grid in its fully distributed mode, the
-Session Map is the first component that should be started.
+associated to a session id.
 
 ## Event Bus
 
 The Event Bus serves as a communication path between the Nodes, Distributor, and Session Map. 
 The Grid does most of its internal communication through messages, avoiding expensive HTTP calls.
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Roles in Grid
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.nl.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.nl.md
@@ -59,13 +59,13 @@ whereas this would not be possible on Linux or Mac.
 The Session Map is a data store that keeps the information of the session id and the Node 
 where the session is running. It serves as a support for the Router in the process of 
 forwarding a request to the Node. The Router will ask the Session Map for the Node 
-associated to a session id. When starting the Grid in its fully distributed mode, the
-Session Map is the first component that should be started.
+associated to a session id.
 
 ## Event Bus
 
 The Event Bus serves as a communication path between the Nodes, Distributor, and Session Map. 
 The Grid does most of its internal communication through messages, avoiding expensive HTTP calls.
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Roles in Grid
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.pt-br.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.pt-br.md
@@ -3,6 +3,12 @@ title: "Componentes"
 weight: 1
 ---
 
+{{% notice info %}}
+<i class="fas fa-language"></i> Page being translated from 
+English to Portuguese. Do you speak Portuguese? Help us to translate
+it by sending us pull requests!
+{{% /notice %}}
+
 ![Grid](/images/grid_4.png)
 
 ## Roteador

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.pt-br.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.pt-br.md
@@ -4,10 +4,11 @@ weight: 1
 ---
 
 {{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
+<i class="fas fa-language"></i> There are certain paragaraphs needs translation from 
 English to Portuguese. Do you speak Portuguese? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
+
 
 ![Grid](/images/grid_4.png)
 
@@ -54,13 +55,12 @@ o mesmo sistema operacional que os outros componentes. Por exemplo, um nó do Wi
 pode ter a capacidade de oferecer o Internet Explorer como uma opção de navegador,
 considerando que isso não seria possível no Linux ou Mac.
 
-## Mapa de Sessão
+## Session Map
 
-O Mapa da Sessão é um armazenamento de dados que mantém as informações do ID da sessão e do Nó
-onde a sessão está sendo executada. Serve como suporte para o Roteador no processo de
-encaminhamento de uma solicitação para o Nó. O Roteador irá pedir o mapa da sessão para o nó
-associado a um ID de sessão. Ao iniciar a Grid em seu modo totalmente distribuído,
-o Mapa da Sessão é o primeiro componente que deve ser iniciado.
+The Session Map is a data store that keeps the information of the session id and the Node 
+where the session is running. It serves as a support for the Router in the process of 
+forwarding a request to the Node. The Router will ask the Session Map for the Node 
+associated to a session id.
 
 ## Enfileirador de Sessão, Fila de Sessão
 
@@ -91,8 +91,9 @@ recebe o evento.
 
 ## Event Bus
 
-O Event Bus serve como um caminho de comunicação entre os nós, o distribuidor, o enfileirador de sessão e o mapa da sessão.
-A Grid faz a maior parte de sua comunicação interna por meio de mensagens, evitando chamadas HTTP caras.
+The Event Bus serves as a communication path between the Nodes, Distributor, New Session Queuer, and Session Map. 
+The Grid does most of its internal communication through messages, avoiding expensive HTTP calls. 
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Funções na Grid
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.zh-cn.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.zh-cn.md
@@ -3,6 +3,11 @@ title: "服务网格的组件"
 weight: 1
 ---
 
+{{% notice info %}}
+<i class="fas fa-language"></i> Page being translated from 
+English to Chinese. Do you speak Chinese? Help us to translate
+it by sending us pull requests!
+{{% /notice %}}
 
 ![Grid](/images/grid_4.png)
 

--- a/docs_source_files/content/grid/grid_4/components_of_a_grid.zh-cn.md
+++ b/docs_source_files/content/grid/grid_4/components_of_a_grid.zh-cn.md
@@ -4,10 +4,11 @@ weight: 1
 ---
 
 {{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
+<i class="fas fa-language"></i> There are certain paragaraphs needs translation from 
 English to Chinese. Do you speak Chinese? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
+
 
 ![Grid](/images/grid_4.png)
 
@@ -60,19 +61,43 @@ it by sending us pull requests!
 
 ## Session Map
 
-会话集合是一种数据存储的形式,
-用于保存会话ID和会话正在运行的节点的信息.
-它在将请求转发到节点的过程中为路由器提供支持.
-路由器将向会话集合询问与会话ID关联的节点.
-当以完全分布式模式启动Grid时,
-Session Map是应该启动的第一个组件.
+The Session Map is a data store that keeps the information of the session id and the Node 
+where the session is running. It serves as a support for the Router in the process of 
+forwarding a request to the Node. The Router will ask the Session Map for the Node 
+associated to a session id.
+
+## New Session Queuer, New Session Queue
+
+The New Session Queuer is the only
+component which can communicate with the New Session Queue. It handles all queue operations like
+add to manipulate the queue. It has configurable parameters for setting 
+the request timeout and request retry interval.
+
+The New Session Queuer receives the new session request from the Router and adds it to the queue. 
+The queuer waits until it receives the response for the request. 
+If the request times out, the request is rejected immediately and not added to the queue. 
+
+Upon successfully adding the request to the queue, Event Bus triggers an event. 
+The Distributor picks up this event and polls the queue. It now attempts to create a session.
+
+If the requested capabilities do not exist in any of the registered Nodes, then the request is rejected
+immediately and the client receives a response.
+
+If the requested capabilities match the capabilities of any of Node slots, Distributor attempts to get the
+available slot. If all the slots are busy, the Distributor will ask the queuer to add the request 
+to the front of the queue. The Distributor receives the request again after the request retry interval. 
+It will attempt retries until the request is successful or has timed out. 
+If request times out while retrying or adding to the front of the queue its rejected.
+
+After getting an available slot and session creation, the Distributor passes the new session response 
+to the New Session Queuer via the Event Bus. The New Session Queuer will respond to the client when it
+receives the event.
 
 ## Event Bus
 
-事件总线作为一种通讯的路径,
-服务于节点、分发服务器和会话集合之间.
-网格通过消息进行大部分内部通信,
-从而避免了昂贵的HTTP调用.
+The Event Bus serves as a communication path between the Nodes, Distributor, New Session Queuer, and Session Map. 
+The Grid does most of its internal communication through messages, avoiding expensive HTTP calls. 
+When starting the Grid in its fully distributed mode, the Event Bus is the first component that should be started. 
 
 ## Roles in Grid
 


### PR DESCRIPTION
### Description
Conflicting information on which component should be started first in fully distributed grid 4.

Question raised in slack channel about this - https://seleniumhq.slack.com/archives/C0ABCS03F/p1618484382029000


### Motivation and Context
Avoiding confusion on which component should be started and why.

### Types of changes
- [ x] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
