### PR TITLE
Update select_elements.en.md

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/select_elements.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/select_elements.en.md
@@ -187,7 +187,7 @@ the `<select>` element contains:
 List<WebElement> allAvailableOptions = selectObject.getOptions();
   {{< /tab >}}
   {{< tab header="Python" >}}
-# Return a list[WebElement] of options that the &lt;select&gt; element contains
+# Return a list[WebElement] of options that the <select> element contains
 all_available_options = select_object.options
   {{< /tab >}}
   {{< tab header="CSharp" >}}
@@ -195,7 +195,7 @@ all_available_options = select_object.options
 IList<IWebElement> allAvailableOptions = selectObject.Options;
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-# Return an Array[Element] of options that the &lt;select&gt; element contains
+# Return an Array[Element] of options that the <select> element contains
 all_available_options = select_object.options
   {{< /tab >}}
   {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/elements/select_elements.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/select_elements.ja.md
@@ -182,7 +182,7 @@ val firstSelectedOption = selectObject.firstSelectedOption
 List<WebElement> allAvailableOptions = selectObject.getOptions();
   {{< /tab >}}
   {{< tab header="Python" >}}
-# Return a list[WebElement] of options that the &lt;select&gt; element contains
+# Return a list[WebElement] of options that the <select> element contains
 all_available_options = select_object.options
   {{< /tab >}}
   {{< tab header="CSharp" >}}
@@ -190,7 +190,7 @@ all_available_options = select_object.options
 IList<IWebElement> allAvailableOptions = selectObject.Options;
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-# Return an Array[Element] of options that the &lt;select&gt; element contains
+# Return an Array[Element] of options that the <select> element contains
 all_available_options = select_object.options
   {{< /tab >}}
   {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/elements/select_elements.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/select_elements.pt-br.md
@@ -187,7 +187,7 @@ o elemento `<select>` contém:
 List<WebElement> allAvailableOptions = selectObject.getOptions();
   {{< /tab >}}
   {{< tab header="Python" >}}
-# Return a list[WebElement] of options that the &lt;select&gt; element contains
+# Return a list[WebElement] of options that the <select> element contains
 all_available_options = select_object.options
   {{< /tab >}}
   {{< tab header="CSharp" >}}
@@ -195,7 +195,7 @@ all_available_options = select_object.options
 IList<IWebElement> allAvailableOptions = selectObject.Options;
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-# Return an Array[Element] of options that the &lt;select&gt; element contains
+# Return an Array[Element] of options that the <select> element contains
 all_available_options = select_object.options
   {{< /tab >}}
   {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/elements/select_elements.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/select_elements.zh-cn.md
@@ -183,7 +183,7 @@ val firstSelectedOption = selectObject.firstSelectedOption
 List<WebElement> allAvailableOptions = selectObject.getOptions();
   {{< /tab >}}
   {{< tab header="Python" >}}
-# Return a list[WebElement] of options that the &lt;select&gt; element contains
+# Return a list[WebElement] of options that the <select> element contains
 all_available_options = select_object.options
   {{< /tab >}}
   {{< tab header="CSharp" >}}
@@ -191,7 +191,7 @@ all_available_options = select_object.options
 IList<IWebElement> allAvailableOptions = selectObject.Options;
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-# Return an Array[Element] of options that the &lt;select&gt; element contains
+# Return an Array[Element] of options that the <select> element contains
 all_available_options = select_object.options
   {{< /tab >}}
   {{< tab header="JavaScript" >}}


### PR DESCRIPTION
Replaced the `&lt;` and `&gt;` to `<` and `>` in a example for python and ruby.

### Description
The `&lt;` and `&gt;` are not rendered to `<` and `>` symbols in the web page as they are formatted as code.
It is displayed as `&lt;select&gt;` in the web page, so made this changes so it will be displayed as `<select>`.

### Motivation and Context
Please add this proposed changes as it may affect people who are reading examples.

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
