### PR TITLE
Removing cmd 'npm install' from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Steps needed to have this working locally and work on it:
 - Clone this repository
 - Run `git submodule update --init --recursive`
 - Run `cd website_and_docs`
-- Run `npm install`
 - Run `hugo server`
 
 A full contribution guideline can be seen at [contributing](https://selenium.dev/documentation/about/contributing/)


### PR DESCRIPTION

### Description
Removing `npm install` from readme as it is not required/mandatory

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
