### PR TITLE
Fix wrong WebElement use in Execute Script Section

### DIFF
--- a/docs_source_files/content/webdriver/browser_manipulation.de.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.de.md
@@ -1313,9 +1313,9 @@ current context of a selected frame or window.
     //Button Element
       WebElement button =driver.findElement(By.name("btnLogin"));
     //Executing JavaScript to click on element
-      js.executeScript("arguments[0].click();", element);
+      js.executeScript("arguments[0].click();", button);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.en.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.en.md
@@ -1307,9 +1307,9 @@ current context of a selected frame or window.
     //Button Element
       WebElement button =driver.findElement(By.name("btnLogin"));
     //Executing JavaScript to click on element
-      js.executeScript("arguments[0].click();", element);
+      js.executeScript("arguments[0].click();", button);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.es.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.es.md
@@ -1320,9 +1320,9 @@ current context of a selected frame or window.
     //Button Element
       WebElement button =driver.findElement(By.name("btnLogin"));
     //Executing JavaScript to click on element
-      js.executeScript("arguments[0].click();", element);
+      js.executeScript("arguments[0].click();", button);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.fr.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.fr.md
@@ -1309,9 +1309,9 @@ current context of a selected frame or window.
     //Button Element
       WebElement button =driver.findElement(By.name("btnLogin"));
     //Executing JavaScript to click on element
-      js.executeScript("arguments[0].click();", element);
+      js.executeScript("arguments[0].click();", button);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.ja.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.ja.md
@@ -1266,9 +1266,9 @@ current context of a selected frame or window.
     //Button Element
       WebElement button =driver.findElement(By.name("btnLogin"));
     //Executing JavaScript to click on element
-      js.executeScript("arguments[0].click();", element);
+      js.executeScript("arguments[0].click();", button);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.ko.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.ko.md
@@ -1311,9 +1311,9 @@ current context of a selected frame or window.
     //Button Element
       WebElement button =driver.findElement(By.name("btnLogin"));
     //Executing JavaScript to click on element
-      js.executeScript("arguments[0].click();", element);
+      js.executeScript("arguments[0].click();", button);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.nl.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.nl.md
@@ -1309,9 +1309,9 @@ current context of a selected frame or window.
     //Button Element
       WebElement button =driver.findElement(By.name("btnLogin"));
     //Executing JavaScript to click on element
-      js.executeScript("arguments[0].click();", element);
+      js.executeScript("arguments[0].click();", button);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.pt-br.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.pt-br.md
@@ -1302,9 +1302,9 @@ contexto atual de um frame ou janela selecionada.
     //Button Element
       WebElement button =driver.findElement(By.name("btnLogin"));
     //Executing JavaScript to click on element
-      js.executeScript("arguments[0].click();", element);
+      js.executeScript("arguments[0].click();", button);
     //Get return value from script
-      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+      String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
     //Executing JavaScript directly
       js.executeScript("console.log('hello world')");
   {{< / code-panel >}}

--- a/docs_source_files/content/webdriver/browser_manipulation.zh-cn.md
+++ b/docs_source_files/content/webdriver/browser_manipulation.zh-cn.md
@@ -1237,9 +1237,9 @@ JavascriptExecutor js = (JavascriptExecutor)driver;
 //Button Element
 WebElement button =driver.findElement(By.name("btnLogin"));
 //Executing JavaScript to click on element
-js.executeScript("arguments[0].click();", element);
+js.executeScript("arguments[0].click();", button);
 //Get return value from script
-String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
+String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", button);
 //Executing JavaScript directly
 js.executeScript("console.log('hello world')");
 {{< / code-panel >}}


### PR DESCRIPTION





<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
In https://www.selenium.dev/documentation/en/webdriver/browser_manipulation/ under Execute Script Section,
WebElement is declared as , 
```
WebElement button =driver.findElement(By.name("btnLogin"));
```
but used as ,
```
 js.executeScript("arguments[0].click();", element);
String text = (String) javascriptExecutor.executeScript("return arguments[0].innerText", element);
```
"element" should be replaced with "button".

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Error free Documentation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
