### PR TITLE
Fix typo in the documentation

### DIFF
--- a/docs_source_files/content/webdriver/browser_manipulation.en.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.en.md
@@ -1309,7 +1309,7 @@ current context of a selected frame or window.
     //Executing JavaScript to click on element
       js.executeScript("arguments[0].click();", element);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) js.executeScript("return arguments[0].innerText", element);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}


### PR DESCRIPTION
https://www.selenium.dev/documentation/en/webdriver/browser_manipulation/ page typo in section "Execute Script" in the code example for java: wrong variable name used in the code block

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
