### PR TITLE
fix move_by_offset example

### DIFF
--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
@@ -565,12 +565,10 @@ driver = webdriver.Chrome()
     # Navigate to url
 driver.get("http://www.google.com")
 
-    # Store 'google search' button web element
-gmailLink = driver.find_element(By.LINK_TEXT, "Gmail")
-    # Set x and y offset positions of element
+    # Set x and y offset to move by
 xOffset = 100
 yOffset = 100
-    # Performs mouse move action onto the element
+    # Performs mouse move action
 webdriver.ActionChains(driver).move_by_offset(xOffset,yOffset).perform()
   {{< /tab >}}
   {{< tab header="CSharp" >}}


### PR DESCRIPTION
### Description

`move_by_offset` doesn't have a specific element that it interacts with.

This change cleans up the Python version of the example.

I don't have experience with the non-Python languages, and I don't want to introduce bugs there.
I hope someone else will clean them up.

### Motivation and Context

The existing example is confusing because it refers to things that are irrelevant.

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
