### PR TITLE
Elements finder typo

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/finders.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.en.md
@@ -152,7 +152,7 @@ references to all fruits and vegetable list items will be returned in a collecti
 List<WebElement> plants = driver.findElements(By.tagName("li"));
   {{< /tab >}}
   {{< tab header="Python" >}}
-plants = driver.find_elemnts(By.TAG_NAME, "li")
+plants = driver.find_elements(By.TAG_NAME, "li")
   {{< /tab >}}
   {{< tab header="CSharp" >}}
 IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));

--- a/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
@@ -153,7 +153,7 @@ references to all fruits and vegetable list items will be returned in a collecti
 List<WebElement> plants = driver.findElements(By.tagName("li"));
   {{< /tab >}}
   {{< tab header="Python" >}}
-plants = driver.find_elemnts(By.TAG_NAME, "li")
+plants = driver.find_elements(By.TAG_NAME, "li")
   {{< /tab >}}
   {{< tab header="CSharp" >}}
 IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));

--- a/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
@@ -153,7 +153,7 @@ references to all fruits and vegetable list items will be returned in a collecti
 List<WebElement> plants = driver.findElements(By.tagName("li"));
   {{< /tab >}}
   {{< tab header="Python" >}}
-plants = driver.find_elemnts(By.TAG_NAME, "li")
+plants = driver.find_elements(By.TAG_NAME, "li")
   {{< /tab >}}
   {{< tab header="CSharp" >}}
 IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));

--- a/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
@@ -153,7 +153,7 @@ references to all fruits and vegetable list items will be returned in a collecti
 List<WebElement> plants = driver.findElements(By.tagName("li"));
   {{< /tab >}}
   {{< tab header="Python" >}}
-plants = driver.find_elemnts(By.TAG_NAME, "li")
+plants = driver.find_elements(By.TAG_NAME, "li")
   {{< /tab >}}
   {{< tab header="CSharp" >}}
 IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));


### PR DESCRIPTION
This fixes a typo in the finders examples files: elemnts -> elements. It includes the changes for all languages.
(I will squash before merging).