### PR TITLE
Add dismissible banner shortcode

### DIFF
--- a/website_and_docs/content/_index.en.html
+++ b/website_and_docs/content/_index.en.html
@@ -14,6 +14,10 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
+{{< dismissible-banner title="CVE-2021-45105 Log4j Vulnerability" >}}
+	<em>Note</em>: Selenium does <strong>not</strong> use Log4j, thus is unaffected by <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105</a>.
+{{< /dismissible-banner >}}
+
 {{< getting-started color="100" height="auto" title="Getting Started" >}}
 
 {{% getting-started-item icon="icons/webdriver.svg" title="Selenium WebDriver" color="selenium-webdriver" url="/documentation/webdriver/" url_text="Read more" %}}

--- a/website_and_docs/content/_index.ja.html
+++ b/website_and_docs/content/_index.ja.html
@@ -14,6 +14,10 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
+{{< dismissible-banner title="CVE-2021-45105 Log4j Vulnerability" >}}
+	<em>Note</em>: Selenium does <strong>not</strong> use Log4j, thus is unaffected by <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105</a>.
+{{< /dismissible-banner >}}
+
 {{< language-alert locale="ja" language="Japanese" >}}
 
 {{< getting-started color="100" height="auto" title="Getting Started" >}}

--- a/website_and_docs/content/_index.other.html
+++ b/website_and_docs/content/_index.other.html
@@ -14,6 +14,10 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
+{{< dismissible-banner title="CVE-2021-45105 Log4j Vulnerability" >}}
+	<em>Note</em>: Selenium does <strong>not</strong> use Log4j, thus is unaffected by <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105</a>.
+{{< /dismissible-banner >}}
+
 <div class="row td-box--200 justify-content-center">
 	<div class="alert alert-orange bg-transparent col-6 pl-lg-5 my-4 alert-dismissible fade show" role="alert">
 		<h2 class="alert-heading pb-3 text-center">Welcome!</h2>

--- a/website_and_docs/content/_index.pt-br.html
+++ b/website_and_docs/content/_index.pt-br.html
@@ -14,6 +14,10 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
+{{< dismissible-banner title="CVE-2021-45105 Log4j Vulnerability" >}}
+	<em>Note</em>: Selenium does <strong>not</strong> use Log4j, thus is unaffected by <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105</a>.
+{{< /dismissible-banner >}}
+
 {{< language-alert locale="pt-br" language="Portuguese" >}}
 
 {{< getting-started color="100" height="auto" title="Getting Started" >}}

--- a/website_and_docs/content/_index.zh-cn.html
+++ b/website_and_docs/content/_index.zh-cn.html
@@ -14,6 +14,10 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
+{{< dismissible-banner title="CVE-2021-45105 Log4j Vulnerability" >}}
+	<em>Note</em>: Selenium does <strong>not</strong> use Log4j, thus is unaffected by <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105</a>.
+{{< /dismissible-banner >}}
+
 {{< language-alert locale="zh-cn" language="Chinese" >}}
 
 {{< getting-started color="100" height="auto" title="Getting Started" >}}

--- a/website_and_docs/layouts/shortcodes/dismissible-banner.html
+++ b/website_and_docs/layouts/shortcodes/dismissible-banner.html
@@ -1,15 +1,17 @@
 <div class="row td-box--200 justify-content-center">
 	<div class="alert alert-orange bg-transparent col-6 pl-lg-5 my-4 alert-dismissible fade show"
-			 role="alert" id="banner-blm">
-		<h2 class="alert-heading pb-3 text-center">
-			<strong>BLACK LIVES MATTER</strong>
-		</h2>
+			 role="alert" id="dismissible-banner">
+        {{ with .Get "title" }}
+            <h2 class="alert-heading pb-3 text-center">
+			  {{ . }}
+		    </h2>
+        {{ end }}
 		<div class="w-100">
-			<h3>
-				In solidarity, we ask that you consider financially supporting efforts such as
-				<a target='_blank' href="https://support.eji.org/give/153413/#!/donation/checkout">The Equal Justice Initiative</a>,
-				<a target='_blank' href="https://www.naacpldf.org/">NAACP Legal Defense and Education Fund</a>,
-				or your local civil rights charity.
+            {{ if eq .Page.File.Ext "md" }}
+				{{ .Inner | markdownify }}
+			{{ else }}
+				{{ .Inner | htmlUnescape | safeHTML }}
+			{{ end }}
 			</h3>
 		</div>
 		<button type="button" class="close" data-dismiss="alert" aria-label="Close">
@@ -32,8 +34,7 @@
 					localStorage.setItem(config.id, Date.now());
 					return banner.parentElement.removeChild(banner);
 				});
-			})({ "id": "banner-blm", "duration": "" });
+			})({ "id": "dismissible-banner", "duration": "" });
 		</script>
-
 	</div>
 </div>


### PR DESCRIPTION
### Description

- Refactor old dismissible banner to be a shortcode for Hugo.
- Add CVE-2021-45105 vulnerability banner

### Motivation and Context

Noting the Selenium software is not affected by CVE-2021-45105 .

rel: https://github.com/SeleniumHQ/seleniumhq.github.io/pull/897

### Screenshot

![Screen Shot 2021-12-21 at 16 07 09](https://user-images.githubusercontent.com/2972876/146997821-91223021-5c8c-4c36-a5b0-aecf420b1095.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [-] Improved translation
- [-] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
