### PR TITLE
Adding an article regarding Python binding locator changes

### DIFF
--- a/website_and_docs/content/blog/2022/python_locators_se4.md
+++ b/website_and_docs/content/blog/2022/python_locators_se4.md
@@ -1,23 +1,29 @@
 ---
-title: "Locate Your Locators - Python Bindings Changes Upcoming"
-linkTitle: "Locate Your Locators Python Bindings Changes Upcoming"
+title: "Locate your locators - Python bindings changes upcoming"
+linkTitle: "Locate Your Locators"
 date: 2022-02-01
 tags: ["webdriver", "python"]
 categories: ["general"]
 author: Josh Grant ([@joshin4colours](https://twitter.com/joshin4colours))
 description: >
-  Updating Your Locators for Changes in the Pythom Bindings in Selenium 4
+  Updating your locators for changes in the Python 
+  bindings in Selenium 4
 ---
 
-(This article was originally posted [here](https://simplythetest.tumblr.com/post/674917293614039040/locate-your-locators-python-bindings-changes). Thanks to the Selenium core contributors for adding this here!)
+In real estate, the mantra for finding a new house or office space is
+"location, location, location!". 
+It could be said that when working with Selenium, a critical aspect of
+writing tests is "locators, locators, locators!".
+Having a robust locator strategy - in your app under test and in
+your test framework - is highly important for effective testing.
 
-In real estate, the mantra for finding a new house or office space is "location, location, location!". It could be said that when working with Selenium, a critical aspect of writing tests is "locators, locators, locators!". Having a robust locator strategy - in your app under test and in your test framework - is highly important for effective testing.
+If you are a Pythonista like myself and using Selenium for your test automation,
+then there are some important changes coming to how locators are defined and used.
 
-If you are a Pythonista like myself and using Selenium for your test automation, then there are some important changes coming to how locators are defined and used.
+Sometime after Selenium 4.2, the Python Selenium bindings will remove
+locator-specific methods for finding elements. This means that the methods
 
-As of Selenium 4.1.2, the Python Selenium bindings will remove locator-specific methods for finding elements. This means that the methods
-
-```
+```python
 driver.find_element_by_id("some_id")
 driver.find_element_by_name("some_name")
 driver.find_element_by_tag_name("some_tag")
@@ -29,31 +35,39 @@ driver.find_element_by_xpath("some_xpath")
 ```
 will be removed. All of these methods are in fact special cases of
 
-```
+```python
 driver.find_element(By_object, "some_locator")
 ```
 
 so this approach is now preferred (required, even) with the Python bindings.
 
-Note that it's good practice to use the [By object](https://www.selenium.dev/selenium/docs/api/py/webdriver/selenium.webdriver.common.by.html#module-selenium.webdriver.common.by) which has specific values for using particular locator strategies. For example, this line
+Note that it's good practice to use the
+[By object](https://www.selenium.dev/selenium/docs/api/py/webdriver/selenium.webdriver.common.by.html#module-selenium.webdriver.common.by)
+which has specific values for using particular locator strategies. For example, this line
 
-```
+```python
 driver.find_element_by_id("submit_button").click()
 driver.find_element_by_css_selectors('.myelement child').text
 ```
 
 becomes
 
-```
+```python
 driver.find_element(By.ID, "submit_button").click()
 driver.find_element(By.CSS_SELECTOR, '.myelement child').text
 ```
 
 If you're really desperate however you can use strings instead of the By object:
 
-```
+```python
 driver.find_element('id', "submit_button").click()
 driver.find_element('css selector', '.myelement child').text
 ```
 
-If you have any plans to upgrade your Selenium client for your Python tests to recent versions of Selenium 4, definitely keep these changes in mind. It's a good time to update your locator strategy and structure.
+If you have any plans to upgrade your Selenium client for your Python tests
+to recent versions of Selenium 4, definitely keep these changes in mind.
+It's a good time to update your locator strategy and structure.
+
+(This article was originally posted
+[here](https://simplythetest.tumblr.com/post/674917293614039040/locate-your-locators-python-bindings-changes).
+Thanks to the Selenium core contributors for adding this here!)

--- a/website_and_docs/content/blog/2022/python_locators_se4.md
+++ b/website_and_docs/content/blog/2022/python_locators_se4.md
@@ -1,0 +1,59 @@
+---
+title: "Locate Your Locators - Python Bindings Changes Upcoming"
+linkTitle: "Locate Your Locators Python Bindings Changes Upcoming"
+date: 2022-02-01
+tags: ["webdriver", "python"]
+categories: ["general"]
+author: Josh Grant ([@joshin4colours](https://twitter.com/joshin4colours))
+description: >
+  Updating Your Locators for Changes in the Pythom Bindings in Selenium 4
+---
+
+(This article was originally posted [here](https://simplythetest.tumblr.com/post/674917293614039040/locate-your-locators-python-bindings-changes). Thanks to the Selenium core contributors for adding this here!)
+
+In real estate, the mantra for finding a new house or office space is "location, location, location!". It could be said that when working with Selenium, a critical aspect of writing tests is "locators, locators, locators!". Having a robust locator strategy - in your app under test and in your test framework - is highly important for effective testing.
+
+If you are a Pythonista like myself and using Selenium for your test automation, then there are some important changes coming to how locators are defined and used.
+
+As of Selenium 4.1.2, the Python Selenium bindings will remove locator-specific methods for finding elements. This means that the methods
+
+```
+driver.find_element_by_id("some_id")
+driver.find_element_by_name("some_name")
+driver.find_element_by_tag_name("some_tag")
+driver.find_element_by_css_selector("some_selector")
+driver.find_element_by_class_name("some_class")
+driver.find_element_by_link_text("some_text")
+driver.find_element_by_partial_link_text("some_other_text")
+driver.find_element_by_xpath("some_xpath")
+```
+will be removed. All of these methods are in fact special cases of
+
+```
+driver.find_element(By_object, "some_locator")
+```
+
+so this approach is now preferred (required, even) with the Python bindings.
+
+Note that it's good practice to use the [By object](https://www.selenium.dev/selenium/docs/api/py/webdriver/selenium.webdriver.common.by.html#module-selenium.webdriver.common.by) which has specific values for using particular locator strategies. For example, this line
+
+```
+driver.find_element_by_id("submit_button").click()
+driver.find_element_by_css_selectors('.myelement child').text
+```
+
+becomes
+
+```
+driver.find_element(By.ID, "submit_button").click()
+driver.find_element(By.CSS_SELECTOR, '.myelement child').text
+```
+
+If you're really desperate however you can use strings instead of the By object:
+
+```
+driver.find_element('id', "submit_button").click()
+driver.find_element('css selector', '.myelement child').text
+```
+
+If you have any plans to upgrade your Selenium client for your Python tests to recent versions of Selenium 4, definitely keep these changes in mind. It's a good time to update your locator strategy and structure.


### PR DESCRIPTION
In an upcoming version of the Python bindings, some locator-specific
methods are being removed, which will likely cause a lot of
Python binding users pain and frustration. This post tries to
help make people aware of these changes.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
I'm adding a new entry to the Selenium blog! It's about changes to the Python bindings regarding find_element_* methods.

### Motivation and Context
Removing the find_element_by* may cause some confusion for Python users of Selenium, so I tried to help with a blog entry about how to update locators for these new changes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
