### PR TITLE
Preventing deprecation warnings in Python

### DIFF
--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.de.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.de.md
@@ -528,6 +528,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 

--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.en.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.en.md
@@ -519,6 +519,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 

--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.es.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.es.md
@@ -528,6 +528,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 

--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.fr.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.fr.md
@@ -528,6 +528,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 

--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.ja.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.ja.md
@@ -528,6 +528,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 

--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.ko.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.ko.md
@@ -528,6 +528,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 

--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.nl.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.nl.md
@@ -528,6 +528,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 

--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.pt-br.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.pt-br.md
@@ -523,6 +523,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 

--- a/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.zh-cn.md
+++ b/website_and_docs/content/documentation/getting_started/how_to_upgrade_to_selenium_4.zh-cn.md
@@ -528,6 +528,35 @@ browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
 {{< /card >}}
 {{< /cardpane >}}
 
+### Python
+
+#### `executable_path has been deprecated, please pass in a Service object`
+
+In Selenium 4, you'll need to set the driver's ``executable_path`` from a Service object to prevent deprecation warnings. (Or don't set the path and instead make sure that the driver you need is on the System PATH.)
+
+{{< cardpane >}}
+{{< card header="Before" >}}
+```python
+from selenium import webdriver
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+driver = webdriver.Chrome(executable_path=CHROMEDRIVER_PATH, options=options)
+```
+{{< /card >}}
+{{< card header="After" >}}
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+options = webdriver.ChromeOptions()
+options.add_experimental_option("excludeSwitches", ["enable-automation"])
+options.add_experimental_option("useAutomationExtension", False)
+service = ChromeService(executable_path=CHROMEDRIVER_PATH)
+driver = webdriver.Chrome(service=service, options=options)
+```
+{{< /card >}}
+{{< /cardpane >}}
+
 ## Summary
 
 We went through the major changes to be taken into consideration when upgrading to Selenium 4. 


### PR DESCRIPTION
Preventing: ``executable_path has been deprecated, please pass in a Service object`` in Python.

### Description
Helping people avoid deprecation warnings in Python when upgrading to Selenium 4.
Preventing: ``executable_path has been deprecated, please pass in a Service object`` in Python.

### Motivation and Context
Helping people avoid deprecation warnings in Python when upgrading to Selenium 4.
Preventing: ``executable_path has been deprecated, please pass in a Service object`` in Python.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
