### PR TITLE
Point people to GitHub to download the java standalone server

### DIFF
--- a/website_and_docs/layouts/downloads/list.html
+++ b/website_and_docs/layouts/downloads/list.html
@@ -23,7 +23,7 @@
       <div class="card-body">
         <p class="card-text">
           Latest stable version 
-          <a href="https://selenium-release.storage.googleapis.com/3.141/selenium-server-standalone-3.141.59.jar">3.141.59</a>
+          <a href="https://github.com/SeleniumHQ/selenium/releases/download/selenium-3.141.59/selenium-server-standalone-3.141.59.jar">3.141.59</a>
         </p>
         <p class="card-text">
           To use the Selenium Server in a Grid configuration see the 


### PR DESCRIPTION
### Description
We're going to start migrating people from Google Storage to GitHub. Time to get the show on the road.

### Motivation and Context
We can't afford to host on Google Storage

### Types of changes
- [x] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
