### PR TITLE
Add JavaScript exception example for Chrome Dev tools in Java

### DIFF
--- a/docs_source_files/content/support_packages/chrome_devtools.de.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.de.md
@@ -4,11 +4,11 @@ weight: 10
 ---
 
 {{% notice info %}}
-<i class="fas fa-language"></i> Diese Seite wird von Englisch 
-auf Deutsch übersetzt. Sprichst Du Deutsch? Hilf uns die Seite 
+<i class="fas fa-language"></i> Diese Seite wird von Englisch
+auf Deutsch übersetzt. Sprichst Du Deutsch? Hilf uns die Seite
 zu übersetzen indem Du uns einen Pull Reqeust schickst!
 {{% /notice %}}
- 
+
 Selenium 4 alpha versions have much awaited native support for Chrome Dev Protocol through "DevTools" interface. This helps us getting Chrome Development properties such as Application Cache, Fetch, Network, Performance, Profiler, Resource Timing, Security and Target CDP domains etc.
 
 Chrome DevTools is a set of web developer tools built directly into the Google Chrome browser. DevTools can help you edit pages on-the-fly and diagnose problems quickly, which ultimately helps you build better websites, faster.
@@ -60,7 +60,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -111,7 +111,7 @@ fun main() {
     coordinates.put("accuracy", 1)
     driver.executeCdpCommand("Emulation.setGeolocationOverride", coordinates)
     driver.get("https://www.google.com")
-} 
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 
@@ -191,7 +191,32 @@ Using Selenium's integration with CDP, one can listen to the JS Exceptions and r
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -273,7 +298,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{
         put("width", 600);
@@ -281,7 +306,7 @@ public void deviceSimulationTest() {
         put("mobile", true);
         put("deviceScaleFactor", 50);
     }};
-        
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }

--- a/docs_source_files/content/support_packages/chrome_devtools.en.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.en.md
@@ -35,10 +35,10 @@ from selenium.webdriver.chrome.service import Service
 def geoLocationTest():
     driver = webdriver.Chrome()
     Map_coordinates = dict({
-        "latitude": 41.8781, 
+        "latitude": 41.8781,
         "longitude": -87.6298,
         "accuracy": 100
-        }) 
+        })
     driver.execute_cdp_cmd("Emulation.setGeolocationOverride", Map_coordinates)
     driver.get("<your site url>")
   {{< / code-panel >}}
@@ -54,7 +54,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -184,7 +184,32 @@ Using Selenium's integration with CDP, one can listen to the JS Exceptions and r
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+          link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -266,7 +291,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{  
         put("width", 600);
@@ -274,7 +299,7 @@ public void deviceSimulationTest() {
         put("mobile", true);
         put("deviceScaleFactor", 50);
     }};
-    
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }

--- a/docs_source_files/content/support_packages/chrome_devtools.es.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.es.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 {{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
+<i class="fas fa-language"></i> Page being translated from
 English to Spanish. Do you speak Spanish? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
@@ -60,7 +60,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -190,7 +190,32 @@ Using Selenium's integration with CDP, one can listen to the JS Exceptions and r
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -272,7 +297,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{
       put("width", 600);
@@ -280,7 +305,7 @@ public void deviceSimulationTest() {
       put("mobile", true);
       put("deviceScaleFactor", 50);
     }};
-    
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }

--- a/docs_source_files/content/support_packages/chrome_devtools.fr.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.fr.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 {{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
+<i class="fas fa-language"></i> Page being translated from
 English to French. Do you speak French? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
@@ -60,7 +60,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -190,7 +190,32 @@ Using Selenium's integration with CDP, one can listen to the JS Exceptions and r
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -272,7 +297,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{
       put("width", 600);
@@ -280,7 +305,7 @@ public void deviceSimulationTest() {
       put("mobile", true);
       put("deviceScaleFactor", 50);
     }};
-    
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }

--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 Selenium 4 alphaバージョンには、"DevTools" インターフェースを介した
-Chrome Dev Protocolのネイティブサポートが待望されています。 
+Chrome Dev Protocolのネイティブサポートが待望されています。
 これにより、アプリケーションキャッシュ、フェッチ、ネットワーク、パフォーマンス、
 プロファイラー、リソースタイミング、セキュリティ、
 ターゲットCDPドメインなどのChrome開発プロパティを取得できます。
@@ -64,7 +64,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -115,7 +115,7 @@ fun main() {
     coordinates.put("accuracy", 1)
     driver.executeCdpCommand("Emulation.setGeolocationOverride", coordinates)
     driver.get("https://www.google.com")
-} 
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 
@@ -194,7 +194,32 @@ Using Selenium's integration with CDP, one can listen to the JS Exceptions and r
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -276,7 +301,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{
       put("width", 600);
@@ -284,7 +309,7 @@ public void deviceSimulationTest() {
       put("mobile", true);
       put("deviceScaleFactor", 50);
     }};
-    
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }

--- a/docs_source_files/content/support_packages/chrome_devtools.ko.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ko.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 {{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
+<i class="fas fa-language"></i> Page being translated from
 English to Korean. Do you speak Korean? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
@@ -60,7 +60,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -190,7 +190,32 @@ Using Selenium's integration with CDP, one can listen to the JS Exceptions and r
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -272,7 +297,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{
         put("width", 600);
@@ -280,7 +305,7 @@ public void deviceSimulationTest() {
         put("mobile", true);
         put("deviceScaleFactor", 50);
     }};
-    
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }

--- a/docs_source_files/content/support_packages/chrome_devtools.nl.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.nl.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 {{% notice info %}}
-<i class="fas fa-language"></i> Page being translated from 
+<i class="fas fa-language"></i> Page being translated from
 English to Dutch. Do you speak Dutch? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
@@ -60,7 +60,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -111,7 +111,7 @@ fun main() {
     coordinates.put("accuracy", 1)
     driver.executeCdpCommand("Emulation.setGeolocationOverride", coordinates)
     driver.get("https://www.google.com")
-} 
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 
@@ -190,7 +190,32 @@ Using Selenium's integration with CDP, one can listen to the JS Exceptions and r
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -272,7 +297,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{
         put("width", 600);
@@ -280,7 +305,7 @@ public void deviceSimulationTest() {
         put("mobile", true);
         put("deviceScaleFactor", 50);
     }};
-    
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }

--- a/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
@@ -54,7 +54,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -184,7 +184,32 @@ Using Selenium's integration with CDP, one can listen to the JS Exceptions and r
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -266,7 +291,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{
         put("width", 600);
@@ -274,7 +299,7 @@ public void deviceSimulationTest() {
         put("mobile", true);
         put("deviceScaleFactor", 50);
     }};
-    
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }

--- a/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
@@ -54,7 +54,7 @@ namespace dotnet_test {
     public static void Main(string[] args) {
       GeoLocation().GetAwaiter().GetResult();
     }
-        
+
     public static async Task GeoLocation() {
       ChromeDriver driver = new ChromeDriver();
       DevToolsSession devToolsSession = driver.CreateDevToolsSession();
@@ -111,10 +111,10 @@ fun main() {
 
 ## 注册基本认证
 
-一些应用要求某些页面基于认证过的状态, 
-而大多数时候为了保持简单, 
-开发者使用基本认证. 
-通过Selenium和开发者工具的集成, 
+一些应用要求某些页面基于认证过的状态,
+而大多数时候为了保持简单,
+开发者使用基本认证.
+通过Selenium和开发者工具的集成,
 您可以在出现自动认证的时候自动进行输入.
 
 {{< code-tab >}}
@@ -189,7 +189,32 @@ await driver.wait(until.elementIsVisible(revealed), 5000);
 
 {{< code-tab >}}
   {{< code-panel language="java" >}}
-# Please raise a PR to add code sample
+import org.openqa.selenium.*;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.devtools.DevTools;
+
+public void jsExceptionsExample() {
+    ChromeDriver driver = new ChromeDriver();
+    DevTools devTools = driver.getDevTools();
+    devTools.createSession();
+
+    List<JavascriptException> jsExceptionsList = new ArrayList<>();
+    Consumer<JavascriptException> addEntry = jsExceptionsList::add;
+    devTools.getDomains().events().addJavascriptExceptionListener(addEntry);
+
+    driver.get("<your site url>");
+
+    WebElement link2click = driver.findElement(By.linkText("<your link text>"));
+    ((JavascriptExecutor) driver).executeScript("arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')");
+    link2click.click();
+
+    for (JavascriptException jsException : jsExceptionsList) {
+        System.out.println("JS exception message: " + jsException.getMessage());
+        System.out.println("JS exception system information: " + jsException.getSystemInformation());
+        jsException.printStackTrace();
+    }
+}
   {{< / code-panel >}}
   {{< code-panel language="python" >}}
 # Please raise a PR to add code sample
@@ -272,7 +297,7 @@ public void deviceSimulationTest() {
     ChromeDriver driver = (ChromeDriver) Driver.getDriver();
     tools = driver.getDevTools();
     tools.createSession();
-    
+
     Map deviceMetrics = new HashMap()
     {{
         put("width", 600);
@@ -280,7 +305,7 @@ public void deviceSimulationTest() {
         put("mobile", true);
         put("deviceScaleFactor", 50);
     }};
-    
+
     driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics);
     driver.get("https://www.google.com");
 }


### PR DESCRIPTION


### Description
Chrome Dev Tools example code for capturing JavaScript errors in the latest version of Selenium.

### Motivation and Context
There was no example for this functionality in Java.

### Types of changes
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
