### PR TITLE
Fix syntax errors in python samples

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
@@ -65,7 +65,7 @@ Most of what you'll do with Selenium is a combination of these basic commands:
     driver.getTitle(); // => "Google"
     {{< /tab >}}
     {{< tab header="Python" >}}
-    driver.title() # => "Google"
+    driver.title # => "Google"
     {{< /tab >}}
     {{< tab header="CSharp" >}}
     driver.Title; // => "Google"
@@ -146,7 +146,7 @@ Most of what you'll do with Selenium is a combination of these basic commands:
     driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
     {{< /tab >}}
     {{< tab header="Python" >}}
-    driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+    driver.find_element(By.NAME, "q").get_attribute("value") # => "Selenium"
     {{< /tab >}}
     {{< tab header="CSharp" >}}
     driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
@@ -222,7 +222,7 @@ driver = webdriver.Chrome()
 
 driver.get("http://www.google.com")
 
-driver.title() # => "Google"
+driver.title # => "Google"
 
 search_box = driver.find_element(By.NAME, "q")
 search_button = driver.find_element(By.NAME, "btnK")
@@ -230,7 +230,7 @@ search_button = driver.find_element(By.NAME, "btnK")
 search_box.send_keys("Selenium")
 search_button.click()
 
-driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+driver.find_element(By.NAME, "q").get_attribute("value") # => "Selenium"
 
 driver.quit()
 

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
@@ -65,7 +65,7 @@ Seleniumで行うことのほとんどは、次の基本的なコマンドの組
     driver.getTitle(); // => "Google"
     {{< /tab >}}
     {{< tab header="Python" >}}
-    driver.title() # => "Google"
+    driver.title # => "Google"
     {{< /tab >}}
     {{< tab header="CSharp" >}}
     driver.Title; // => "Google"
@@ -146,7 +146,7 @@ Seleniumで行うことのほとんどは、次の基本的なコマンドの組
     driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
     {{< /tab >}}
     {{< tab header="Python" >}}
-    driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+    driver.find_element(By.NAME, "q").get_attribute("value") # => "Selenium"
     {{< /tab >}}
     {{< tab header="CSharp" >}}
     driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
@@ -222,7 +222,7 @@ driver = webdriver.Chrome()
 
 driver.get("http://www.google.com")
 
-driver.title() # => "Google"
+driver.title # => "Google"
 
 search_box = driver.find_element(By.NAME, "q")
 search_button = driver.find_element(By.NAME, "btnK")
@@ -230,7 +230,7 @@ search_button = driver.find_element(By.NAME, "btnK")
 search_box.send_keys("Selenium")
 search_button.click()
 
-driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+driver.find_element(By.NAME, "q").get_attribute("value") # => "Selenium"
 
 driver.quit()
 

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
@@ -66,7 +66,7 @@ Most of what you'll do with Selenium is a combination of these basic commands:
     driver.getTitle(); // => "Google"
     {{< /tab >}}
     {{< tab header="Python" >}}
-    driver.title() # => "Google"
+    driver.title # => "Google"
     {{< /tab >}}
     {{< tab header="CSharp" >}}
     driver.Title; // => "Google"
@@ -147,7 +147,7 @@ Most of what you'll do with Selenium is a combination of these basic commands:
     driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
     {{< /tab >}}
     {{< tab header="Python" >}}
-    driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+    driver.find_element(By.NAME, "q").get_attribute("value") # => "Selenium"
     {{< /tab >}}
     {{< tab header="CSharp" >}}
     driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
@@ -223,7 +223,7 @@ driver = webdriver.Chrome()
 
 driver.get("http://www.google.com")
 
-driver.title() # => "Google"
+driver.title # => "Google"
 
 search_box = driver.find_element(By.NAME, "q")
 search_button = driver.find_element(By.NAME, "btnK")
@@ -231,7 +231,7 @@ search_button = driver.find_element(By.NAME, "btnK")
 search_box.send_keys("Selenium")
 search_button.click()
 
-driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+driver.find_element(By.NAME, "q").get_attribute("value") # => "Selenium"
 
 driver.quit()
 

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
@@ -68,7 +68,7 @@ Selenium所做的一切,
     driver.getTitle(); // => "Google"
     {{< /tab >}}
     {{< tab header="Python" >}}
-    driver.title() # => "Google"
+    driver.title # => "Google"
     {{< /tab >}}
     {{< tab header="CSharp" >}}
     driver.Title; // => "Google"
@@ -149,7 +149,7 @@ Selenium所做的一切,
     driver.findElement(By.name("q")).getAttribute("value"); // => "Selenium"
     {{< /tab >}}
     {{< tab header="Python" >}}
-    driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+    driver.find_element(By.NAME, "q").get_attribute("value") # => "Selenium"
     {{< /tab >}}
     {{< tab header="CSharp" >}}
     driver.FindElement(By.Name("q")).GetAttribute("value"); // => "Selenium"
@@ -226,7 +226,7 @@ driver = webdriver.Chrome()
 
 driver.get("http://www.google.com")
 
-driver.title() # => "Google"
+driver.title # => "Google"
 
 search_box = driver.find_element(By.NAME, "q")
 search_button = driver.find_element(By.NAME, "btnK")
@@ -234,7 +234,7 @@ search_button = driver.find_element(By.NAME, "btnK")
 search_box.send_keys("Selenium")
 search_button.click()
 
-driver.find_element(By.NAME, "q").getAttribute() # => "Selenium"
+driver.find_element(By.NAME, "q").get_attribute("value") # => "Selenium"
 
 driver.quit()
 


### PR DESCRIPTION
### Description
Python samples contains syntax errors
* `title` is an attribute, not an method
* `getAttribute` must be `get_attribute` and have an argument

### Motivation and Context
Make it new users easier to start

### Types of changes
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
