### PR TITLE
Add google verification page

### DIFF
--- a/website_and_docs/static/googlef3e6aa07fecc4b79.html
+++ b/website_and_docs/static/googlef3e6aa07fecc4b79.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef3e6aa07fecc4b79.html


### PR DESCRIPTION
We need this verification in place to allow us to verify the page with
the Google Chrome Web Store. Without this, we can't point the IDE to
https://selenium.dev.

### Description
Verify our site with the Google Web Store

### Motivation and Context
We want to point people at our site when they download the IDE

### Types of changes
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

