### PR TITLE
create first script page

### DIFF
--- a/website_and_docs/content/documentation/_index.en.md
+++ b/website_and_docs/content/documentation/_index.en.md
@@ -26,128 +26,83 @@ to further an open discussion around automation of the web platform.
 The project organises [an annual conference](//seleniumconf.com/)
 to teach and nurture the community.
 
-At the core of Selenium is [WebDriver](/documentation/webdriver), 
+At the core of Selenium is [WebDriver]({{< ref "webdriver" >}}), 
 an interface to write instruction sets that can be run interchangeably in many 
-browsers. Here is one of the simplest instructions you can make:
+browsers. Once you've installed everything, only a few lines of code get you inside
+a browser. You can find a more comprehensive example in [Writing your first Selenium script]({{< ref "first_script.md" >}})
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
+{{< tab header="Java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.support.ui.WebDriverWait;
-import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
-import java.time.Duration;
+import org.openqa.selenium.chrome.ChromeDriver;
 
 public class HelloSelenium {
-
     public static void main(String[] args) {
-        WebDriver driver = new FirefoxDriver();
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
-        try {
-            driver.get("https://google.com/ncr");
-            driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER);
-            WebElement firstResult = wait.until(presenceOfElementLocated(By.cssSelector("h3")));
-            System.out.println(firstResult.getAttribute("textContent"));
-        } finally {
-            driver.quit();
-        }
+        WebDriver driver = new ChromeDriver();
+
+        driver.get("https://selenium.dev");
+
+        driver.quit();
     }
 }
-  {{< /tab >}}
-  {{< tab header="Python" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
 from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support.expected_conditions import presence_of_element_located
 
-#This example requires Selenium WebDriver 3.13 or newer
-with webdriver.Firefox() as driver:
-    wait = WebDriverWait(driver, 10)
-    driver.get("https://google.com/ncr")
-    driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3")))
-    print(first_result.get_attribute("textContent"))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-using System;
+
+driver = webdriver.Chrome()
+
+driver.get("http://selenium.dev")
+
+driver.quit()
+
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using OpenQA.Selenium;
-using OpenQA.Selenium.Firefox;
-using OpenQA.Selenium.Support.UI;
+using OpenQA.Selenium.Chrome;
 
 class HelloSelenium {
-  static void Main() {
-    using(IWebDriver driver = new FirefoxDriver()) {
-      WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-      driver.Navigate().GoToUrl("https://www.google.com/ncr");
-      driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
-      wait.Until(webDriver => webDriver.FindElement(By.CssSelector("h3")).Displayed);
-      IWebElement firstResult = driver.FindElement(By.CssSelector("h3"));
-      Console.WriteLine(firstResult.GetAttribute("textContent"));
+    static void Main() {
+        var driver = new ChromeDriver();
+
+        driver.Navigate().GoToUrl("https://selenium.dev");
+
+        driver.Quit();
     }
-  }
 }
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 require 'selenium-webdriver'
 
-driver = Selenium::WebDriver.for :firefox
-wait = Selenium::WebDriver::Wait.new(timeout: 10)
+driver = Selenium::WebDriver.for :chrome
 
-begin
-  driver.get 'https://google.com/ncr'
-  driver.find_element(name: 'q').send_keys 'cheese', :return
-  first_result = wait.until { driver.find_element(css: 'h3') }
-  puts first_result.attribute('textContent')
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+driver.get 'https://selenium.dev'
+
+driver.quit
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 const {Builder, By, Key, until} = require('selenium-webdriver');
 
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    try {
-        // Navigate to Url
-        await driver.get('https://www.google.com');
+(async function helloSelenium() {
+    let driver = await new Builder().forBrowser('chrome').build();
 
-        // Enter text "cheese" and perform keyboard action "Enter"
-        await driver.findElement(By.name('q')).sendKeys('cheese', Key.ENTER);
+    await driver.get('https://selenium.dev');
 
-        let firstResult = await driver.wait(until.elementLocated(By.css('h3')), 10000);
-
-        console.log(await firstResult.getAttribute('textContent'));
-    }
-    finally{
-        await driver.quit();
-    }
+    await driver.quit();
 })();
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 import org.openqa.selenium.By
-import org.openqa.selenium.Keys
-import org.openqa.selenium.firefox.FirefoxDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated
-import org.openqa.selenium.support.ui.WebDriverWait
-import java.time.Duration
+import org.openqa.selenium.chrome.ChromeDriver
 
 fun main() {
-    val driver = FirefoxDriver()
-    val wait = WebDriverWait(driver, Duration.ofSeconds(10))
-    try {
-        driver.get("https://google.com/ncr")
-        driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER)
-        val firstResult = wait.until(presenceOfElementLocated(By.cssSelector("h3")))
-        println(firstResult.getAttribute("textContent"))
-    } finally {
-        driver.quit()
-    }
+    val driver = ChromeDriver()
+
+    driver.get("https://selenium.dev")
+
+    driver.quit()
 }
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 See the [Overview]({{< ref "overview" >}}) to check the different project 

--- a/website_and_docs/content/documentation/_index.ja.md
+++ b/website_and_docs/content/documentation/_index.ja.md
@@ -17,124 +17,79 @@ Seleniumはウェブプラットフォームの自動化のより開かれた議
 Seleniumの中核は[WebDriver]({{< ref "/webdriver.md" >}})であり、様々なブラウザーを変えてインストラクション集を実行できるインターフェースです。これは作りえる一番基本的な
 インストラクションの一つです:
 
+
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
+{{< tab header="Java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.support.ui.WebDriverWait;
-import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
-import java.time.Duration;
+import org.openqa.selenium.chrome.ChromeDriver;
 
 public class HelloSelenium {
-
     public static void main(String[] args) {
-        WebDriver driver = new FirefoxDriver();
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
-        try {
-            driver.get("https://google.com/ncr");
-            driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER);
-            WebElement firstResult = wait.until(presenceOfElementLocated(By.cssSelector("h3")));
-            System.out.println(firstResult.getAttribute("textContent"));
-        } finally {
-            driver.quit();
-        }
+        WebDriver driver = new ChromeDriver();
+
+        driver.get("https://selenium.dev");
+
+        driver.quit();
     }
 }
-  {{< /tab >}}
-  {{< tab header="Python" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
 from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support.expected_conditions import presence_of_element_located
 
-#This example requires Selenium WebDriver 3.13 or newer
-with webdriver.Firefox() as driver:
-    wait = WebDriverWait(driver, 10)
-    driver.get("https://google.com/ncr")
-    driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3")))
-    print(first_result.get_attribute("textContent"))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-using System;
+
+driver = webdriver.Chrome()
+
+driver.get("http://selenium.dev")
+
+driver.quit()
+
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using OpenQA.Selenium;
-using OpenQA.Selenium.Firefox;
-using OpenQA.Selenium.Support.UI;
+using OpenQA.Selenium.Chrome;
 
 class HelloSelenium {
-  static void Main() {
-    using(IWebDriver driver = new FirefoxDriver()) {
-      WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-      driver.Navigate().GoToUrl("https://www.google.com/ncr");
-      driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
-      wait.Until(webDriver => webDriver.FindElement(By.CssSelector("h3")).Displayed);
-      IWebElement firstResult = driver.FindElement(By.CssSelector("h3"));
-      Console.WriteLine(firstResult.GetAttribute("textContent"));
+    static void Main() {
+        var driver = new ChromeDriver();
+
+        driver.Navigate().GoToUrl("https://selenium.dev");
+
+        driver.Quit();
     }
-  }
 }
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 require 'selenium-webdriver'
 
-driver = Selenium::WebDriver.for :firefox
-wait = Selenium::WebDriver::Wait.new(timeout: 10)
+driver = Selenium::WebDriver.for :chrome
 
-begin
-  driver.get 'https://google.com/ncr'
-  driver.find_element(name: 'q').send_keys 'cheese', :return
-  first_result = wait.until { driver.find_element(css: 'h3') }
-  puts first_result.attribute('textContent')
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+driver.get 'https://selenium.dev'
+
+driver.quit
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 const {Builder, By, Key, until} = require('selenium-webdriver');
 
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    try {
-        // Navigate to Url
-        await driver.get('https://www.google.com');
+(async function helloSelenium() {
+    let driver = await new Builder().forBrowser('chrome').build();
 
-        // Enter text "cheese" and perform keyboard action "Enter"
-        await driver.findElement(By.name('q')).sendKeys('cheese', Key.ENTER);
+    await driver.get('https://selenium.dev');
 
-        let firstResult = await driver.wait(until.elementLocated(By.css('h3')), 10000);
-
-        console.log(await firstResult.getAttribute('textContent'));
-    }
-    finally{
-        await driver.quit();
-    }
+    await driver.quit();
 })();
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 import org.openqa.selenium.By
-import org.openqa.selenium.Keys
-import org.openqa.selenium.firefox.FirefoxDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated
-import org.openqa.selenium.support.ui.WebDriverWait
-import java.time.Duration
+import org.openqa.selenium.chrome.ChromeDriver
 
 fun main() {
-    val driver = FirefoxDriver()
-    val wait = WebDriverWait(driver, Duration.ofSeconds(10))
-    try {
-        driver.get("https://google.com/ncr")
-        driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER)
-        val firstResult = wait.until(presenceOfElementLocated(By.cssSelector("h3")))
-        println(firstResult.getAttribute("textContent"))
-    } finally {
-        driver.quit()
-    }
+    val driver = ChromeDriver()
+
+    driver.get("https://selenium.dev")
+
+    driver.quit()
 }
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 

--- a/website_and_docs/content/documentation/_index.pt-br.md
+++ b/website_and_docs/content/documentation/_index.pt-br.md
@@ -39,125 +39,78 @@ navegadores. Aqui está uma das instruções mais simples que você pode fazer:
 
 
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
+{{< tab header="Java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.support.ui.WebDriverWait;
-import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
-import java.time.Duration;
+import org.openqa.selenium.chrome.ChromeDriver;
 
 public class HelloSelenium {
-
     public static void main(String[] args) {
-        WebDriver driver = new FirefoxDriver();
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
-        try {
-            driver.get("https://google.com/ncr");
-            driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER);
-            WebElement firstResult = wait.until(presenceOfElementLocated(By.cssSelector("h3")));
-            System.out.println(firstResult.getAttribute("textContent"));
-        } finally {
-            driver.quit();
-        }
+        WebDriver driver = new ChromeDriver();
+
+        driver.get("https://selenium.dev");
+
+        driver.quit();
     }
 }
-  {{< /tab >}}
-  {{< tab header="Python" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
 from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support.expected_conditions import presence_of_element_located
 
-#This example requires Selenium WebDriver 3.13 or newer
-with webdriver.Firefox() as driver:
-    wait = WebDriverWait(driver, 10)
-    driver.get("https://google.com/ncr")
-    driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3")))
-    print(first_result.get_attribute("textContent"))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-using System;
+
+driver = webdriver.Chrome()
+
+driver.get("http://selenium.dev")
+
+driver.quit()
+
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using OpenQA.Selenium;
-using OpenQA.Selenium.Firefox;
-using OpenQA.Selenium.Support.UI;
+using OpenQA.Selenium.Chrome;
 
 class HelloSelenium {
-  static void Main() {
-    using(IWebDriver driver = new FirefoxDriver()) {
-      WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-      driver.Navigate().GoToUrl("https://www.google.com/ncr");
-      driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
-      wait.Until(webDriver => webDriver.FindElement(By.CssSelector("h3")).Displayed);
-      IWebElement firstResult = driver.FindElement(By.CssSelector("h3"));
-      Console.WriteLine(firstResult.GetAttribute("textContent"));
+    static void Main() {
+        var driver = new ChromeDriver();
+
+        driver.Navigate().GoToUrl("https://selenium.dev");
+
+        driver.Quit();
     }
-  }
 }
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 require 'selenium-webdriver'
 
-driver = Selenium::WebDriver.for :firefox
-wait = Selenium::WebDriver::Wait.new(timeout: 10)
+driver = Selenium::WebDriver.for :chrome
 
-begin
-  driver.get 'https://google.com/ncr'
-  driver.find_element(name: 'q').send_keys 'cheese', :return
-  first_result = wait.until { driver.find_element(css: 'h3') }
-  puts first_result.attribute('textContent')
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+driver.get 'https://selenium.dev'
+
+driver.quit
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 const {Builder, By, Key, until} = require('selenium-webdriver');
 
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    try {
-        // Navigate to Url
-        await driver.get('https://www.google.com');
+(async function helloSelenium() {
+    let driver = await new Builder().forBrowser('chrome').build();
 
-        // Enter text "cheese" and perform keyboard action "Enter"
-        await driver.findElement(By.name('q')).sendKeys('cheese', Key.ENTER);
+    await driver.get('https://selenium.dev');
 
-        let firstResult = await driver.wait(until.elementLocated(By.css('h3')), 10000);
-
-        console.log(await firstResult.getAttribute('textContent'));
-    }
-    finally{
-       await driver.quit();
-    }
+    await driver.quit();
 })();
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 import org.openqa.selenium.By
-import org.openqa.selenium.Keys
-import org.openqa.selenium.firefox.FirefoxDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated
-import org.openqa.selenium.support.ui.WebDriverWait
-import java.time.Duration
+import org.openqa.selenium.chrome.ChromeDriver
 
 fun main() {
-    val driver = FirefoxDriver()
-    val wait = WebDriverWait(driver, Duration.ofSeconds(10))
-    try {
-        driver.get("https://google.com/ncr")
-        driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER)
-        val firstResult = wait.until(presenceOfElementLocated(By.cssSelector("h3")))
-        println(firstResult.getAttribute("textContent"))
-    } finally {
-        driver.quit()
-    }
-}
-  {{< /tab >}}
-{{< /tabpane >}}
+    val driver = ChromeDriver()
 
+    driver.get("https://selenium.dev")
+
+    driver.quit()
+}
+{{< /tab >}}
+{{< /tabpane >}}
 
 
 See the [Overview]({{< ref "overview" >}}) to check the different project 

--- a/website_and_docs/content/documentation/_index.zh-cn.md
+++ b/website_and_docs/content/documentation/_index.zh-cn.md
@@ -22,124 +22,79 @@ Selenium 的核心是 [WebDriver]({{< ref "/webdriver.md" >}})，这是一个编
 这里有一个最简单的说明：
 
 
+
 {{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
+{{< tab header="Java" >}}
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.support.ui.WebDriverWait;
-import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
-import java.time.Duration;
+import org.openqa.selenium.chrome.ChromeDriver;
 
 public class HelloSelenium {
-
     public static void main(String[] args) {
-        WebDriver driver = new FirefoxDriver();
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
-        try {
-            driver.get("https://google.com/ncr");
-            driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER);
-            WebElement firstResult = wait.until(presenceOfElementLocated(By.cssSelector("h3")));
-            System.out.println(firstResult.getAttribute("textContent"));
-        } finally {
-            driver.quit();
-        }
+        WebDriver driver = new ChromeDriver();
+
+        driver.get("https://selenium.dev");
+
+        driver.quit();
     }
 }
-  {{< /tab >}}
-  {{< tab header="Python" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
 from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support.expected_conditions import presence_of_element_located
 
-#This example requires Selenium WebDriver 3.13 or newer
-with webdriver.Firefox() as driver:
-    wait = WebDriverWait(driver, 10)
-    driver.get("https://google.com/ncr")
-    driver.find_element(By.NAME, "q").send_keys("cheese" + Keys.RETURN)
-    first_result = wait.until(presence_of_element_located((By.CSS_SELECTOR, "h3")))
-    print(first_result.get_attribute("textContent"))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-using System;
+
+driver = webdriver.Chrome()
+
+driver.get("http://selenium.dev")
+
+driver.quit()
+
+{{< /tab >}}
+{{< tab header="CSharp" >}}
 using OpenQA.Selenium;
-using OpenQA.Selenium.Firefox;
-using OpenQA.Selenium.Support.UI;
+using OpenQA.Selenium.Chrome;
 
 class HelloSelenium {
-  static void Main() {
-    using(IWebDriver driver = new FirefoxDriver()) {
-      WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-      driver.Navigate().GoToUrl("https://www.google.com/ncr");
-      driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
-      wait.Until(webDriver => webDriver.FindElement(By.CssSelector("h3")).Displayed);
-      IWebElement firstResult = driver.FindElement(By.CssSelector("h3"));
-      Console.WriteLine(firstResult.GetAttribute("textContent"));
+    static void Main() {
+        var driver = new ChromeDriver();
+
+        driver.Navigate().GoToUrl("https://selenium.dev");
+
+        driver.Quit();
     }
-  }
 }
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
 require 'selenium-webdriver'
 
-driver = Selenium::WebDriver.for :firefox
-wait = Selenium::WebDriver::Wait.new(timeout: 10)
+driver = Selenium::WebDriver.for :chrome
 
-begin
-  driver.get 'https://google.com/ncr'
-  driver.find_element(name: 'q').send_keys 'cheese', :return
-  first_result = wait.until { driver.find_element(css: 'h3') }
-  puts first_result.attribute('textContent')
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
+driver.get 'https://selenium.dev'
+
+driver.quit
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
 const {Builder, By, Key, until} = require('selenium-webdriver');
 
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    try {
-        // Navigate to Url
-        await driver.get('https://www.google.com');
+(async function helloSelenium() {
+    let driver = await new Builder().forBrowser('chrome').build();
 
-        // Enter text "cheese" and perform keyboard action "Enter"
-        await driver.findElement(By.name('q')).sendKeys('cheese', Key.ENTER);
+    await driver.get('https://selenium.dev');
 
-        let firstResult = await driver.wait(until.elementLocated(By.css('h3')), 10000);
-
-        console.log(await firstResult.getAttribute('textContent'));
-    }
-    finally{
-       await driver.quit();
-    }
+    await driver.quit();
 })();
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
 import org.openqa.selenium.By
-import org.openqa.selenium.Keys
-import org.openqa.selenium.firefox.FirefoxDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated
-import org.openqa.selenium.support.ui.WebDriverWait
-import java.time.Duration
+import org.openqa.selenium.chrome.ChromeDriver
 
 fun main() {
-    val driver = FirefoxDriver()
-    val wait = WebDriverWait(driver, Duration.ofSeconds(10))
-    try {
-        driver.get("https://google.com/ncr")
-        driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER)
-        val firstResult = wait.until(presenceOfElementLocated(By.cssSelector("h3")))
-        println(firstResult.getAttribute("textContent"))
-    } finally {
-        driver.quit()
-    }
+    val driver = ChromeDriver()
+
+    driver.get("https://selenium.dev")
+
+    driver.quit()
 }
-  {{< /tab >}}
+{{< /tab >}}
 {{< /tabpane >}}
 
 

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
@@ -1,0 +1,324 @@
+---
+title: "Writing your first Selenium script"
+linkTitle: "First Script"
+weight: 3
+description: >
+    Step-by-step instructions for constructing a Selenium script
+---
+
+Once you have [Selenium installed]({{< ref "install_selenium_library.md" >}}) and
+[Drivers installed]({{< ref "install_drivers.md" >}}), you're ready to write Selenium code.
+
+Everything Selenium does is send the browser commands to do something or send requests for information.
+Most of what you'll do with Selenium is a combination of these basic commands:
+
+1. Start the session with a driver instance
+
+   {{< tabpane langEqualsHeader=true >}}
+   {{< tab header="Java" >}}
+   WebDriver driver = new ChromeDriver();
+   {{< /tab >}}
+   {{< tab header="Python" >}}
+   driver = webdriver.Chrome()
+   {{< /tab >}}
+   {{< tab header="CSharp" >}}
+   var driver = new ChromeDriver();
+   {{< /tab >}}
+   {{< tab header="Ruby" >}}
+   driver = Selenium::WebDriver.for :chrome
+   {{< /tab >}}
+   {{< tab header="JavaScript" >}}
+   let driver = await new Builder().forBrowser('chrome').build();
+   {{< /tab >}}
+   {{< tab header="Kotlin" >}}
+   val driver = ChromeDriver()
+   {{< /tab >}}
+   {{< /tabpane >}}
+
+2. Send command for browser to [Navigate]({{< ref "/documentation/webdriver/browser/navigation.md" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.get("https://google.com");
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.get("http://www.google.com")
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Navigate().GoToUrl("https://www.google.com");
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.get 'https://google.com'
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.get('https://www.google.com');
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.get("https://google.com")
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+3. Request [information about the browser]({{< ref "/documentation/webdriver/browser" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.getTitle(); // => "Google"
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.title() # => "Google"
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Title; // => "Google"
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.title # => 'Google'
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.getTitle(); // => "Google"
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.getTitle() // => "Google"
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+4. Send command to [find an element]({{< ref "/documentation/webdriver/elements" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    WebElement searchBox = driver.findElement(By.name("q"));
+    WebElement searchButton = driver.findElement(By.name("btnK"));
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    search_box = driver.find_element(By.NAME, "q")
+    search_button = driver.find_element(By.NAME, "btnK")
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    var searchBox = driver.FindElement(By.Name("q"));
+    var searchButton = driver.FindElement(By.Name("btnK"))
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    search_box = driver.find_element(name: 'q')
+    search_button = driver.find_element(name: 'btnK')
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    let searchBox = await driver.findElement(By.name('q'));
+    let searchButton = await driver.findElement(By.name('btnK'));
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    val searchBox = driver.findElement(By.name("q"));
+    val searchButton = driver.findElement(By.name("btnK"))
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+5. Send command to [take action on an element]()
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    search_box.send_keys("Selenium")
+    search_button.click()
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    searchBox.SendKeys("Selenium");
+    searchButton.Click();
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    search_box.send_keys 'Selenium'
+    search_button.click
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await searchBox.sendKeys('Selenium');
+    await searchButton.click();
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+6. Request [information about an element]()
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.find_element(name: 'q').attribute('value') # => "Selenium"
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.findElement(By.name('q')).getAttribute("value"); // => 'Selenium'
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+7. End the session 
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.quit();
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.quit()
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Quit();
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.quit
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.quit();
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.quit()
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+Let's combine these 7 things into a complete script, including the libraries that need to be used:
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="Java" >}}
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+public class HelloSelenium {
+    public static void main(String[] args) {
+        WebDriver driver = new ChromeDriver();
+
+        driver.get("https://google.com");
+        
+        driver.getTitle(); // => "Google"
+
+        WebElement searchBox = driver.findElement(By.name("q"));
+        WebElement searchButton = driver.findElement(By.name("btnK"))
+        
+        searchBox.sendKeys("Selenium");
+        searchButton.click();
+
+        driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+
+        driver.quit();
+    }
+}
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+
+driver = webdriver.Chrome()
+
+driver.get("http://www.google.com")
+
+driver.title() # => "Google"
+
+search_box = driver.find_element(By.NAME, "q")
+search_button = driver.find_element(By.NAME, "btnK")
+
+search_box.send_keys("Selenium")
+search_button.click()
+
+driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+
+driver.quit()
+
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+class HelloSelenium {
+    static void Main() {
+        var driver = new ChromeDriver();
+
+        driver.Navigate().GoToUrl("https://www.google.com");
+
+        driver.Title; // => "Google"
+
+        var searchBox = driver.FindElement(By.Name("q"));
+        var searchButton = driver.FindElement(By.Name("btnK"))
+
+        searchBox.SendKeys("Selenium");
+        searchButton.Click();
+
+        driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
+
+        driver.Quit();
+    }
+}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+driver.get 'https://google.com'
+
+driver.title # => 'Google'
+
+search_box = driver.find_element(name: 'q')
+search_button = driver.find_element(name: 'btnK')
+
+search_box.send_keys 'Selenium'
+search_button.click
+
+driver.find_element(name: 'q').attribute('value') # => "Selenium"
+
+driver.quit
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+const {Builder, By, Key, until} = require('selenium-webdriver');
+
+(async function helloSelenium() {
+    let driver = await new Builder().forBrowser('chrome').build();
+
+    await driver.get('https://www.google.com');
+
+    await driver.getTitle(); // => "Google"
+
+    let searchBox = await driver.findElement(By.name('q'));
+    let searchButton = await driver.findElement(By.name('btnK'));
+
+    await searchBox.sendKeys('Selenium');
+    await searchButton.click();
+
+    await driver.findElement(By.name('q')).getAttribute("value"); // => 'Selenium'
+
+    await driver.quit();
+})();
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+import org.openqa.selenium.By
+import org.openqa.selenium.chrome.ChromeDriver
+
+fun main() {
+    val driver = ChromeDriver()
+
+    driver.get("https://google.com")
+
+    driver.getTitle(); // => "Google"
+
+    val searchBox = driver.findElement(By.name("q"));
+    val searchButton = driver.findElement(By.name("btnK"))
+
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+
+    driver.quit()
+}
+{{< /tab >}}
+{{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
@@ -1,0 +1,325 @@
+---
+title: "Writing your first Selenium script"
+linkTitle: "First Script"
+weight: 3
+needsTranslation: true
+description: >
+    Step-by-step instructions for constructing a Selenium script
+---
+
+Once you have [Selenium installed]({{< ref "install_selenium_library.md" >}}) and
+[Drivers installed]({{< ref "install_drivers.md" >}}), you're ready to write Selenium code.
+
+Everything Selenium does is send the browser commands to do something or send requests for information.
+Most of what you'll do with Selenium is a combination of these basic commands:
+
+1. Start the session with a driver instance
+
+   {{< tabpane langEqualsHeader=true >}}
+   {{< tab header="Java" >}}
+   WebDriver driver = new ChromeDriver();
+   {{< /tab >}}
+   {{< tab header="Python" >}}
+   driver = webdriver.Chrome()
+   {{< /tab >}}
+   {{< tab header="CSharp" >}}
+   var driver = new ChromeDriver();
+   {{< /tab >}}
+   {{< tab header="Ruby" >}}
+   driver = Selenium::WebDriver.for :chrome
+   {{< /tab >}}
+   {{< tab header="JavaScript" >}}
+   let driver = await new Builder().forBrowser('chrome').build();
+   {{< /tab >}}
+   {{< tab header="Kotlin" >}}
+   val driver = ChromeDriver()
+   {{< /tab >}}
+   {{< /tabpane >}}
+
+2. Send command for browser to [Navigate]({{< ref "/documentation/webdriver/browser/navigation.md" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.get("https://google.com");
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.get("http://www.google.com")
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Navigate().GoToUrl("https://www.google.com");
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.get 'https://google.com'
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.get('https://www.google.com');
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.get("https://google.com")
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+3. Request [information about the browser]({{< ref "/documentation/webdriver/browser" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.getTitle(); // => "Google"
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.title() # => "Google"
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Title; // => "Google"
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.title # => 'Google'
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.getTitle(); // => "Google"
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.getTitle() // => "Google"
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+4. Send command to [find an element]({{< ref "/documentation/webdriver/elements" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    WebElement searchBox = driver.findElement(By.name("q"));
+    WebElement searchButton = driver.findElement(By.name("btnK"));
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    search_box = driver.find_element(By.NAME, "q")
+    search_button = driver.find_element(By.NAME, "btnK")
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    var searchBox = driver.FindElement(By.Name("q"));
+    var searchButton = driver.FindElement(By.Name("btnK"))
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    search_box = driver.find_element(name: 'q')
+    search_button = driver.find_element(name: 'btnK')
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    let searchBox = await driver.findElement(By.name('q'));
+    let searchButton = await driver.findElement(By.name('btnK'));
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    val searchBox = driver.findElement(By.name("q"));
+    val searchButton = driver.findElement(By.name("btnK"))
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+5. Send command to [take action on an element]()
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    search_box.send_keys("Selenium")
+    search_button.click()
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    searchBox.SendKeys("Selenium");
+    searchButton.Click();
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    search_box.send_keys 'Selenium'
+    search_button.click
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await searchBox.sendKeys('Selenium');
+    await searchButton.click();
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+6. Request [information about an element]()
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.find_element(name: 'q').attribute('value') # => "Selenium"
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.findElement(By.name('q')).getAttribute("value"); // => 'Selenium'
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+7. End the session 
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.quit();
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.quit()
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Quit();
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.quit
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.quit();
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.quit()
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+Let's combine these 7 things into a complete script, including the libraries that need to be used:
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="Java" >}}
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+public class HelloSelenium {
+    public static void main(String[] args) {
+        WebDriver driver = new ChromeDriver();
+
+        driver.get("https://google.com");
+        
+        driver.getTitle(); // => "Google"
+
+        WebElement searchBox = driver.findElement(By.name("q"));
+        WebElement searchButton = driver.findElement(By.name("btnK"))
+        
+        searchBox.sendKeys("Selenium");
+        searchButton.click();
+
+        driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+
+        driver.quit();
+    }
+}
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+
+driver = webdriver.Chrome()
+
+driver.get("http://www.google.com")
+
+driver.title() # => "Google"
+
+search_box = driver.find_element(By.NAME, "q")
+search_button = driver.find_element(By.NAME, "btnK")
+
+search_box.send_keys("Selenium")
+search_button.click()
+
+driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+
+driver.quit()
+
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+class HelloSelenium {
+    static void Main() {
+        var driver = new ChromeDriver();
+
+        driver.Navigate().GoToUrl("https://www.google.com");
+
+        driver.Title; // => "Google"
+
+        var searchBox = driver.FindElement(By.Name("q"));
+        var searchButton = driver.FindElement(By.Name("btnK"))
+
+        searchBox.SendKeys("Selenium");
+        searchButton.Click();
+
+        driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
+
+        driver.Quit();
+    }
+}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+driver.get 'https://google.com'
+
+driver.title # => 'Google'
+
+search_box = driver.find_element(name: 'q')
+search_button = driver.find_element(name: 'btnK')
+
+search_box.send_keys 'Selenium'
+search_button.click
+
+driver.find_element(name: 'q').attribute('value') # => "Selenium"
+
+driver.quit
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+const {Builder, By, Key, until} = require('selenium-webdriver');
+
+(async function helloSelenium() {
+    let driver = await new Builder().forBrowser('chrome').build();
+
+    await driver.get('https://www.google.com');
+
+    await driver.getTitle(); // => "Google"
+
+    let searchBox = await driver.findElement(By.name('q'));
+    let searchButton = await driver.findElement(By.name('btnK'));
+
+    await searchBox.sendKeys('Selenium');
+    await searchButton.click();
+
+    await driver.findElement(By.name('q')).getAttribute("value"); // => 'Selenium'
+
+    await driver.quit();
+})();
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+import org.openqa.selenium.By
+import org.openqa.selenium.chrome.ChromeDriver
+
+fun main() {
+    val driver = ChromeDriver()
+
+    driver.get("https://google.com")
+
+    driver.getTitle(); // => "Google"
+
+    val searchBox = driver.findElement(By.name("q"));
+    val searchButton = driver.findElement(By.name("btnK"))
+
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+
+    driver.quit()
+}
+{{< /tab >}}
+{{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
@@ -1,0 +1,326 @@
+---
+title: "Writing your first Selenium script"
+linkTitle: "First Script"
+weight: 3
+needsTranslation: true
+description: >
+    Step-by-step instructions for constructing a Selenium script
+---
+
+Once you have [Selenium installed]({{< ref "install_selenium_library.md" >}}) and
+[Drivers installed]({{< ref "install_drivers.md" >}}), you're ready to write Selenium code.
+
+Everything Selenium does is send the browser commands to do something or send requests for information.
+Most of what you'll do with Selenium is a combination of these basic commands:
+
+1. Start the session with a driver instance
+
+   {{< tabpane langEqualsHeader=true >}}
+   {{< tab header="Java" >}}
+   WebDriver driver = new ChromeDriver();
+   {{< /tab >}}
+   {{< tab header="Python" >}}
+   driver = webdriver.Chrome()
+   {{< /tab >}}
+   {{< tab header="CSharp" >}}
+   var driver = new ChromeDriver();
+   {{< /tab >}}
+   {{< tab header="Ruby" >}}
+   driver = Selenium::WebDriver.for :chrome
+   {{< /tab >}}
+   {{< tab header="JavaScript" >}}
+   let driver = await new Builder().forBrowser('chrome').build();
+   {{< /tab >}}
+   {{< tab header="Kotlin" >}}
+   val driver = ChromeDriver()
+   {{< /tab >}}
+   {{< /tabpane >}}
+
+2. Send command for browser to [Navigate]({{< ref "/documentation/webdriver/browser/navigation.md" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.get("https://google.com");
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.get("http://www.google.com")
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Navigate().GoToUrl("https://www.google.com");
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.get 'https://google.com'
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.get('https://www.google.com');
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.get("https://google.com")
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+3. Request [information about the browser]({{< ref "/documentation/webdriver/browser" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.getTitle(); // => "Google"
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.title() # => "Google"
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Title; // => "Google"
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.title # => 'Google'
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.getTitle(); // => "Google"
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.getTitle() // => "Google"
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+4. Send command to [find an element]({{< ref "/documentation/webdriver/elements" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    WebElement searchBox = driver.findElement(By.name("q"));
+    WebElement searchButton = driver.findElement(By.name("btnK"));
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    search_box = driver.find_element(By.NAME, "q")
+    search_button = driver.find_element(By.NAME, "btnK")
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    var searchBox = driver.FindElement(By.Name("q"));
+    var searchButton = driver.FindElement(By.Name("btnK"))
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    search_box = driver.find_element(name: 'q')
+    search_button = driver.find_element(name: 'btnK')
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    let searchBox = await driver.findElement(By.name('q'));
+    let searchButton = await driver.findElement(By.name('btnK'));
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    val searchBox = driver.findElement(By.name("q"));
+    val searchButton = driver.findElement(By.name("btnK"))
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+5. Send command to [take action on an element]()
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    search_box.send_keys("Selenium")
+    search_button.click()
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    searchBox.SendKeys("Selenium");
+    searchButton.Click();
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    search_box.send_keys 'Selenium'
+    search_button.click
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await searchBox.sendKeys('Selenium');
+    await searchButton.click();
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+6. Request [information about an element]()
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.find_element(name: 'q').attribute('value') # => "Selenium"
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.findElement(By.name('q')).getAttribute("value"); // => 'Selenium'
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+7. End the session 
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.quit();
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.quit()
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Quit();
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.quit
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.quit();
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.quit()
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+Let's combine these 7 things into a complete script, including the libraries that need to be used:
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="Java" >}}
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+public class HelloSelenium {
+    public static void main(String[] args) {
+        WebDriver driver = new ChromeDriver();
+
+        driver.get("https://google.com");
+        
+        driver.getTitle(); // => "Google"
+
+        WebElement searchBox = driver.findElement(By.name("q"));
+        WebElement searchButton = driver.findElement(By.name("btnK"))
+        
+        searchBox.sendKeys("Selenium");
+        searchButton.click();
+
+        driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+
+        driver.quit();
+    }
+}
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+
+driver = webdriver.Chrome()
+
+driver.get("http://www.google.com")
+
+driver.title() # => "Google"
+
+search_box = driver.find_element(By.NAME, "q")
+search_button = driver.find_element(By.NAME, "btnK")
+
+search_box.send_keys("Selenium")
+search_button.click()
+
+driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+
+driver.quit()
+
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+class HelloSelenium {
+    static void Main() {
+        var driver = new ChromeDriver();
+
+        driver.Navigate().GoToUrl("https://www.google.com");
+
+        driver.Title; // => "Google"
+
+        var searchBox = driver.FindElement(By.Name("q"));
+        var searchButton = driver.FindElement(By.Name("btnK"))
+
+        searchBox.SendKeys("Selenium");
+        searchButton.Click();
+
+        driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
+
+        driver.Quit();
+    }
+}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+driver.get 'https://google.com'
+
+driver.title # => 'Google'
+
+search_box = driver.find_element(name: 'q')
+search_button = driver.find_element(name: 'btnK')
+
+search_box.send_keys 'Selenium'
+search_button.click
+
+driver.find_element(name: 'q').attribute('value') # => "Selenium"
+
+driver.quit
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+const {Builder, By, Key, until} = require('selenium-webdriver');
+
+(async function helloSelenium() {
+    let driver = await new Builder().forBrowser('chrome').build();
+
+    await driver.get('https://www.google.com');
+
+    await driver.getTitle(); // => "Google"
+
+    let searchBox = await driver.findElement(By.name('q'));
+    let searchButton = await driver.findElement(By.name('btnK'));
+
+    await searchBox.sendKeys('Selenium');
+    await searchButton.click();
+
+    await driver.findElement(By.name('q')).getAttribute("value"); // => 'Selenium'
+
+    await driver.quit();
+})();
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+import org.openqa.selenium.By
+import org.openqa.selenium.chrome.ChromeDriver
+
+fun main() {
+    val driver = ChromeDriver()
+
+    driver.get("https://google.com")
+
+    driver.getTitle(); // => "Google"
+
+    val searchBox = driver.findElement(By.name("q"));
+    val searchButton = driver.findElement(By.name("btnK"))
+
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+
+    driver.quit()
+}
+{{< /tab >}}
+{{< /tabpane >}}
+

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
@@ -1,0 +1,325 @@
+---
+title: "Writing your first Selenium script"
+linkTitle: "First Script"
+weight: 3
+needsTranslation: true
+description: >
+    Step-by-step instructions for constructing a Selenium script
+---
+
+Once you have [Selenium installed]({{< ref "install_selenium_library.md" >}}) and
+[Drivers installed]({{< ref "install_drivers.md" >}}), you're ready to write Selenium code.
+
+Everything Selenium does is send the browser commands to do something or send requests for information.
+Most of what you'll do with Selenium is a combination of these basic commands:
+
+1. Start the session with a driver instance
+
+   {{< tabpane langEqualsHeader=true >}}
+   {{< tab header="Java" >}}
+   WebDriver driver = new ChromeDriver();
+   {{< /tab >}}
+   {{< tab header="Python" >}}
+   driver = webdriver.Chrome()
+   {{< /tab >}}
+   {{< tab header="CSharp" >}}
+   var driver = new ChromeDriver();
+   {{< /tab >}}
+   {{< tab header="Ruby" >}}
+   driver = Selenium::WebDriver.for :chrome
+   {{< /tab >}}
+   {{< tab header="JavaScript" >}}
+   let driver = await new Builder().forBrowser('chrome').build();
+   {{< /tab >}}
+   {{< tab header="Kotlin" >}}
+   val driver = ChromeDriver()
+   {{< /tab >}}
+   {{< /tabpane >}}
+
+2. Send command for browser to [Navigate]({{< ref "/documentation/webdriver/browser/navigation.md" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.get("https://google.com");
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.get("http://www.google.com")
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Navigate().GoToUrl("https://www.google.com");
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.get 'https://google.com'
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.get('https://www.google.com');
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.get("https://google.com")
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+3. Request [information about the browser]({{< ref "/documentation/webdriver/browser" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.getTitle(); // => "Google"
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.title() # => "Google"
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Title; // => "Google"
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.title # => 'Google'
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.getTitle(); // => "Google"
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.getTitle() // => "Google"
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+4. Send command to [find an element]({{< ref "/documentation/webdriver/elements" >}})
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    WebElement searchBox = driver.findElement(By.name("q"));
+    WebElement searchButton = driver.findElement(By.name("btnK"));
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    search_box = driver.find_element(By.NAME, "q")
+    search_button = driver.find_element(By.NAME, "btnK")
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    var searchBox = driver.FindElement(By.Name("q"));
+    var searchButton = driver.FindElement(By.Name("btnK"))
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    search_box = driver.find_element(name: 'q')
+    search_button = driver.find_element(name: 'btnK')
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    let searchBox = await driver.findElement(By.name('q'));
+    let searchButton = await driver.findElement(By.name('btnK'));
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    val searchBox = driver.findElement(By.name("q"));
+    val searchButton = driver.findElement(By.name("btnK"))
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+5. Send command to [take action on an element]()
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    search_box.send_keys("Selenium")
+    search_button.click()
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    searchBox.SendKeys("Selenium");
+    searchButton.Click();
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    search_box.send_keys 'Selenium'
+    search_button.click
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await searchBox.sendKeys('Selenium');
+    await searchButton.click();
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+6. Request [information about an element]()
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.find_element(name: 'q').attribute('value') # => "Selenium"
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.findElement(By.name('q')).getAttribute("value"); // => 'Selenium'
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+7. End the session 
+
+    {{< tabpane langEqualsHeader=true >}}
+    {{< tab header="Java" >}}
+    driver.quit();
+    {{< /tab >}}
+    {{< tab header="Python" >}}
+    driver.quit()
+    {{< /tab >}}
+    {{< tab header="CSharp" >}}
+    driver.Quit();
+    {{< /tab >}}
+    {{< tab header="Ruby" >}}
+    driver.quit
+    {{< /tab >}}
+    {{< tab header="JavaScript" >}}
+    await driver.quit();
+    {{< /tab >}}
+    {{< tab header="Kotlin" >}}
+    driver.quit()
+    {{< /tab >}}
+    {{< /tabpane >}}
+
+Let's combine these 7 things into a complete script, including the libraries that need to be used:
+
+{{< tabpane langEqualsHeader=true >}}
+{{< tab header="Java" >}}
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+public class HelloSelenium {
+    public static void main(String[] args) {
+        WebDriver driver = new ChromeDriver();
+
+        driver.get("https://google.com");
+        
+        driver.getTitle(); // => "Google"
+
+        WebElement searchBox = driver.findElement(By.name("q"));
+        WebElement searchButton = driver.findElement(By.name("btnK"))
+        
+        searchBox.sendKeys("Selenium");
+        searchButton.click();
+
+        driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+
+        driver.quit();
+    }
+}
+{{< /tab >}}
+{{< tab header="Python" >}}
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+
+driver = webdriver.Chrome()
+
+driver.get("http://www.google.com")
+
+driver.title() # => "Google"
+
+search_box = driver.find_element(By.NAME, "q")
+search_button = driver.find_element(By.NAME, "btnK")
+
+search_box.send_keys("Selenium")
+search_button.click()
+
+driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+
+driver.quit()
+
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+class HelloSelenium {
+    static void Main() {
+        var driver = new ChromeDriver();
+
+        driver.Navigate().GoToUrl("https://www.google.com");
+
+        driver.Title; // => "Google"
+
+        var searchBox = driver.FindElement(By.Name("q"));
+        var searchButton = driver.FindElement(By.Name("btnK"))
+
+        searchBox.SendKeys("Selenium");
+        searchButton.Click();
+
+        driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
+
+        driver.Quit();
+    }
+}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+require 'selenium-webdriver'
+
+driver = Selenium::WebDriver.for :chrome
+
+driver.get 'https://google.com'
+
+driver.title # => 'Google'
+
+search_box = driver.find_element(name: 'q')
+search_button = driver.find_element(name: 'btnK')
+
+search_box.send_keys 'Selenium'
+search_button.click
+
+driver.find_element(name: 'q').attribute('value') # => "Selenium"
+
+driver.quit
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+const {Builder, By, Key, until} = require('selenium-webdriver');
+
+(async function helloSelenium() {
+    let driver = await new Builder().forBrowser('chrome').build();
+
+    await driver.get('https://www.google.com');
+
+    await driver.getTitle(); // => "Google"
+
+    let searchBox = await driver.findElement(By.name('q'));
+    let searchButton = await driver.findElement(By.name('btnK'));
+
+    await searchBox.sendKeys('Selenium');
+    await searchButton.click();
+
+    await driver.findElement(By.name('q')).getAttribute("value"); // => 'Selenium'
+
+    await driver.quit();
+})();
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+import org.openqa.selenium.By
+import org.openqa.selenium.chrome.ChromeDriver
+
+fun main() {
+    val driver = ChromeDriver()
+
+    driver.get("https://google.com")
+
+    driver.getTitle(); // => "Google"
+
+    val searchBox = driver.findElement(By.name("q"));
+    val searchButton = driver.findElement(By.name("btnK"))
+
+    searchBox.sendKeys("Selenium");
+    searchButton.click();
+
+    driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
+
+    driver.quit()
+}
+{{< /tab >}}
+{{< /tabpane >}}


### PR DESCRIPTION
The example code on the main docs page is more complicated than I think we should be showing right off. I've replaced it with a trivial example that's easy to look at, but maybe I've gone too far the other way?

The code to do a Google search I moved to a "first script" page so that we can put the commands in context of what kind of interaction it is. I'm doing this part now and holding off on all other code examples, mostly to provide structure for how I'm organizing other pages in browser & element sections.