### PR TITLE
Adding feature to reflect language change in samples

### DIFF
--- a/docs_source_files/layouts/shortcodes/code-tab.html
+++ b/docs_source_files/layouts/shortcodes/code-tab.html
@@ -4,9 +4,9 @@
 <div class="tabset">
   {{ range $index, $language := $languages }}
     {{ if eq $index 0 }}
-      <input type="radio" name="tabset{{$codeTabId}}" id="tab{{$index}}{{$codeTabId}}" aria-controls="{{$language}}{{$codeTabId}}" checked>
+      <input type="radio" name="tabset{{$codeTabId}}" class="tab{{$language}}" id="tab{{$index}}{{$codeTabId}}" aria-controls="{{$language}}{{$codeTabId}}" onclick="handleClick(this);" value="{{$language}}" checked>
     {{ else }}
-      <input type="radio" name="tabset{{$codeTabId}}" id="tab{{$index}}{{$codeTabId}}" aria-controls="{{$language}}{{$codeTabId}}">
+      <input type="radio" name="tabset{{$codeTabId}}" class="tab{{$language}}" id="tab{{$index}}{{$codeTabId}}" aria-controls="{{$language}}{{$codeTabId}}" onclick="handleClick(this);" value="{{$language}}">
     {{ end }}
     <label for="tab{{$index}}{{$codeTabId}}">{{index $languagesNice $index}}</label>
     {{ end }}  

--- a/docs_source_files/themes/hugo-theme-learn/layouts/partials/custom-footer.html
+++ b/docs_source_files/themes/hugo-theme-learn/layouts/partials/custom-footer.html
@@ -1,5 +1,18 @@
-<!-- Partial intended to be overwritten with tags loaded at the end of the page loading (usually for Javascript) 
 <script>
-    console.log("running some javascript");
+  if (typeof (Storage) !== "undefined") {
+    const activeLanguage = localStorage.getItem("active_language");
+    if (activeLanguage) {
+      document.querySelectorAll(".tab" + activeLanguage).forEach(element => {
+        element.checked = true;
+      });
+    }
+  }
+  function handleClick(languageRadio) {
+    if (typeof (Storage) !== "undefined") {
+      localStorage.setItem("active_language", languageRadio.value);
+      document.querySelectorAll(".tab" + languageRadio.value).forEach(element => {
+        element.checked = true;
+      });
+    }
+  }
 </script>
--->


### PR DESCRIPTION
Adding a feature to reflect the change in programming language for one
sample across all code samples. It also persists in the selected language
for any further session.

Fixes #525

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->

Before:
![image](https://user-images.githubusercontent.com/16668163/116169274-ffa9a780-a721-11eb-8180-24e80fa829be.png)

After:
![image](https://user-images.githubusercontent.com/16668163/116169298-0a643c80-a722-11eb-9166-ded85012f9aa.png)

