### PR TITLE
Changing syntax highlight from chroma to prism (enable code copy option)

### DIFF
--- a/website_and_docs/config.toml
+++ b/website_and_docs/config.toml
@@ -163,7 +163,7 @@ offlineSearchMaxResults = 30
 algolia_docsearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
-prism_syntax_highlighting = false
+prism_syntax_highlighting = true
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION

### Description
Changing code syntax highlight from chroma to prism to enable copy to clipboard for code samples

### Motivation and Context
To enable copy option for code samples

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
