### PR TITLE
Update typo on french "project and tools" page

### DIFF
--- a/docs_source_files/content/introduction/the_selenium_project_and_tools.fr.md
+++ b/docs_source_files/content/introduction/the_selenium_project_and_tools.fr.md
@@ -53,7 +53,7 @@ sur une gamme de machines.
 Imaginez une banque d'ordinateurs dans votre salle de serveurs ou votre centre de données
 allumer tous les navigateurs en même temps
 frapper les liens, les formulaires de votre site,
-et tables & mdash; tester votre application 24h / 24.
+et tables&mdash;tester votre application 24h / 24.
 Grâce à l'interface de programmation simple
 fournie pour les langues les plus courantes,
 ces tests se dérouleront sans relâche en parallèle,


### PR DESCRIPTION
### Description
The "&mdash" was written & mdash; , thus not making a dash.
Changes were made based on the english page "Project and tools".

### Motivation and Context
The typo made the text "& mdash;" appear in the page. Making it a "&mdash" simply makes it a dash as intended.
(Had to write it without a ";" so it doesn't made a direct dash in the PR)

### Types of changes
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
