### PR TITLE
Removing `withTagName` from examples

### DIFF
--- a/website_and_docs/content/documentation/webdriver/locating_elements.de.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.de.md
@@ -237,38 +237,38 @@ Funktionalität der relativen Locators besser zu verstehen:
 Liefert das WebElement, welches sich über dem spezifiziertem Element befindet.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement passwordField= driver.findElement(By.id("password"));
+WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -277,37 +277,38 @@ Findet das WebElement, welches sich unter dem
 spezifiziertem Element befindet.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressField= driver.findElement(By.id("email"));
+WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-email_address_field= driver.find_element(:id, "email")
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -316,38 +317,39 @@ Liefert das WebElement, welches sich links vom spezifizierten Element
 befindet.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement submitButton= driver.findElement(By.id("submit"));
-WebElement cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton));
-
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(By.id("submit"));
+WebElement cancelButton = driver.findElement(with(By.tagName("button"))
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val submitButton= driver.findElement(By.id("submit"))
-val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val submitButton = driver.findElement(By.id("submit"))
+val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -356,38 +358,38 @@ val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitB
 Liefert das WebElement, das sich rechts des spezifierten Elements befindet.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement cancelButton= driver.findElement(By.id("cancel"));
-WebElement submitButton= driver.findElement(with(By.tagName("button"))
-                                            .toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement cancelButton = driver.findElement(By.id("cancel"));
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val cancelButton= driver.findElement(By.id("cancel"))
-val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val cancelButton = driver.findElement(By.id("cancel"))
+val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near() - in der Nähe von
@@ -396,36 +398,36 @@ Liefert das WebElement, welches maximal `50px` vom spezifizierten
 Element entfernt ist.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressLabel= driver.findElement(By.id("lbl-email"));
-WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                               .near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
+WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/locating_elements.en.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.en.md
@@ -235,37 +235,38 @@ Returns the WebElement, which appears
 above to the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement passwordField= driver.findElement(By.id("password"));
+WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -275,37 +276,38 @@ Returns the WebElement, which appears
 below to the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressField= driver.findElement(By.id("email"));
+WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-email_address_field= driver.find_element(:id, "email")
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -315,38 +317,39 @@ Returns the WebElement, which appears
 to left of specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement submitButton= driver.findElement(By.id("submit"));
-WebElement cancelButton= driver.findElement(with(By.tagName("button"))
-                                            .toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(By.id("submit"));
+WebElement cancelButton = driver.findElement(with(By.tagName("button"))
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val submitButton= driver.findElement(By.id("submit"))
-val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val submitButton = driver.findElement(By.id("submit"))
+val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -356,37 +359,38 @@ Returns the WebElement, which appears
 to right of the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement cancelButton= driver.findElement(By.id("cancel"));
-WebElement submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement cancelButton = driver.findElement(By.id("cancel"));
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val cancelButton= driver.findElement(By.id("cancel"))
-val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val cancelButton = driver.findElement(By.id("cancel"))
+val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near()
@@ -395,35 +399,36 @@ Returns the WebElement, which is
 at most `50px` away from the specified element.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressLabel= driver.findElement(By.id("lbl-email"));
+WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/locating_elements.es.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.es.md
@@ -236,37 +236,38 @@ Returns the WebElement, which appears
 above to the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement passwordField= driver.findElement(By.id("password"));
+WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -276,38 +277,40 @@ Returns the WebElement, which appears
 below to the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressField= driver.findElement(By.id("email"));
+WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-email_address_field= driver.find_element(:id, "email")
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
+
 
 
 ### toLeftOf()
@@ -316,38 +319,39 @@ Returns the WebElement, which appears
 to left of specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement submitButton= driver.findElement(By.id("submit"));
-WebElement cancelButton= driver.findElement(with(By.tagName("button"))
-                                            .toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(By.id("submit"));
+WebElement cancelButton = driver.findElement(with(By.tagName("button"))
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val submitButton= driver.findElement(By.id("submit"))
-val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val submitButton = driver.findElement(By.id("submit"))
+val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -357,38 +361,38 @@ Returns the WebElement, which appears
 to right of the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement cancelButton= driver.findElement(By.id("cancel"));
-WebElement submitButton= driver.findElement(with(By.tagName("button"))
-                                            .toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement cancelButton = driver.findElement(By.id("cancel"));
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val cancelButton= driver.findElement(By.id("cancel"))
-val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val cancelButton = driver.findElement(By.id("cancel"))
+val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near()
@@ -397,36 +401,36 @@ Returns the WebElement, which is
 at most `50px` away from the specified element.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressLabel= driver.findElement(By.id("lbl-email"));
-WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
+WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/locating_elements.fr.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.fr.md
@@ -233,37 +233,38 @@ Returns the WebElement, which appears
 above to the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement passwordField= driver.findElement(By.id("password"));
+WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -273,38 +274,40 @@ Returns the WebElement, which appears
 below to the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressField= driver.findElement(By.id("email"));
+WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-email_address_field= driver.find_element(:id, "email")
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
+
 
 
 ### toLeftOf()
@@ -313,38 +316,39 @@ Returns the WebElement, which appears
 to left of specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement submitButton= driver.findElement(By.id("submit"));
-WebElement cancelButton= driver.findElement(with(By.tagName("button"))
-                                            .toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(By.id("submit"));
+WebElement cancelButton = driver.findElement(with(By.tagName("button"))
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val submitButton= driver.findElement(By.id("submit"))
-val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val submitButton = driver.findElement(By.id("submit"))
+val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -354,38 +358,38 @@ Returns the WebElement, which appears
 to right of the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement cancelButton= driver.findElement(By.id("cancel"));
-WebElement submitButton= driver.findElement(with(By.tagName("button"))
-                                            .toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement cancelButton = driver.findElement(By.id("cancel"));
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val cancelButton= driver.findElement(By.id("cancel"))
-val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val cancelButton = driver.findElement(By.id("cancel"))
+val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near()
@@ -394,36 +398,36 @@ Returns the WebElement, which is
 at most `50px` away from the specified element.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressLabel= driver.findElement(By.id("lbl-email"));
-WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
+WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/locating_elements.ja.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.ja.md
@@ -202,37 +202,38 @@ Seleniumは、JavaScript関数 [getBoundingClientRect()](https://developer.mozil
 指定された要素の上に表示されるWebElementを返します。
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement passwordField= driver.findElement(By.id("password"));
+WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -241,37 +242,38 @@ val emailAddressField = driver.findElement(with(By.tagName("input")).above(passw
 指定された要素の下に表示されるWebElementを返します。
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressField= driver.findElement(By.id("email"));
+WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-email_address_field= driver.find_element(:id, "email")
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -280,38 +282,39 @@ val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddr
 指定された要素の左側に表示されるWebElementを返します。
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement submitButton= driver.findElement(By.id("submit"));
-WebElement cancelButton= driver.findElement(with(By.tagName("button"))
-                                            .toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(By.id("submit"));
+WebElement cancelButton = driver.findElement(with(By.tagName("button"))
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val submitButton= driver.findElement(By.id("submit"))
-val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val submitButton = driver.findElement(By.id("submit"))
+val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -320,38 +323,38 @@ val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitB
 指定された要素の右側に表示されるWebElementを返します。
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement cancelButton= driver.findElement(By.id("cancel"));
-WebElement submitButton= driver.findElement(with(By.tagName("button"))
-                                            .toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement cancelButton = driver.findElement(By.id("cancel"));
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val cancelButton= driver.findElement(By.id("cancel"))
-val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val cancelButton = driver.findElement(By.id("cancel"))
+val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near()
@@ -359,36 +362,36 @@ val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancel
 指定した要素から最大 `50px` 離れたWebElementを返します。
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressLabel= driver.findElement(By.id("lbl-email"));
-WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
+WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/locating_elements.ko.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.ko.md
@@ -182,37 +182,38 @@ Locator들을 최대한 가독성 있고 간단하게 유지하는 것을 추천
 특정 element 위의 WebElement를 반환합니다.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement passwordField= driver.findElement(By.id("password"));
+WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -221,37 +222,38 @@ val emailAddressField = driver.findElement(with(By.tagName("input")).above(passw
 특정 element 아래의 WebElement를 반환합니다.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressField= driver.findElement(By.id("email"));
+WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-using static OpenQA.Selenium.RelativeBy;  
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-email_address_field= driver.find_element(:id, "email")
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -260,38 +262,39 @@ val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddr
 특정 element 왼쪽의 WebElement를 반환합니다.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement submitButton= driver.findElement(By.id("submit"));
-WebElement cancelButton= driver.findElement(with(By.tagName("button"))
-                                            .toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(By.id("submit"));
+WebElement cancelButton = driver.findElement(with(By.tagName("button"))
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val submitButton= driver.findElement(By.id("submit"))
-val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val submitButton = driver.findElement(By.id("submit"))
+val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -300,38 +303,38 @@ val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitB
 특정 element 오른쪽의 WebElement를 반환합니다.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement cancelButton= driver.findElement(By.id("cancel"));
-WebElement submitButton= driver.findElement(with(By.tagName("button"))
-                                            .toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement cancelButton = driver.findElement(By.id("cancel"));
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val cancelButton= driver.findElement(By.id("cancel"))
-val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val cancelButton = driver.findElement(By.id("cancel"))
+val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near()
@@ -339,36 +342,36 @@ val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancel
 특정 element의 최대 50px 근처의 WebElement를 반환합니다.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressLabel= driver.findElement(By.id("lbl-email"));
-WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
+WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/locating_elements.nl.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.nl.md
@@ -244,37 +244,38 @@ Returns the WebElement, which appears
 above to the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement passwordField= driver.findElement(By.id("password"));
+WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -284,38 +285,40 @@ Returns the WebElement, which appears
 below to the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressField= driver.findElement(By.id("email"));
+WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-email_address_field= driver.find_element(:id, "email")
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
+
 
 
 ### toLeftOf()
@@ -324,38 +327,39 @@ Returns the WebElement, which appears
 to left of specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement submitButton= driver.findElement(By.id("submit"));
-WebElement cancelButton= driver.findElement(with(By.tagName("button"))
-                                            .toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(By.id("submit"));
+WebElement cancelButton = driver.findElement(with(By.tagName("button"))
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val submitButton= driver.findElement(By.id("submit"))
-val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val submitButton = driver.findElement(By.id("submit"))
+val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -365,37 +369,38 @@ Returns the WebElement, which appears
 to right of the specified element
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement cancelButton= driver.findElement(By.id("cancel"));
-WebElement submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement cancelButton = driver.findElement(By.id("cancel"));
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val cancelButton= driver.findElement(By.id("cancel"))
-val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val cancelButton = driver.findElement(By.id("cancel"))
+val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near()
@@ -404,35 +409,36 @@ Returns the WebElement, which is
 at most `50px` away from the specified element.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressLabel= driver.findElement(By.id("lbl-email"));
+WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/locating_elements.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.pt-br.md
@@ -231,37 +231,38 @@ Retorna o WebElement, que aparece
 acima do elemento especificado
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
 WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-password_field = driver.find_element(:id, "password")
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -271,37 +272,38 @@ Retorna o WebElement, que aparece
 abaixo do elemento especificado
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
 WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -311,38 +313,39 @@ Retorna o WebElement, que aparece
 à esquerda do elemento especificado
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
 WebElement submitButton = driver.findElement(By.id("submit"));
 WebElement cancelButton = driver.findElement(with(By.tagName("button"))
-                                            .toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-submit_button = driver.find_element(:id, "submit")
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val submitButton = driver.findElement(By.id("submit"))
 val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -352,38 +355,38 @@ Retorna o WebElement, que aparece
 à direita do elemento especificado
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
 WebElement cancelButton = driver.findElement(By.id("cancel"));
-WebElement submitButton = driver.findElement(with(By.tagName("button"))
-                                            .toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val cancelButton = driver.findElement(By.id("cancel"))
 val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near()
@@ -392,36 +395,36 @@ Retorna o WebElement, que está
 no máximo a `50px` de distância do elemento especificado.
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
 WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
-WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/locating_elements.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/locating_elements.zh-cn.md
@@ -187,37 +187,38 @@ Selenium是通过使用JavaScript函数
 返回当前指定元素位置上方的WebElement对象
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement passwordField= driver.findElement(By.id("password"));
+WebElement passwordField = driver.findElement(By.id("password"));
 WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.above(passwordField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 passwordField = driver.find_element(By.ID, "password")
-emailAddressField = driver.find_element(with_tag_name("input").above(passwordField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").above(passwordField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement passwordField = driver.FindElement(By.Id("password"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Above(passwordField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 password_field= driver.find_element(:id, "password")
 email_address_field = driver.find_element(relative: {tag_name: 'input', above:password_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let passwordField = driver.findElement(By.id('password'));
-let emailAddressField = await driver.findElement(withTagName('input').above(passwordField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(locateWith(By.tagName('input')).above(passwordField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val passwordField = driver.findElement(By.id("password"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).above(passwordField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -227,37 +228,38 @@ val emailAddressField = driver.findElement(with(By.tagName("input")).above(passw
 
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressField= driver.findElement(By.id("email"));
+WebElement emailAddressField = driver.findElement(By.id("email"));
 WebElement passwordField = driver.findElement(with(By.tagName("input"))
-	                                          .below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+.below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressField = driver.find_element(By.ID, "email")
-passwordField = driver.find_element(with_tag_name("input").below(emailAddressField))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+passwordField = driver.find_element(locate_with(By.TAG_NAME, "input").below(emailAddressField))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressField = driver.FindElement(By.Id("email"));
-IWebElement passwordField = driver.FindElement(WithTagName("input").Below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-email_address_field= driver.find_element(:id, "email")
+IWebElement passwordField = driver.FindElement(RelativeBy(By.TagName("input")).Below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+email_address_field = driver.find_element(:id, "email")
 password_field = driver.find_element(relative: {tag_name: 'input', below: email_address_field})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressField = driver.findElement(By.id('email'));
-let passwordField = await driver.findElement(withTagName('input').below(emailAddressField));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let passwordField = await driver.findElement(locateWith(By.tagName('input')).below(emailAddressField));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressField = driver.findElement(By.id("email"))
 val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddressField))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -266,38 +268,39 @@ val passwordField = driver.findElement(with(By.tagName("input")).below(emailAddr
 返回当前指定元素位置左方的WebElement对象
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement submitButton= driver.findElement(By.id("submit"));
-WebElement cancelButton= driver.findElement(with(By.tagName("button"))
-                                            .toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement submitButton = driver.findElement(By.id("submit"));
+WebElement cancelButton = driver.findElement(with(By.tagName("button"))
+.toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 submitButton = driver.find_element(By.ID, "submit")
-cancelButton = driver.find_element(with_tag_name("button").
-                                   to_left_of(submitButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+cancelButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_left_of(submitButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement submitButton = driver.FindElement(By.Id("submit"));
-IWebElement cancelButton = driver.FindElement(WithTagName("button").LeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement cancelButton = driver.FindElement(RelativeBy(By.TagName("button")).LeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 submit_button= driver.find_element(:id, "submit")
 cancel_button = driver.find_element(relative: {tag_name: 'button', left:submit_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let submitButton = driver.findElement(By.id("submit"));
-let cancelButton = await driver.findElement(withTagName("button").toLeftOf(submitButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val submitButton= driver.findElement(By.id("submit"))
-val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
-  {{< /tab >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+let submitButton = driver.findElement(By.id('submit'));
+let cancelButton = await driver.findElement(locateWith(By.tagName('button')).toLeftOf(submitButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val submitButton = driver.findElement(By.id("submit"))
+val cancelButton = driver.findElement(with(By.tagName("button")).toLeftOf(submitButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 
@@ -306,38 +309,38 @@ val cancelButton= driver.findElement(with(By.tagName("button")).toLeftOf(submitB
 返回当前指定元素位置右方的WebElement对象
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement cancelButton= driver.findElement(By.id("cancel"));
-WebElement submitButton= driver.findElement(with(By.tagName("button"))
-                                            .toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement cancelButton = driver.findElement(By.id("cancel"));
+WebElement submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 cancelButton = driver.find_element(By.ID, "cancel")
-submitButton = driver.find_element(with_tag_name("button").
-                                   to_right_of(cancelButton))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+submitButton = driver.find_element(locate_with(By.TAG_NAME, "button").
+to_right_of(cancelButton))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement cancelButton = driver.FindElement(By.Id("cancel"));
-IWebElement submitButton = driver.FindElement(WithTagName("button").RightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement submitButton = driver.FindElement(RelativeBy(By.TagName("button")).RightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 cancel_button = driver.find_element(:id, "cancel")
 submit_button = driver.find_element(relative: {tag_name: 'button', right:cancel_button})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let cancelButton = driver.findElement(By.id('cancel'));
-let submitButton = await driver.findElement(withTagName('button').toRightOf(cancelButton));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val cancelButton= driver.findElement(By.id("cancel"))
-val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
-  {{< /tab >}}
+let submitButton = await driver.findElement(locateWith(By.tagName('button')).toRightOf(cancelButton));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+val cancelButton = driver.findElement(By.id("cancel"))
+val submitButton = driver.findElement(with(By.tagName("button")).toRightOf(cancelButton))
+{{< /tab >}}
 {{< /tabpane >}}
 
 ### near() 附近
@@ -345,36 +348,36 @@ val submitButton= driver.findElement(with(By.tagName("button")).toRightOf(cancel
 返回当前指定元素位置附近大约`px50`50像素的WebElement对象
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
+{{< tab header="Java" >}}
 import static org.openqa.selenium.support.locators.RelativeLocator.with;
 
-WebElement emailAddressLabel= driver.findElement(By.id("lbl-email"));
-WebElement emailAddressField = driver.findElement(with(By.tagName("input"))
-                                                  .near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.relative_locator import with_tag_name
+WebElement emailAddressLabel = driver.findElement(By.id("lbl-email"));
+WebElement emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
 
 emailAddressLabel = driver.find_element(By.ID, "lbl-email")
-emailAddressField = driver.find_element(with_tag_name("input").
-                                       near(emailAddressLabel))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
+emailAddressField = driver.find_element(locate_with(By.TAG_NAME, "input").
+near(emailAddressLabel))
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using static OpenQA.Selenium.RelativeBy;
 
 IWebElement emailAddressLabel = driver.FindElement(By.Id("lbl-email"));
-IWebElement emailAddressField = driver.FindElement(WithTagName("input").Near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+IWebElement emailAddressField = driver.FindElement(RelativeBy(By.TagName("input")).Near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 email_address_label = driver.find_element(:id, "lbl-email")
 email_address_field = driver.find_element(relative: {tag_name: 'input', near: email_address_label})
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 let emailAddressLabel = driver.findElement(By.id("lbl-email"));
-let emailAddressField = await driver.findElement(withTagName("input").near(emailAddressLabel));
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+let emailAddressField = await driver.findElement(with(By.tagName("input")).near(emailAddressLabel));
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 val emailAddressLabel = driver.findElement(By.id("lbl-email"))
 val emailAddressField = driver.findElement(with(By.tagName("input")).near(emailAddressLabel))
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
All bindings receive a locator strategy, so removing examples that use `withTagName`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
