### PR TITLE
add IDE page to top level

### DIFF
--- a/website_and_docs/content/documentation/ide.en.md
+++ b/website_and_docs/content/documentation/ide.en.md
@@ -3,7 +3,7 @@ title: "Selenium IDE"
 linkTitle: "IDE"
 weight: 10
 description: >
-The Selenium IDE is a browser extension that records and plays back a user's actions.
+    The Selenium IDE is a browser extension that records and plays back a user's actions.
 ---
 
 Selenium's Integrated Development Environment ([Selenium IDE](//selenium.dev/selenium-ide))

--- a/website_and_docs/content/documentation/ide.en.md
+++ b/website_and_docs/content/documentation/ide.en.md
@@ -1,0 +1,17 @@
+---
+title: "Selenium IDE"
+linkTitle: "IDE"
+weight: 10
+description: >
+The Selenium IDE is a browser extension that records and plays back a user's actions.
+---
+
+Selenium's Integrated Development Environment ([Selenium IDE](//selenium.dev/selenium-ide))
+is an easy-to-use browser extension that records a user's
+actions in the browser using existing Selenium commands,
+with parameters defined by the context of each element.
+It provides an excellent way to learn Selenium syntax.
+It's available for Google Chrome, Mozilla Firefox, and Microsoft Edge.
+
+For more information, visit the complete
+[Selenium IDE Documentation](https://www.selenium.dev/selenium-ide/docs/en/introduction/getting-started)

--- a/website_and_docs/content/documentation/ide.ja.md
+++ b/website_and_docs/content/documentation/ide.ja.md
@@ -1,0 +1,18 @@
+---
+title: "Selenium IDE"
+linkTitle: "IDE"
+weight: 10
+needsTranslation: true
+description: >
+    The Selenium IDE is a browser extension that records and plays back a user's actions.
+---
+
+Selenium's Integrated Development Environment ([Selenium IDE](//selenium.dev/selenium-ide))
+is an easy-to-use browser extension that records a user's
+actions in the browser using existing Selenium commands, 
+with parameters defined by the context of each element. 
+It provides an excellent way to learn Selenium syntax.
+It's available for Google Chrome, Mozilla Firefox, and Microsoft Edge.
+
+For more information, visit the complete
+[Selenium IDE Documentation](https://www.selenium.dev/selenium-ide/docs/en/introduction/getting-started)

--- a/website_and_docs/content/documentation/ide.pt-br.md
+++ b/website_and_docs/content/documentation/ide.pt-br.md
@@ -4,7 +4,7 @@ linkTitle: "IDE"
 weight: 10
 needsTranslation: true
 description: >
-The Selenium IDE is a browser extension that records and plays back a user's actions.
+    The Selenium IDE is a browser extension that records and plays back a user's actions.
 ---
 
 Selenium's Integrated Development Environment ([Selenium IDE](//selenium.dev/selenium-ide))

--- a/website_and_docs/content/documentation/ide.pt-br.md
+++ b/website_and_docs/content/documentation/ide.pt-br.md
@@ -1,0 +1,18 @@
+---
+title: "Selenium IDE"
+linkTitle: "IDE"
+weight: 10
+needsTranslation: true
+description: >
+The Selenium IDE is a browser extension that records and plays back a user's actions.
+---
+
+Selenium's Integrated Development Environment ([Selenium IDE](//selenium.dev/selenium-ide))
+is an easy-to-use browser extension that records a user's
+actions in the browser using existing Selenium commands,
+with parameters defined by the context of each element.
+It provides an excellent way to learn Selenium syntax.
+It's available for Google Chrome, Mozilla Firefox, and Microsoft Edge.
+
+For more information, visit the complete
+[Selenium IDE Documentation](https://www.selenium.dev/selenium-ide/docs/en/introduction/getting-started)

--- a/website_and_docs/content/documentation/ide.zh-cn.md
+++ b/website_and_docs/content/documentation/ide.zh-cn.md
@@ -4,7 +4,7 @@ linkTitle: "IDE"
 weight: 10
 needsTranslation: true
 description: >
-The Selenium IDE is a browser extension that records and plays back a user's actions.
+    The Selenium IDE is a browser extension that records and plays back a user's actions.
 ---
 
 Selenium's Integrated Development Environment ([Selenium IDE](//selenium.dev/selenium-ide))

--- a/website_and_docs/content/documentation/ide.zh-cn.md
+++ b/website_and_docs/content/documentation/ide.zh-cn.md
@@ -1,0 +1,18 @@
+---
+title: "Selenium IDE"
+linkTitle: "IDE"
+weight: 10
+needsTranslation: true
+description: >
+The Selenium IDE is a browser extension that records and plays back a user's actions.
+---
+
+Selenium's Integrated Development Environment ([Selenium IDE](//selenium.dev/selenium-ide))
+is an easy-to-use browser extension that records a user's
+actions in the browser using existing Selenium commands,
+with parameters defined by the context of each element.
+It provides an excellent way to learn Selenium syntax.
+It's available for Google Chrome, Mozilla Firefox, and Microsoft Edge.
+
+For more information, visit the complete
+[Selenium IDE Documentation](https://www.selenium.dev/selenium-ide/docs/en/introduction/getting-started)


### PR DESCRIPTION
Adds Placeholder page for Selenium IDE and link to the docs.

Can we move all of these docs over instead of just linking? Or can we not alias the old content correctly?