### PR TITLE
Add missing import statement for By keyword

### DIFF
--- a/docs_source_files/content/webdriver/browser_manipulation.en.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.en.md
@@ -649,6 +649,7 @@ using something like:
 driver.findElement(By.tagName("button")).click();
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
+from selenium.webdriver.common.by import By
 # This Wont work
 driver.find_element(By.TAG_NAME, 'button').click()
   {{< / code-panel >}}


### PR DESCRIPTION
Without this statement, the sample code below won't work.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Add missing import statement for By keyword before introducing the code.

### Motivation and Context
without the import, it gives an error, and identifying what to import is not intuitive.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [X] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [X] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
