### PR TITLE
Overrid device mode example in Kotlin

### DIFF
--- a/docs_source_files/content/support_packages/chrome_devtools.de.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.de.md
@@ -237,7 +237,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+      "arguments[0].setAttribute(arguments[1], arguments[2]);",
+      link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/chrome_devtools.de.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.de.md
@@ -341,6 +341,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.en.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.en.md
@@ -230,7 +230,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+      "arguments[0].setAttribute(arguments[1], arguments[2]);",
+      link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/chrome_devtools.en.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.en.md
@@ -334,6 +334,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.es.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.es.md
@@ -340,6 +340,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.es.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.es.md
@@ -236,7 +236,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+      "arguments[0].setAttribute(arguments[1], arguments[2]);",
+      link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/chrome_devtools.fr.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.fr.md
@@ -340,6 +340,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.fr.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.fr.md
@@ -236,7 +236,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+      "arguments[0].setAttribute(arguments[1], arguments[2]);",
+      link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -344,6 +344,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.ja.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ja.md
@@ -240,7 +240,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+        "arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/chrome_devtools.ko.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ko.md
@@ -340,6 +340,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.ko.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.ko.md
@@ -236,7 +236,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+        "arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/chrome_devtools.nl.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.nl.md
@@ -340,6 +340,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.nl.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.nl.md
@@ -236,7 +236,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+        "arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
@@ -334,6 +334,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.pt-br.md
@@ -230,7 +230,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+        "arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 

--- a/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
@@ -340,6 +340,21 @@ public void deviceSimulationTest() {
 # Please raise a PR to add code sample
 {{< / code-panel >}}
 {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinOverridDeviceMode() {
+  val driver = ChromeDriver()
+
+  val deviceMetrics: Map<String, Any> = object : HashMap<String, Any>() {
+    init {
+        put("width", 600)
+        put("height", 1000)
+        put("mobile", true)
+        put("deviceScaleFactor", 50)
+    }
+  }
+
+  driver.executeCdpCommand("Emulation.setDeviceMetricsOverride", deviceMetrics)
+  driver.get("https://www.google.com")
+  driver.quit()
+}
 {{< / code-panel >}}
 {{< / code-tab >}}

--- a/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
+++ b/docs_source_files/content/support_packages/chrome_devtools.zh-cn.md
@@ -235,7 +235,25 @@ let element = driver.findElement({id: 'throwing-mouseover'})
 await element.click()
   {{< / code-panel >}}
   {{< code-panel language="kotlin" >}}
-# Please raise a PR to add code sample
+fun kotlinJsErrorListener() {
+    val driver = ChromeDriver()
+    val devTools = driver.devTools
+    devTools.createSession()
+
+    val logJsError = { j: JavascriptException -> print("Javascript error: '" + j.localizedMessage + "'.") }
+    devTools.domains.events().addJavascriptExceptionListener(logJsError)
+
+    driver.get("https://www.google.com")
+
+    val link2click = driver.findElement(By.name("q"))
+    (driver as JavascriptExecutor).executeScript(
+        "arguments[0].setAttribute(arguments[1], arguments[2]);",
+        link2click, "onclick", "throw new Error('Hello, world!')"
+    )
+    link2click.click()
+
+    driver.quit()
+}
   {{< / code-panel >}}
 {{< / code-tab >}}
 


### PR DESCRIPTION
### Description
Example of overriding device mode in Kotlin & and example of a javascript exception listener in Kotlin

### Motivation and Context
The examples were not present

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
