### PR TITLE
Navbar toggler not visible on mobile devices.

### DIFF
--- a/website_and_docs/layouts/partials/navbar.html
+++ b/website_and_docs/layouts/partials/navbar.html
@@ -1,5 +1,5 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
-<nav class="js-navbar-scroll navbar navbar-expand-lg navbar-color {{ if $cover}} td-navbar-cover {{ end }} td-navbar">
+<nav class="js-navbar-scroll navbar navbar-expand-lg navbar-dark navbar-color {{ if $cover}} td-navbar-cover {{ end }} td-navbar">
   <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
 		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span>
 	</a>


### PR DESCRIPTION
Added a `navbar-dark` class [here](https://github.com/code-reaper08/seleniumhq.github.io/blob/dev/website_and_docs/layouts/partials/navbar.html#L2)

<!--- Provide a general summary of your changes in the Title above -->

### Description
Added `navbar-dark` class for the `<nav>` element. 
This makes the navbar toggler visible.

Fixes #811
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
