### PR TITLE
Fix a spelling mistake.

### DIFF
--- a/website_and_docs/content/documentation/webdriver/locating_elements.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.zh-cn.md
@@ -169,11 +169,11 @@ val muchoCheese: List<WebElement>  = driver.findElements(By.cssSelector("#cheese
 * *toRightOf* 元素右
 * *near* 附近
 
-_findElement_ 方法现在支持`witTagName()`新方法其可返回RelativeLocator相对定位对象。
+_findElement_ 方法现在支持`withTagName()`新方法其可返回RelativeLocator相对定位对象。
 
 **NOTE**: Java bindings now support `with(By)` instead of `withTagName()` allowing users to pick
 locator of their choice like _By.id_, _By.cssSelector_  etc.
-This feature landed in **Selenium4 - beta3**
+This feature landed in **Selenium4 - beta3h**
 
 ### 如何工作
 

--- a/website_and_docs/content/documentation/webdriver/locating_elements.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.zh-cn.md
@@ -173,9 +173,10 @@ _findElement_ 方法现在支持`withTagName()`新方法其可返回RelativeLoca
 
 **NOTE**: Java bindings now support `with(By)` instead of `withTagName()` allowing users to pick
 locator of their choice like _By.id_, _By.cssSelector_  etc.
-This feature landed in **Selenium4 - beta3h**
+This feature landed in **Selenium4 - beta3**
 
 ### 如何工作
+
 
 Selenium是通过使用JavaScript函数
 [getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)


### PR DESCRIPTION
I find a spell mistake in Chinese Document. It locates in "WebDriver/定位元素/相对定位/line 8". It seems like "withTagName()" rather than "witTagName()".

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
