### PR TITLE
add Ukraine support to main page

### DIFF
--- a/website_and_docs/assets/scss/_screen.scss
+++ b/website_and_docs/assets/scss/_screen.scss
@@ -15,6 +15,12 @@
   padding-bottom: 1rem !important;
 }
 
+.td-cover-block--height-tiny {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  min-height: 250px !important;
+}
+
 .td-cover-block--height-min {
     min-height: 300px !important;
 }

--- a/website_and_docs/content/_index.en.html
+++ b/website_and_docs/content/_index.en.html
@@ -29,20 +29,8 @@ linkTitle = "Selenium"
 		</a>
 	</span>
 	<span class="pr-3">
-		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-			Ukraine Crisis Relief Fund - GlobalGiving
-		</a>
-	</span>
-</p>
-<p>
-	<span class="pr-3">
 		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
 			Ukraine Crisis Relief Fund - Save the Children
-		</a>
-	</span>
-	<span class="pr-3">
-		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-			Crisis in Ukraine - International Rescue Committee
 		</a>
 	</span>
 </p>

--- a/website_and_docs/content/_index.en.html
+++ b/website_and_docs/content/_index.en.html
@@ -16,8 +16,16 @@ linkTitle = "Selenium"
 
 {{< dismissible-banner color="yellow" >}}
 {{< blocks/cover height="min" color="selenium-cyan" >}}
-<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
-<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
+<div class="container">
+	<div class="row justify-content-center align-items-center">
+		<div class="col-8 pr-2">
+			<h1 class="display-1 m-0 p-0 text-right">Selenium Supports Ukraine</h1>
+		</div>
+		<div class="col-2 pl-2 text-left">
+			<h1 style="font-size: 5rem;" class="m-0 p-0">🇺🇦</h1>
+		</div>
+	</div>
+</div>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>

--- a/website_and_docs/content/_index.en.html
+++ b/website_and_docs/content/_index.en.html
@@ -15,31 +15,36 @@ linkTitle = "Selenium"
 {{< /blocks/cover >}}
 
 {{< dismissible-banner color="yellow" >}}
-{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
-<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+{{< blocks/cover height="min" color="selenium-cyan" >}}
+<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
+<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
 </p>
 <p>
-	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
-		Ukraine Crisis Fund
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+			Ukraine Crisis Fund
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+			Ukraine Crisis Relief Fund - GlobalGiving
+		</a>
+	</span>
 </p>
 <p>
-	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-		Ukraine Crisis Relief Fund - GlobalGiving
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
-		Ukraine Crisis Relief Fund - Save the Children
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-		Crisis in Ukraine - International Rescue Committee
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+			Ukraine Crisis Relief Fund - Save the Children
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+			Crisis in Ukraine - International Rescue Committee
+		</a>
+	</span>
 </p>
 {{< /blocks/cover >}}
 {{< /dismissible-banner >}}

--- a/website_and_docs/content/_index.en.html
+++ b/website_and_docs/content/_index.en.html
@@ -15,7 +15,7 @@ linkTitle = "Selenium"
 {{< /blocks/cover >}}
 
 {{< dismissible-banner color="yellow" >}}
-{{< blocks/cover height="min" color="selenium-cyan" >}}
+{{< blocks/cover height="tiny" color="selenium-cyan" >}}
 <div class="container">
 	<div class="row justify-content-center align-items-center">
 		<div class="col-8 pr-2">

--- a/website_and_docs/content/_index.en.html
+++ b/website_and_docs/content/_index.en.html
@@ -14,8 +14,34 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
-{{< dismissible-banner title="Log4j Vulnerability" alert="note" color="orange" >}}
-Selenium does <strong>not</strong> use Log4j, thus is unaffected by [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105).
+{{< dismissible-banner color="yellow" >}}
+{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
+<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+<p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
+<p>
+	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
+</p>
+<p>
+	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+		Ukraine Crisis Fund
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+		Ukraine Crisis Relief Fund - GlobalGiving
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+		Ukraine Crisis Relief Fund - Save the Children
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+		Crisis in Ukraine - International Rescue Committee
+	</a>
+</p>
+{{< /blocks/cover >}}
 {{< /dismissible-banner >}}
 
 {{< getting-started color="100" height="auto" title="Getting Started" >}}

--- a/website_and_docs/content/_index.ja.html
+++ b/website_and_docs/content/_index.ja.html
@@ -14,8 +14,34 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
-{{< dismissible-banner title="Log4jの脆弱性" alert="note" color="orange" >}}
-Selenium は Log4j を使って <strong>いません</strong> 。 したがって、 <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105</a> の影響を受けません。
+{{< dismissible-banner color="yellow" >}}
+{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
+<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+<p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
+<p>
+	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
+</p>
+<p>
+	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+		Ukraine Crisis Fund
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+		Ukraine Crisis Relief Fund - GlobalGiving
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+		Ukraine Crisis Relief Fund - Save the Children
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+		Crisis in Ukraine - International Rescue Committee
+	</a>
+</p>
+{{< /blocks/cover >}}
 {{< /dismissible-banner >}}
 
 {{< getting-started color="100" height="auto" title="入門" >}}
@@ -26,7 +52,7 @@ Selenium は Log4j を使って <strong>いません</strong> 。 したがっ�
 {{% /getting-started-item %}}
 
 {{% getting-started-item icon="icons/ide.svg" title="Selenium IDE" color="selenium-ide" url="https://selenium.dev/selenium-ide/" url_text="Read more" %}}
-迅速なバグ再現スクリプトを作成したい場合、自動化支援の探索的テストを支援するスクリプトを作成したい場合は、SeleniumIDEを使用します。 
+迅速なバグ再現スクリプトを作成したい場合、自動化支援の探索的テストを支援するスクリプトを作成したい場合は、SeleniumIDEを使用します。
 Chrome、Firefox、Edgeのアドオンがブラウザとの対話の簡単な記録と再生を行います。
 {{% /getting-started-item %}}
 

--- a/website_and_docs/content/_index.ja.html
+++ b/website_and_docs/content/_index.ja.html
@@ -29,20 +29,8 @@ linkTitle = "Selenium"
 		</a>
 	</span>
 	<span class="pr-3">
-		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-			Ukraine Crisis Relief Fund - GlobalGiving
-		</a>
-	</span>
-</p>
-<p>
-	<span class="pr-3">
 		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
 			Ukraine Crisis Relief Fund - Save the Children
-		</a>
-	</span>
-	<span class="pr-3">
-		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-			Crisis in Ukraine - International Rescue Committee
 		</a>
 	</span>
 </p>

--- a/website_and_docs/content/_index.ja.html
+++ b/website_and_docs/content/_index.ja.html
@@ -16,8 +16,16 @@ linkTitle = "Selenium"
 
 {{< dismissible-banner color="yellow" >}}
 {{< blocks/cover height="min" color="selenium-cyan" >}}
-<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
-<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
+<div class="container">
+	<div class="row justify-content-center align-items-center">
+		<div class="col-8 pr-2">
+			<h1 class="display-1 m-0 p-0 text-right">Selenium Supports Ukraine</h1>
+		</div>
+		<div class="col-2 pl-2 text-left">
+			<h1 style="font-size: 5rem;" class="m-0 p-0">🇺🇦</h1>
+		</div>
+	</div>
+</div>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>

--- a/website_and_docs/content/_index.ja.html
+++ b/website_and_docs/content/_index.ja.html
@@ -15,31 +15,36 @@ linkTitle = "Selenium"
 {{< /blocks/cover >}}
 
 {{< dismissible-banner color="yellow" >}}
-{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
-<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+{{< blocks/cover height="min" color="selenium-cyan" >}}
+<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
+<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
 </p>
 <p>
-	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
-		Ukraine Crisis Fund
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+			Ukraine Crisis Fund
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+			Ukraine Crisis Relief Fund - GlobalGiving
+		</a>
+	</span>
 </p>
 <p>
-	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-		Ukraine Crisis Relief Fund - GlobalGiving
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
-		Ukraine Crisis Relief Fund - Save the Children
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-		Crisis in Ukraine - International Rescue Committee
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+			Ukraine Crisis Relief Fund - Save the Children
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+			Crisis in Ukraine - International Rescue Committee
+		</a>
+	</span>
 </p>
 {{< /blocks/cover >}}
 {{< /dismissible-banner >}}

--- a/website_and_docs/content/_index.other.html
+++ b/website_and_docs/content/_index.other.html
@@ -29,20 +29,8 @@ linkTitle = "Selenium"
 		</a>
 	</span>
 	<span class="pr-3">
-		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-			Ukraine Crisis Relief Fund - GlobalGiving
-		</a>
-	</span>
-</p>
-<p>
-	<span class="pr-3">
 		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
 			Ukraine Crisis Relief Fund - Save the Children
-		</a>
-	</span>
-	<span class="pr-3">
-		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-			Crisis in Ukraine - International Rescue Committee
 		</a>
 	</span>
 </p>

--- a/website_and_docs/content/_index.other.html
+++ b/website_and_docs/content/_index.other.html
@@ -16,8 +16,16 @@ linkTitle = "Selenium"
 
 {{< dismissible-banner color="yellow" >}}
 {{< blocks/cover height="min" color="selenium-cyan" >}}
-<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
-<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
+<div class="container">
+	<div class="row justify-content-center align-items-center">
+		<div class="col-8 pr-2">
+			<h1 class="display-1 m-0 p-0 text-right">Selenium Supports Ukraine</h1>
+		</div>
+		<div class="col-2 pl-2 text-left">
+			<h1 style="font-size: 5rem;" class="m-0 p-0">🇺🇦</h1>
+		</div>
+	</div>
+</div>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>

--- a/website_and_docs/content/_index.other.html
+++ b/website_and_docs/content/_index.other.html
@@ -15,31 +15,36 @@ linkTitle = "Selenium"
 {{< /blocks/cover >}}
 
 {{< dismissible-banner color="yellow" >}}
-{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
-<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+{{< blocks/cover height="min" color="selenium-cyan" >}}
+<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
+<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
 </p>
 <p>
-	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
-		Ukraine Crisis Fund
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+			Ukraine Crisis Fund
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+			Ukraine Crisis Relief Fund - GlobalGiving
+		</a>
+	</span>
 </p>
 <p>
-	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-		Ukraine Crisis Relief Fund - GlobalGiving
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
-		Ukraine Crisis Relief Fund - Save the Children
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-		Crisis in Ukraine - International Rescue Committee
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+			Ukraine Crisis Relief Fund - Save the Children
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+			Crisis in Ukraine - International Rescue Committee
+		</a>
+	</span>
 </p>
 {{< /blocks/cover >}}
 {{< /dismissible-banner >}}

--- a/website_and_docs/content/_index.other.html
+++ b/website_and_docs/content/_index.other.html
@@ -14,8 +14,34 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
-{{< dismissible-banner title="Log4j Vulnerability" alert="note" color="orange" >}}
-Selenium does <strong>not</strong> use Log4j, thus is unaffected by [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105).
+{{< dismissible-banner color="yellow" >}}
+{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
+<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+<p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
+<p>
+	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
+</p>
+<p>
+	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+		Ukraine Crisis Fund
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+		Ukraine Crisis Relief Fund - GlobalGiving
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+		Ukraine Crisis Relief Fund - Save the Children
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+		Crisis in Ukraine - International Rescue Committee
+	</a>
+</p>
+{{< /blocks/cover >}}
 {{< /dismissible-banner >}}
 
 {{< dismissible-banner title="Welcome!" alert="note" color="blue" >}}

--- a/website_and_docs/content/_index.pt-br.html
+++ b/website_and_docs/content/_index.pt-br.html
@@ -29,20 +29,8 @@ linkTitle = "Selenium"
 		</a>
 	</span>
 	<span class="pr-3">
-		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-			Ukraine Crisis Relief Fund - GlobalGiving
-		</a>
-	</span>
-</p>
-<p>
-	<span class="pr-3">
 		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
 			Ukraine Crisis Relief Fund - Save the Children
-		</a>
-	</span>
-	<span class="pr-3">
-		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-			Crisis in Ukraine - International Rescue Committee
 		</a>
 	</span>
 </p>

--- a/website_and_docs/content/_index.pt-br.html
+++ b/website_and_docs/content/_index.pt-br.html
@@ -16,8 +16,16 @@ linkTitle = "Selenium"
 
 {{< dismissible-banner color="yellow" >}}
 {{< blocks/cover height="min" color="selenium-cyan" >}}
-<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
-<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
+<div class="container">
+	<div class="row justify-content-center align-items-center">
+		<div class="col-8 pr-2">
+			<h1 class="display-1 m-0 p-0 text-right">Selenium Supports Ukraine</h1>
+		</div>
+		<div class="col-2 pl-2 text-left">
+			<h1 style="font-size: 5rem;" class="m-0 p-0">🇺🇦</h1>
+		</div>
+	</div>
+</div>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>

--- a/website_and_docs/content/_index.pt-br.html
+++ b/website_and_docs/content/_index.pt-br.html
@@ -15,31 +15,36 @@ linkTitle = "Selenium"
 {{< /blocks/cover >}}
 
 {{< dismissible-banner color="yellow" >}}
-{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
-<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+{{< blocks/cover height="min" color="selenium-cyan" >}}
+<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
+<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
 </p>
 <p>
-	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
-		Ukraine Crisis Fund
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+			Ukraine Crisis Fund
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+			Ukraine Crisis Relief Fund - GlobalGiving
+		</a>
+	</span>
 </p>
 <p>
-	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-		Ukraine Crisis Relief Fund - GlobalGiving
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
-		Ukraine Crisis Relief Fund - Save the Children
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-		Crisis in Ukraine - International Rescue Committee
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+			Ukraine Crisis Relief Fund - Save the Children
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+			Crisis in Ukraine - International Rescue Committee
+		</a>
+	</span>
 </p>
 {{< /blocks/cover >}}
 {{< /dismissible-banner >}}

--- a/website_and_docs/content/_index.pt-br.html
+++ b/website_and_docs/content/_index.pt-br.html
@@ -14,8 +14,34 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
-{{< dismissible-banner title="Log4j Vulnerability" alert="note" color="orange" >}}
-Selenium does <strong>not</strong> use Log4j, thus is unaffected by [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105).
+{{< dismissible-banner color="yellow" >}}
+{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
+<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+<p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
+<p>
+	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
+</p>
+<p>
+	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+		Ukraine Crisis Fund
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+		Ukraine Crisis Relief Fund - GlobalGiving
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+		Ukraine Crisis Relief Fund - Save the Children
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+		Crisis in Ukraine - International Rescue Committee
+	</a>
+</p>
+{{< /blocks/cover >}}
 {{< /dismissible-banner >}}
 
 {{< translation-alert >}}

--- a/website_and_docs/content/_index.zh-cn.html
+++ b/website_and_docs/content/_index.zh-cn.html
@@ -29,20 +29,8 @@ linkTitle = "Selenium"
 		</a>
 	</span>
 	<span class="pr-3">
-		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-			Ukraine Crisis Relief Fund - GlobalGiving
-		</a>
-	</span>
-</p>
-<p>
-	<span class="pr-3">
 		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
 			Ukraine Crisis Relief Fund - Save the Children
-		</a>
-	</span>
-	<span class="pr-3">
-		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-			Crisis in Ukraine - International Rescue Committee
 		</a>
 	</span>
 </p>

--- a/website_and_docs/content/_index.zh-cn.html
+++ b/website_and_docs/content/_index.zh-cn.html
@@ -16,8 +16,16 @@ linkTitle = "Selenium"
 
 {{< dismissible-banner color="yellow" >}}
 {{< blocks/cover height="min" color="selenium-cyan" >}}
-<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
-<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
+<div class="container">
+	<div class="row justify-content-center align-items-center">
+		<div class="col-8 pr-2">
+			<h1 class="display-1 m-0 p-0 text-right">Selenium Supports Ukraine</h1>
+		</div>
+		<div class="col-2 pl-2 text-left">
+			<h1 style="font-size: 5rem;" class="m-0 p-0">🇺🇦</h1>
+		</div>
+	</div>
+</div>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>

--- a/website_and_docs/content/_index.zh-cn.html
+++ b/website_and_docs/content/_index.zh-cn.html
@@ -15,31 +15,36 @@ linkTitle = "Selenium"
 {{< /blocks/cover >}}
 
 {{< dismissible-banner color="yellow" >}}
-{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
-<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+{{< blocks/cover height="min" color="selenium-cyan" >}}
+<h1 class="display-1 m-0 p-0">Selenium Supports Ukraine</h1>
+<h1 style="font-size: 10rem;" class="m-0 p-0">🇺🇦</h1>
 <p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
 <p>
 	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
 </p>
 <p>
-	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
-		Ukraine Crisis Fund
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+			Ukraine Crisis Fund
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+			Ukraine Crisis Relief Fund - GlobalGiving
+		</a>
+	</span>
 </p>
 <p>
-	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
-		Ukraine Crisis Relief Fund - GlobalGiving
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
-		Ukraine Crisis Relief Fund - Save the Children
-	</a>
-</p>
-<p>
-	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
-		Crisis in Ukraine - International Rescue Committee
-	</a>
+	<span class="pr-3">
+		<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+			Ukraine Crisis Relief Fund - Save the Children
+		</a>
+	</span>
+	<span class="pr-3">
+		<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+			Crisis in Ukraine - International Rescue Committee
+		</a>
+	</span>
 </p>
 {{< /blocks/cover >}}
 {{< /dismissible-banner >}}

--- a/website_and_docs/content/_index.zh-cn.html
+++ b/website_and_docs/content/_index.zh-cn.html
@@ -14,8 +14,34 @@ linkTitle = "Selenium"
 </div>
 {{< /blocks/cover >}}
 
-{{< dismissible-banner title="Log4j Vulnerability" alert="note" color="orange" >}}
-Selenium does <strong>not</strong> use Log4j, thus is unaffected by [CVE-2021-45105](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105">CVE-2021-45105).
+{{< dismissible-banner color="yellow" >}}
+{{< blocks/cover title="Selenium Supports Ukraine" image_anchor="top" height="min" color="selenium-cyan" >}}
+<h1 style="font-size: 10rem;" class="p-0">🇺🇦</h1>
+<p>In solidarity, we ask that you consider financially supporting efforts such as:</p>
+<p>
+	<a target='_blank' href="https://savelife.in.ua/en/donate/">Charity supporting the Ukrainian army</a>
+</p>
+<p>
+	<a target='_blank' href="https://my.care.org/site/Donation2;jsessionid=00000000.app330a?idb=1446257559&df_id=31067&mfc_pref=T&31067.donation=form1&NONCE_TOKEN=DC484FF7D834B5F3C654398E2486150F">
+		Ukraine Crisis Fund
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://www.globalgiving.org/projects/ukraine-crisis-relief-fund/">
+		Ukraine Crisis Relief Fund - GlobalGiving
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://support.savethechildren.org/site/Donation2;jsessionid=00000000.app30117a?idb=476971079&df_id=5751&mfc_pref=T&5751.donation=form1&NONCE_TOKEN=D16B99B6B4D1D1ADCB5FD2CE363DDC2F">
+		Ukraine Crisis Relief Fund - Save the Children
+	</a>
+</p>
+<p>
+	<a target='_blank' href="https://help.rescue.org/donate/ukraine-acq">
+		Crisis in Ukraine - International Rescue Committee
+	</a>
+</p>
+{{< /blocks/cover >}}
 {{< /dismissible-banner >}}
 
 {{< translation-alert >}}

--- a/website_and_docs/layouts/partials/alerts.html
+++ b/website_and_docs/layouts/partials/alerts.html
@@ -1,10 +1,14 @@
 {{ $alert_type := .alert_type }}
 
 <div class="row td-box--200 justify-content-center">
-  <div class="alert alert-{{ .color }} bg-transparent col-6 pl-lg-5 my-4 alert-dismissible fade show" role="alert">
+  <div class="alert alert-{{ .color }} bg-transparent col-10 pl-lg-5 my-4 alert-dismissible fade show" role="alert">
+    {{ if .title }}
     <h2 class="alert-heading pb-3 text-center">{{ .title }}</h2>
+    {{ end }}
     <div class="w-100">
+      {{ if $alert_type }}
       <strong>{{ humanize $alert_type }}: </strong>
+      {{ end }}
       {{ markdownify .p1 }}
       {{ if .p2 }}
       <br><br>

--- a/website_and_docs/layouts/shortcodes/blocks/cover.html
+++ b/website_and_docs/layouts/shortcodes/blocks/cover.html
@@ -5,7 +5,7 @@
 {{ $col_id := .Get "color" | default "dark" }}
 {{ $image_anchor := .Get "image_anchor" | default "smart" }}
 {{ $logo_anchor := .Get "logo_anchor" | default "smart" }}
-{{/* Height can be one of: auto, min, med, max, full. */}}
+{{/* Height can be one of: auto, min, med, max, full, tiny. */}}
 {{ $height := .Get "height" | default "max" }}
 {{ $byline := .Get "byline" | default "" }}
 {{ with $promo_image }}

--- a/website_and_docs/layouts/shortcodes/blocks/cover.html
+++ b/website_and_docs/layouts/shortcodes/blocks/cover.html
@@ -15,36 +15,36 @@
 <link rel="preload" as="image" href="{{ $promo_image_big.RelPermalink }}" media="(min-width: 1200px)">
 <style>
 #{{ $blockID }} {
-    background-image: url({{ $promo_image_small.RelPermalink }}); 
+    background-image: url({{ $promo_image_small.RelPermalink }});
 }
 @media only screen and (min-width: 1200px) {
     #{{ $blockID }} {
-        background-image: url({{ $promo_image_big.RelPermalink }}); 
+        background-image: url({{ $promo_image_big.RelPermalink }});
     }
 }
 </style>
 {{ end }}
 <section id="{{ $blockID }}" class="row td-cover-block td-cover-block--height-{{ $height }} js-td-cover -bg-{{ $col_id }}">
-  <div class="container td-overlay__inner">
-    <div class="row">
-      <div class="col-12">
-        <div class="text-center">
-          {{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-1">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
-          {{ with .Get "subtitle" }}<p class="display-1 font-weight-normal mb-0">{{ . | html }}</p>{{ end }}
-          <div class="pt-3 lead">
-            {{ if eq .Page.File.Ext "md" }}
-                {{ .Inner | markdownify }}
-            {{ else }}
-                {{ .Inner | htmlUnescape | safeHTML }}
-            {{ end }}
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  {{ if $byline }}
-  <div class="byline">
-    <small>{{ $byline }}</small>
-  </div>
-  {{ end }}
+<div class="container td-overlay__inner">
+<div class="row">
+<div class="col-12">
+<div class="text-center">
+{{ with .Get "title" }}<h1 class="display-1 mt-0 mt-md-5 pb-1">{{ $title := . }}{{ with $logo_image }}{{ $logo_image_resized := (.Fit (printf "70x70 %s" $logo_anchor)) }}<img class="td-cover-logo" src="{{ $logo_image_resized.RelPermalink }}" alt="{{ $title | html }} Logo">{{ end }}{{ $title | html }}</h1>{{ end }}
+{{ with .Get "subtitle" }}<p class="display-1 font-weight-normal mb-0">{{ . | html }}</p>{{ end }}
+<div class="pt-3 lead">
+{{ if eq .Page.File.Ext "md" }}
+    {{ .Inner | markdownify }}
+{{ else }}
+    {{ .Inner | htmlUnescape | safeHTML }}
+{{ end }}
+</div>
+</div>
+</div>
+</div>
+</div>
+{{ if $byline }}
+<div class="byline">
+<small>{{ $byline }}</small>
+</div>
+{{ end }}
 </section>


### PR DESCRIPTION
I tried to make a collapsable banner like we did for BLM, but I couldn't figure out how to do that with this visual representation which I prefer. We could do a more text-based banner if we prefer.

I researched various charities with Charity Navigator & Guidestar, and these 4 get nearly top marks for efficiency and transparency.
