### PR TITLE
Japanese Translation of /documentation/

### DIFF
--- a/website_and_docs/content/documentation/_index.ja.md
+++ b/website_and_docs/content/documentation/_index.ja.md
@@ -6,15 +6,6 @@ cascade:
 aliases: ["/documentation/ja/"]
 ---
 
-{{% pageinfo color="warning" %}}
-<p class="lead">
-   <i class="fas fa-language display-4"></i> 
-   Page being translated from 
-   English to Japanese. Do you speak Japanese? Help us to translate
-   it by sending us pull requests!
-</p>
-{{% /pageinfo %}}
-
 Seleniumはブラウザー自動化を可能にし、それを支えるツール群とライブラリー群プロジェクトです。
 
 ユーザーとブラウザーのやり取りのエミュレーション、ブラウザーの割当を増強したり縮減する分散型サーバー、そしてすべてのメジャーなブラウザー用に置換可能なコードの実装を可能にする[W3C WebDriver 仕様](//www.w3.org/TR/webdriver/)インフラの提供します。
@@ -148,11 +139,13 @@ fun main() {
 
 
 
-See the [Overview]({{< ref "overview" >}}) to check the different project 
-components and decide if Selenium is the right tool for you.
+[概要]({{< ref "overview" >}})を参照して、さまざまなプロジェクトコンポーネントを確認し、
+Seleniumが適切なツールであるかどうかを判断してください。
 
-You should continue on to [Getting Started]({{< ref "webdriver/getting_started" >}})
-to understand how you can install Selenium and successfully use it as a test 
-automation tool, and scaling simple tests like this to run in large, distributed 
-environments on multiple browsers, on several different operating systems.
+[入門]({{< ref "webdriver/getting_started" >}})に進んで、
+Seleniumをインストールし、テスト自動化ツールとして正常に使用する方法を理解し、
+このような単純なテストをスケーリングして、複数のブラウザー、
+複数の異なるオペレーティングシステムの大規模な分散環境で実行する必要があります。
+
+
 

--- a/website_and_docs/content/documentation/grid/_index.ja.md
+++ b/website_and_docs/content/documentation/grid/_index.ja.md
@@ -3,7 +3,7 @@ title: "Grid"
 linkTitle: "Grid"
 weight: 6
 description: >
-  Want to run tests in parallel across multiple machines? Then, Grid is for you.
+  複数のマシン間で並行してテストを実行したいですか？ その場合、グリッドはあなたのためになります。
 aliases: 
         [
           "/documentation/ja/selenium_installation/installing_standalone_server/",

--- a/website_and_docs/content/documentation/ide.ja.md
+++ b/website_and_docs/content/documentation/ide.ja.md
@@ -4,7 +4,7 @@ linkTitle: "IDE"
 weight: 10
 needsTranslation: true
 description: >
-    The Selenium IDE is a browser extension that records and plays back a user's actions.
+    Selenium IDEは、ユーザーのアクションを記録および再生するブラウザー拡張機能です。
 ---
 
 Selenium's Integrated Development Environment ([Selenium IDE](//selenium.dev/selenium-ide))

--- a/website_and_docs/content/documentation/ie_driver_server.ja.md
+++ b/website_and_docs/content/documentation/ie_driver_server.ja.md
@@ -3,7 +3,7 @@ title: "IE Driver Server"
 linkTitle: "IE Driver Server"
 weight: 8
 description: >
-    The Internet Explorer Driver is a standalone server that implements the WebDriver specification.
+    Internet Explorer Driverは、WebDriverの仕様を実装するスタンドアロンサーバーです。
 ---
 
 The `InternetExplorerDriver` is a standalone server which implements WebDriver's wire protocol.

--- a/website_and_docs/content/documentation/test_practices/_index.ja.md
+++ b/website_and_docs/content/documentation/test_practices/_index.ja.md
@@ -4,7 +4,7 @@ linkTitle: "ガイドライン"
 chapter: true
 weight: 12
 description: >
-  Some guidelines and recommendations on testing from the Selenium project.
+  Seleniumプロジェクトからのテストに関するいくつかのガイドラインと推奨事項
 ---
 
 {{% pageinfo color="warning" %}}

--- a/website_and_docs/content/documentation/webdriver/_index.ja.md
+++ b/website_and_docs/content/documentation/webdriver/_index.ja.md
@@ -3,18 +3,9 @@ title: "WebDriver"
 linkTitle: "WebDriver"
 weight: 4
 description: >
-  WebDriver drives a browser natively, learn more about it.
+  WebDriverはブラウザをネイティブに操作します。詳細については、こちらをご覧ください。
 aliases: ["/documentation/ja/webdriver/"]
 ---
-
-{{% pageinfo color="warning" %}}
-<p class="lead">
-   <i class="fas fa-language display-4"></i> 
-   Page being translated from 
-   English to Japanese. Do you speak Japanese? Help us to translate
-   it by sending us pull requests!
-</p>
-{{% /pageinfo %}}
 
 WebDriverは、ユーザーがローカルまたはSeleniumサーバーを使用するリモートマシンで行うように、ブラウザをネイティブに動かし、ブラウザの自動化に関して大きく前進します。
 


### PR DESCRIPTION
### Description
Japanese Translation of  documentation top page (/ja/documentation/)
Transelation of _index.ja.md and some pages' descriptions.

I coudn't find this page's issue.
https://github.com/SeleniumHQ/seleniumhq.github.io/issues  

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
