### PR TITLE
Add Nightwatch.js to ecosystem links

### DIFF
--- a/site_source_files/content/ecosystem/nightwatchjs.md
+++ b/site_source_files/content/ecosystem/nightwatchjs.md
@@ -1,0 +1,8 @@
++++
+Description = ""
+Key = "framework"
+BindingName = "Nightwatch.js"
+Language = "JavaScript"
+BindingLink = "https://github.com/nightwatchjs/nightwatch"
+Author = "Andrei Rusu"
++++


### PR DESCRIPTION
### Description
Add Nightwatch.js to the list of frameworks on the Ecosystem page.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
