### PR TITLE
should be find_element_by_link_text

### DIFF
--- a/website_and_docs/content/documentation/webdriver/js_alerts_prompts_and_confirmations.en.md
+++ b/website_and_docs/content/documentation/webdriver/js_alerts_prompts_and_confirmations.en.md
@@ -36,7 +36,7 @@ alert.accept();
   {{< /tab >}}
   {{< tab header="Python" >}}
 # Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See an example alert").click()
+driver.find_element_by_link_text("See an example alert").click()
 
 # Wait for the alert to be displayed and store it in a variable
 alert = wait.until(expected_conditions.alert_is_present())


### PR DESCRIPTION
Reading documentation and using geckodriver, I see that `driver.find_element(By.LINK_TEXT, "Text").click()` is returning error `NameError: name 'By' is not defined`. That is because in the example the By is not imported from selenium.webdriver.common.by
Also noticed that `find_element_by_link_text` works.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I am attaching a screenshot showing the before and after)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
