### PR TITLE
Japanese Translation of test_practices

### DIFF
--- a/website_and_docs/content/documentation/test_practices/_index.ja.md
+++ b/website_and_docs/content/documentation/test_practices/_index.ja.md
@@ -1,20 +1,11 @@
 ---
-title: "ガイドラインとレコメンデーション"
-linkTitle: "ガイドライン"
+title: "テストの実践"
+linkTitle: "テストの実践"
 chapter: true
 weight: 12
 description: >
   Seleniumプロジェクトからのテストに関するいくつかのガイドラインと推奨事項
 ---
-
-{{% pageinfo color="warning" %}}
-<p class="lead">
-   <i class="fas fa-language display-4"></i> 
-   Page being translated from 
-   English to Japanese. Do you speak Japanese? Help us to translate
-   it by sending us pull requests!
-</p>
-{{% /pageinfo %}}
 
 「ベストプラクティス」に関するメモ：このドキュメントでは、"ベストプラクティス"というフレーズを意図的に避けています。
 すべての状況に有効なアプローチはありません。

--- a/website_and_docs/content/documentation/test_practices/design_strategies.en.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.en.md
@@ -9,8 +9,8 @@ weight: 1
 Over time, projects tend to accumulate large numbers of tests. As the total number of tests increases, 
 it becomes harder to make changes to the codebase --- a single "simple" change may cause numerous tests to fail, even though the application still works properly. Sometimes these problems are unavoidable, but when they do occur you want to be up and running again as quickly as possible. The following design patterns and strategies have been used before with WebDriver to help making tests easier to write and maintain. They may help you too.
 
-[DomainDrivenDesign]({{< ref "//encouraged/domain_specific_language.en.md" >}}): Express your tests in the language of the end-user of the app.
-[PageObjects]({{< ref "//encouraged/page_object_models.en.md" >}}): A simple abstraction of the UI of your web app.
+[DomainDrivenDesign]({{< ref "encouraged/domain_specific_language.md" >}}): Express your tests in the language of the end-user of the app.
+[PageObjects]({{< ref "encouraged/page_object_models.md" >}}): A simple abstraction of the UI of your web app.
 LoadableComponent: Modeling PageObjects as components.
 BotStyleTests: Using a command-based approach to automating tests, rather than the object-based approach that PageObjects encourage
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
@@ -1,0 +1,370 @@
+---
+title: "デザインパターンと開発戦略"
+linkTitle: "デザイン戦略"
+weight: 1
+---
+(以前の場所: https://github.com/SeleniumHQ/selenium/wiki/Bot-Style-Tests)
+
+## 概要
+時間の経過とともに、プロジェクトは多数のテストが積み上がる傾向があります。 
+テストの総数が増えると、コードベースに変更を加えることが難しくなります。
+アプリケーションが正常に機能していても、1回の"単純な"変更で多数のテストが失敗する可能性があります。 
+これらの問題が避けられない場合もありますが、問題が発生した場合は、できるだけ早く稼働を再開する必要があります。 
+次のデザインパターンと戦略は、テストの作成と保守を容易にするためにWebDriverで以前に使用されています。 
+それらもあなたにとって役に立つかもしれません。
+
+[DomainDrivenDesign](encouraged/domain_specific_language.ja.md)：アプリのエンドユーザーの言語でテストを表現します。   
+[PageObjects](encouraged/page_object_models.ja.md)：WebアプリのUIの単純な抽象化  
+LoadableComponent：PageObjectsをコンポーネントとしてモデリングします。   
+BotStyleTests：PageObjectsが推奨するオブジェクトベースのアプローチではなく、コマンドベースのアプローチを使用してテストを自動化します。  
+
+## ロード可能なコンポーネント
+
+### それは何ですか？
+
+LoadableComponentは、PageObjectsの作成の負担を軽減することを目的としたベースクラスです。 
+これは、ページがロードされることを保証する標準的な方法を提供し、ページのロードの失敗のデバッグを容易にするフックを提供することによってこれを行います。 
+これを使用して、テストの定型コードの量を減らすことができます。これにより、テストの保守が面倒になります。
+
+現在、Selenium 2の一部として出荷されるJavaの実装がありますが、使用されるアプローチは、どの言語でも実装できるほど単純です。
+
+### 簡単な使用方法
+
+モデル化するUIの例として、[新しいissue](https://github.com/SeleniumHQ/selenium/issues/new)のページをご覧ください。 
+テスト作成者の観点から、これは新しい問題を提出できるサービスを提供します。 
+基本的なページオブジェクトは次のようになります。
+
+```
+package com.example.webdriver;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+public class EditIssue {
+
+  private final WebDriver driver;
+
+  public EditIssue(WebDriver driver) {
+    this.driver = driver;
+  }
+
+  public void setSummary(String summary) {
+    WebElement field = driver.findElement(By.name("summary"));
+    clearAndType(field, summary);
+  }
+
+  public void enterDescription(String description) {
+    WebElement field = driver.findElement(By.name("comment"));
+    clearAndType(field, description);
+  }
+
+  public IssueList submit() {
+    driver.findElement(By.id("submit")).click();
+    return new IssueList(driver);
+  }
+
+  private void clearAndType(WebElement field, String text) {
+    field.clear();
+    field.sendKeys(text);
+  }
+}
+```
+
+これをLoadableComponentに変換するには、これを基本型として設定するだけです。
+
+```
+public class EditIssue extends LoadableComponent<EditIssue> {
+  // rest of class ignored for now
+}
+```
+
+この署名は少し変わっているように見えますが、それは、このクラスがEditIssueページをロードするLoadableComponentを表すことを意味します。
+
+このベースクラスを拡張することにより、2つの新しいメソッドを実装する必要があります。
+
+```
+  @Override
+  protected void load() {
+    driver.get("https://github.com/SeleniumHQ/selenium/issues/new");
+  }
+
+  @Override
+  protected void isLoaded() throws Error {
+    String url = driver.getCurrentUrl();
+    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
+  }
+```
+
+`load` メソッドはページに移動するために使用され、　`isLoaded` メソッドは正しいページにいるかどうかを判断するために使用されます。 
+このメソッドはブール値を返す必要があるように見えますが、代わりにJUnitのAssertクラスを使用して一連のアサーションを実行します。 
+アサーションは好きなだけ少なくても多くてもかまいません。 
+これらのアサーションを使用することで、クラスのユーザーにテストのデバッグに使用できる明確な情報を提供することができます。
+
+少し手直しすると、PageObjectは次のようになります。
+
+```
+package com.example.webdriver;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+import static junit.framework.Assert.assertTrue;
+
+public class EditIssue extends LoadableComponent<EditIssue> {
+
+  private final WebDriver driver;
+  
+  // By default the PageFactory will locate elements with the same name or id
+  // as the field. Since the summary element has a name attribute of "summary"
+  // we don't need any additional annotations.
+  private WebElement summary;
+  
+  // Same with the submit element, which has the ID "submit"
+  private WebElement submit;
+  
+  // But we'd prefer a different name in our code than "comment", so we use the
+  // FindBy annotation to tell the PageFactory how to locate the element.
+  @FindBy(name = "comment") private WebElement description;
+  
+  public EditIssue(WebDriver driver) {
+    this.driver = driver;
+    
+    // This call sets the WebElement fields.
+    PageFactory.initElements(driver, this);
+  }
+
+  @Override
+  protected void load() {
+    driver.get("https://github.com/SeleniumHQ/selenium/issues/new");
+  }
+
+  @Override
+  protected void isLoaded() throws Error {
+    String url = driver.getCurrentUrl();
+    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
+  }
+  
+  public void setSummary(String issueSummary) {
+    clearAndType(summary, issueSummary);
+  }
+
+  public void enterDescription(String issueDescription) {
+    clearAndType(description, issueDescription);
+  }
+
+  public IssueList submit() {
+    submit.click();
+    return new IssueList(driver);
+  }
+
+  private void clearAndType(WebElement field, String text) {
+    field.clear();
+    field.sendKeys(text);
+  }
+}
+
+```
+
+それは私たちをあまり信じられなかったようですよね？ 
+これまでに行ったことの1つは、ページに移動する方法に関する情報をページ自体にカプセル化することです。
+つまり、この情報はコードベース全体に散らばっていません。 
+これは、テストで下記を実行できることも意味します。
+
+```
+EditIssue page = new EditIssue(driver).get();
+```
+
+この呼び出しにより、ドライバーは必要に応じてページに移動します。
+
+### ネストされたコンポーネント
+
+LoadableComponentsは、他のLoadableComponentsと組み合わせて使用すると、より便利になります。 
+この例を使用すると、 "edit issue" ページをプロジェクトのWebサイト内のコンポーネントとして表示できます（結局のところ、そのサイトのタブからアクセスします）。 
+また、issue を報告するにはログインする必要があります。 
+これをネストされたコンポーネントのツリーとしてモデル化できます。
+
+```
+ + ProjectPage
+ +---+ SecuredPage
+     +---+ EditIssue
+```
+
+これはコードではどのように見えますか？ 
+まず、各論理コンポーネントには独自のクラスがあります。 
+それぞれの "load" メソッドは、親クラスを "get" します。 
+上記のEditIssueクラスに加えて、最終結果は次のようになります。
+
+ProjectPage.java:
+
+```
+package com.example.webdriver;
+
+import org.openqa.selenium.WebDriver;
+
+import static org.junit.Assert.assertTrue;
+
+public class ProjectPage extends LoadableComponent<ProjectPage> {
+
+  private final WebDriver driver;
+  private final String projectName;
+
+  public ProjectPage(WebDriver driver, String projectName) {
+    this.driver = driver;
+    this.projectName = projectName;
+  }
+
+  @Override
+  protected void load() {
+    driver.get("http://" + projectName + ".googlecode.com/");
+  }
+
+  @Override
+  protected void isLoaded() throws Error {
+    String url = driver.getCurrentUrl();
+
+    assertTrue(url.contains(projectName));
+  }
+}
+```
+
+and SecuredPage.java:
+
+```
+package com.example.webdriver;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import static org.junit.Assert.fail;
+
+public class SecuredPage extends LoadableComponent<SecuredPage> {
+
+  private final WebDriver driver;
+  private final LoadableComponent<?> parent;
+  private final String username;
+  private final String password;
+
+  public SecuredPage(WebDriver driver, LoadableComponent<?> parent, String username, String password) {
+    this.driver = driver;
+    this.parent = parent;
+    this.username = username;
+    this.password = password;
+  }
+
+  @Override
+  protected void load() {
+    parent.get();
+
+    String originalUrl = driver.getCurrentUrl();
+
+    // Sign in
+    driver.get("https://www.google.com/accounts/ServiceLogin?service=code");
+    driver.findElement(By.name("Email")).sendKeys(username);
+    WebElement passwordField = driver.findElement(By.name("Passwd"));
+    passwordField.sendKeys(password);
+    passwordField.submit();
+
+    // Now return to the original URL
+    driver.get(originalUrl);
+  }
+
+  @Override
+  protected void isLoaded() throws Error {
+    // If you're signed in, you have the option of picking a different login.
+    // Let's check for the presence of that.
+
+    try {
+      WebElement div = driver.findElement(By.id("multilogin-dropdown"));
+    } catch (NoSuchElementException e) {
+      fail("Cannot locate user name link");
+    }
+  }
+}
+```
+
+EditIssueの "load" メソッドは次のようになります。
+
+```
+  @Override
+  protected void load() {
+    securedPage.get();
+
+    driver.get("https://github.com/SeleniumHQ/selenium/issues/new");
+  }
+```
+
+これは、コンポーネントがすべて相互に "ネストされている" ことを示しています。 
+EditIssueで `get()` を呼び出すと、そのすべての依存関係も読み込まれます。 
+使用例：
+
+```
+public class FooTest {
+  private EditIssue editIssue;
+
+  @Before
+  public void prepareComponents() {
+    WebDriver driver = new FirefoxDriver();
+
+    ProjectPage project = new ProjectPage(driver, "selenium");
+    SecuredPage securedPage = new SecuredPage(driver, project, "example", "top secret");
+    editIssue = new EditIssue(driver, securedPage);
+  }
+
+  @Test
+  public void demonstrateNestedLoadableComponents() {
+    editIssue.get();
+
+    editIssue.setSummary("Summary");
+    editIssue.enterDescription("This is an example");
+  }
+}
+```
+
+テストで [Guiceberry](https://github.com/zorzella/guiceberry) などのライブラリを使用している場合は、PageObjectsの設定の前文を省略して、わかりやすく読みやすいテストを作成できます。
+
+## ボットパターン
+
+(以前の場所: https://github.com/SeleniumHQ/selenium/wiki/Bot-Style-Tests)
+
+PageObjectsは、テストでの重複を減らすための便利な方法ですが、チームが快適にフォローできるパターンであるとは限りません。 
+別のアプローチは、より "コマンドのような" スタイルのテストに従うことです。
+
+"ボット" は、生のSeleniumAPIに対するアクション指向の抽象化です。 
+つまり、コマンドがアプリに対して正しいことをしていないことがわかった場合、コマンドを簡単に変更できます。 
+例として：
+
+```
+public class ActionBot {
+  private final WebDriver driver;
+
+  public ActionBot(WebDriver driver) {
+    this.driver = driver;
+  }
+
+  public void click(By locator) {
+    driver.findElement(locator).click();
+  }
+
+  public void submit(By locator) {
+    driver.findElement(locator).submit();
+  }
+
+  /** 
+   * Type something into an input field. WebDriver doesn't normally clear these
+   * before typing, so this method does that first. It also sends a return key
+   * to move the focus out of the element.
+   */
+  public void type(By locator, String text) { 
+    WebElement element = driver.findElement(locator);
+    element.clear();
+    element.sendKeys(text + "\n");
+  }
+}
+```
+
+これらの抽象化が構築され、テストでの重複が特定されると、ボットの上にPageObjectsを階層化することができます。

--- a/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
@@ -13,8 +13,8 @@ weight: 1
 次のデザインパターンと戦略は、テストの作成と保守を容易にするためにWebDriverで以前に使用されています。 
 それらもあなたにとって役に立つかもしれません。
 
-[DomainDrivenDesign]({{< ref "//encouraged/domain_specific_language.ja.md" >}})：アプリのエンドユーザーの言語でテストを表現します。   
-[PageObjects]({{< ref "//encouraged/page_object_models.ja.md" >}})：WebアプリのUIの単純な抽象化  
+[DomainDrivenDesign]({{< ref "encouraged/domain_specific_language.md" >}})：アプリのエンドユーザーの言語でテストを表現します。   
+[PageObjects]({{< ref "encouraged/page_object_models.md" >}})：WebアプリのUIの単純な抽象化  
 LoadableComponent：PageObjectsをコンポーネントとしてモデリングします。   
 BotStyleTests：PageObjectsが推奨するオブジェクトベースのアプローチではなく、コマンドベースのアプローチを使用してテストを自動化します。  
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
@@ -13,8 +13,8 @@ weight: 1
 次のデザインパターンと戦略は、テストの作成と保守を容易にするためにWebDriverで以前に使用されています。 
 それらもあなたにとって役に立つかもしれません。
 
-[DomainDrivenDesign](encouraged/domain_specific_language.ja.md)：アプリのエンドユーザーの言語でテストを表現します。   
-[PageObjects](encouraged/page_object_models.ja.md)：WebアプリのUIの単純な抽象化  
+[DomainDrivenDesign]({{< ref "//encouraged/domain_specific_language.ja.md" >}})：アプリのエンドユーザーの言語でテストを表現します。   
+[PageObjects]({{< ref "//encouraged/page_object_models.ja.md" >}})：WebアプリのUIの単純な抽象化  
 LoadableComponent：PageObjectsをコンポーネントとしてモデリングします。   
 BotStyleTests：PageObjectsが推奨するオブジェクトベースのアプローチではなく、コマンドベースのアプローチを使用してテストを自動化します。  
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
@@ -10,8 +10,8 @@ needsTranslation: true
 Over time, projects tend to accumulate large numbers of tests. As the total number of tests increases, 
 it becomes harder to make changes to the codebase --- a single "simple" change may cause numerous tests to fail, even though the application still works properly. Sometimes these problems are unavoidable, but when they do occur you want to be up and running again as quickly as possible. The following design patterns and strategies have been used before with WebDriver to help making tests easier to write and maintain. They may help you too.
 
-[DomainDrivenDesign]({{< ref "//encouraged/domain_specific_language.pt-br.md" >}}): Express your tests in the language of the end-user of the app.
-[PageObjects]({{< ref "//encouraged/page_object_models.pt-br.md" >}}): A simple abstraction of the UI of your web app.
+[DomainDrivenDesign]({{< ref "encouraged/domain_specific_language.md" >}}): Express your tests in the language of the end-user of the app.
+[PageObjects]({{< ref "encouraged/page_object_models.md" >}}): A simple abstraction of the UI of your web app.
 LoadableComponent: Modeling PageObjects as components.
 BotStyleTests: Using a command-based approach to automating tests, rather than the object-based approach that PageObjects encourage
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
@@ -20,8 +20,8 @@ weight: 1
 Over time, projects tend to accumulate large numbers of tests. As the total number of tests increases, 
 it becomes harder to make changes to the codebase --- a single "simple" change may cause numerous tests to fail, even though the application still works properly. Sometimes these problems are unavoidable, but when they do occur you want to be up and running again as quickly as possible. The following design patterns and strategies have been used before with WebDriver to help making tests easier to write and maintain. They may help you too.
 
-[DomainDrivenDesign]({{< ref "//encouraged/domain_specific_language.zh-cn.md" >}}): Express your tests in the language of the end-user of the app.
-[PageObjects]({{< ref "//encouraged/page_object_models.zh-cn.md" >}}): A simple abstraction of the UI of your web app.
+[DomainDrivenDesign]({{< ref "encouraged/domain_specific_language.md" >}}): Express your tests in the language of the end-user of the app.
+[PageObjects]({{< ref "encouraged/page_object_models.md" >}}): A simple abstraction of the UI of your web app.
 LoadableComponent: Modeling PageObjects as components.
 BotStyleTests: Using a command-based approach to automating tests, rather than the object-based approach that PageObjects encourage
 

--- a/website_and_docs/content/documentation/test_practices/discouraged/_index.ja.md
+++ b/website_and_docs/content/documentation/test_practices/discouraged/_index.ja.md
@@ -1,21 +1,11 @@
 ---
-title: "最悪の慣行"
-linkTitle: "最悪の慣行"
+title: "推奨されない行動"
+linkTitle: "非推奨"
 weight: 8
 description: >
-  Things to avoid when automating browsers with Selenium.
+  Seleniumでブラウザを自動化するときに避けるべきこと。
 aliases: [
 "/documentation/ja/worst_practices/",
 "/ja/documentation/worst_practices/"
 ]
 ---
-
-{{% pageinfo color="warning" %}}
-<p class="lead">
-   <i class="fas fa-language display-4"></i> 
-   Page being translated from 
-   English to Japanese. Do you speak Japanese? Help us to translate
-   it by sending us pull requests!
-</p>
-{{% /pageinfo %}}
-

--- a/website_and_docs/content/documentation/test_practices/encouraged/_index.ja.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/_index.ja.md
@@ -1,24 +1,14 @@
 ---
-title: "ガイドラインとレコメンデーション"
-linkTitle: "ガイドライン"
-chapter: true
-weight: 7
+title: "推奨された行動"
+linkTitle: "推奨"
+weight: 3
 description: >
-  Some guidelines and recommendations on testing from the Selenium project.
+  Seleniumプロジェクトからのテストに関するいくつかのガイドラインと推奨事項
 aliases: [
 "/documentation/ja/guidelines_and_recommendations/",
 "/ja/documentation/guidelines/"
 ]
 ---
-
-{{% pageinfo color="warning" %}}
-<p class="lead">
-   <i class="fas fa-language display-4"></i> 
-   Page being translated from 
-   English to Japanese. Do you speak Japanese? Help us to translate
-   it by sending us pull requests!
-</p>
-{{% /pageinfo %}}
 
 「ベストプラクティス」に関するメモ：このドキュメントでは、"ベストプラクティス"というフレーズを意図的に避けています。
 すべての状況に有効なアプローチはありません。

--- a/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.ja.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.ja.md
@@ -1,7 +1,7 @@
 ---
 title: "テストごとに新しいブラウザを起動する"
 linkTitle: "テストごとに新しいブラウザを起動する"
-weight: 9
+weight: 11
 aliases: [
 "/documentation/ja/guidelines_and_recommendations/fresh_browser_per_test/",
 "/ja/documentation/guidelines/fresh_browser_per_test/"

--- a/website_and_docs/content/documentation/test_practices/encouraged/mock_external_services.ja.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/mock_external_services.ja.md
@@ -1,7 +1,7 @@
 ---
 title: "モック外部サービス"
 linkTitle: "モック外部サービス"
-weight: 4
+weight: 6
 aliases: [
 "/documentation/ja/guidelines_and_recommendations/mock_external_services/",
 "/ja/documentation/guidelines/mock_external_services/"


### PR DESCRIPTION
### Description
Translated Some test_practices  pages to Japanese

- content/documentation/test_practices/_index.ja.md
- content/documentation/test_practices/design_strategies.ja.md
- content/documentation/test_practices/encouraged/_index.ja.md
- content/documentation/test_practices/encouraged/fresh_browser_per_test.ja.md
- content/documentation/test_practices/encouraged/mock_external_services.ja.md
- content/documentation/test_practices/discouraged/_index.ja.md


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
