### PR TITLE
Japanese Translation of Capabilities

### DIFF
--- a/website_and_docs/content/documentation/webdriver/capabilities/_index.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/_index.ja.md
@@ -1,6 +1,6 @@
 ---
-title: "Capabilities"
-linkTitle: "Capabilities"
+title: "Capability"
+linkTitle: "Capability"
 weight: 4
 aliases: [
 "/documentation/ja/driver_idiosyncrasies/",
@@ -8,12 +8,3 @@ aliases: [
 "/ja/documentation/webdriver/capabilities/driver_specific_capabilities/"
 ]
 ---
-
-{{% pageinfo color="warning" %}}
-<p class="lead">
-   <i class="fas fa-language display-4"></i> 
-   Page being translated from 
-   English to Japanese. Do you speak Japanese? Help us to translate
-   it by sending us pull requests!
-</p>
-{{% /pageinfo %}}

--- a/website_and_docs/content/documentation/webdriver/capabilities/chromium.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/chromium.ja.md
@@ -1,10 +1,10 @@
 ---
-title: "Capabilities specific to Chromium browsers"
+title: "Chromiumベースのブラウザ固有のCapability"
 linkTitle: "Chromium"
 weight: 4
 needsTranslation: true
 description: >-
-    These capabilities are specific to Chromium based browsers.
+    これらの機能は、Chromiumベースのブラウザ固有のものです。
 ---
 
 These Capabilities apply to:

--- a/website_and_docs/content/documentation/webdriver/capabilities/chromium.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/chromium.ja.md
@@ -2,7 +2,6 @@
 title: "Chromiumベースのブラウザ固有のCapability"
 linkTitle: "Chromium"
 weight: 4
-needsTranslation: true
 description: >-
     これらの機能は、Chromiumベースのブラウザ固有のものです。
 ---

--- a/website_and_docs/content/documentation/webdriver/capabilities/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/firefox.ja.md
@@ -2,7 +2,6 @@
 title: "Firefox固有のCapabiliy"
 linkTitle: "Firefox"
 weight: 6
-needsTranslation: true
 description: >-
     これらのCapabiliyはFirefox固有のものです。
 ---

--- a/website_and_docs/content/documentation/webdriver/capabilities/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/firefox.ja.md
@@ -1,9 +1,9 @@
 ---
-title: "Firefox固有のCapabiliy"
+title: "Firefox固有のCapability"
 linkTitle: "Firefox"
 weight: 6
 description: >-
-    これらのCapabiliyはFirefox固有のものです。
+    これらのCapabilityはFirefox固有のものです。
 ---
 
 ### `FirefoxOptions` を使用してCapabilitiesを定義する

--- a/website_and_docs/content/documentation/webdriver/capabilities/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/firefox.ja.md
@@ -1,10 +1,10 @@
 ---
-title: "Capabilities specific to Firefox browser"
+title: "Firefox固有のCapabiliy"
 linkTitle: "Firefox"
 weight: 6
 needsTranslation: true
 description: >-
-    These capabilities are specific to Firefox.
+    これらのCapabiliyはFirefox固有のものです。
 ---
 
 ### `FirefoxOptions` を使用してCapabilitiesを定義する

--- a/website_and_docs/content/documentation/webdriver/capabilities/internet_explorer.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/internet_explorer.ja.md
@@ -1,10 +1,10 @@
 ---
-title: "Capabilities specific to Internet Explorer browser"
+title: "InternetExplorer固有のCapabiliy"
 linkTitle: "Internet Explorer"
 weight: 8
 needsTranslation: true
 description: >-
-    These capabilities are specific to Internet Explorer.
+    これらのCapabilityは、InternetExplorer固有のものです。
 ---
 
 ### fileUploadDialogTimeout

--- a/website_and_docs/content/documentation/webdriver/capabilities/internet_explorer.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/internet_explorer.ja.md
@@ -2,7 +2,6 @@
 title: "InternetExplorer固有のCapabiliy"
 linkTitle: "Internet Explorer"
 weight: 8
-needsTranslation: true
 description: >-
     これらのCapabilityは、InternetExplorer固有のものです。
 ---

--- a/website_and_docs/content/documentation/webdriver/capabilities/internet_explorer.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/internet_explorer.ja.md
@@ -1,5 +1,5 @@
 ---
-title: "InternetExplorer固有のCapabiliy"
+title: "InternetExplorer固有のCapability"
 linkTitle: "Internet Explorer"
 weight: 8
 description: >-

--- a/website_and_docs/content/documentation/webdriver/capabilities/safari.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/safari.ja.md
@@ -1,8 +1,8 @@
 ---
-title: "Capabilities specific to Safari browser"
+title: "Safari固有のCapabiliy"
 linkTitle: "Safari"
 weight: 10
 needsTranslation: true
 description: >-
-    These capabilities are specific to Safari.
+    これらのCapabiliyはSafari固有のものです。
 ---

--- a/website_and_docs/content/documentation/webdriver/capabilities/safari.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/safari.ja.md
@@ -1,7 +1,7 @@
 ---
-title: "Safari固有のCapabiliy"
+title: "Safari固有のCapability"
 linkTitle: "Safari"
 weight: 10
 description: >-
-    これらのCapabiliyはSafari固有のものです。
+    これらのCapabilityはSafari固有のものです。
 ---

--- a/website_and_docs/content/documentation/webdriver/capabilities/safari.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/safari.ja.md
@@ -2,7 +2,6 @@
 title: "Safari固有のCapabiliy"
 linkTitle: "Safari"
 weight: 10
-needsTranslation: true
 description: >-
     これらのCapabiliyはSafari固有のものです。
 ---

--- a/website_and_docs/content/documentation/webdriver/capabilities/shared.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/shared.ja.md
@@ -2,7 +2,6 @@
 title: "共通のCapability"
 linkTitle: "共通のCapability"
 weight: 2
-needsTranslation: true
 description: >-
   これらのCapabilityはすべてのブラウザで共通です。
 aliases: [

--- a/website_and_docs/content/documentation/webdriver/capabilities/shared.ja.md
+++ b/website_and_docs/content/documentation/webdriver/capabilities/shared.ja.md
@@ -1,10 +1,10 @@
 ---
-title: "共有Capabilities"
-linkTitle: "共有Capabilities"
+title: "共通のCapability"
+linkTitle: "共通のCapability"
 weight: 2
 needsTranslation: true
 description: >-
-  These capabilities are shared by all browsers.
+  これらのCapabilityはすべてのブラウザで共通です。
 aliases: [
 "/documentation/ja/driver_idiosyncrasies/shared_capabilities/",
 "/ja/documentation/webdriver/capabilities/shared_capabilities/",
@@ -18,10 +18,10 @@ aliases: [
 ---
 
 Selenium WebDriverで新しいセッションを作成するには、ローカルエンドがリモートエンドに基本的なCapabilities（ブラウザの設定情報）を提供する必要があります。
-リモートエンドは、一連の同じCapabilitiesを使用してセッションを作成し、現在のセッション機能を描きます。
+リモートエンドは、一連の同じCapabilityを使用してセッションを作成し、現在のセッション機能を描きます。
 
-WebDriverは、各リモートエンドがCapabilitiesをサポートする/すべきCapabilitiesを提供します。
-WebDriverがサポートするCapabilitiesは次のとおりです。
+WebDriverは、各リモートエンドがCapabilityをサポートする/すべきCapabilityを提供します。
+WebDriverがサポートするCapabilityは次のとおりです。
 
 ## browserName:
 


### PR DESCRIPTION
### Description
Japanese Translation of Capabilities
- content/documentation/webdriver/capabilities/_index.ja.md
- content/documentation/webdriver/capabilities/chromium.ja.md
- content/documentation/webdriver/capabilities/firefox.ja.md
- content/documentation/webdriver/capabilities/internet_explorer.ja.md
- content/documentation/webdriver/capabilities/safari.ja.md
- content/documentation/webdriver/capabilities/shared.ja.md

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
