### PR TITLE
fix typo

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
@@ -191,7 +191,7 @@ val emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-ema
 {{< /tab >}}
 {{< /tabpane >}}
 
-### Chaining relative lcoators
+### Chaining relative locators
 
 You can also chain locators if needed. Sometimes the element is most easily identified as being both above/below one
 element and right/left of another.

--- a/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
@@ -195,7 +195,7 @@ val emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-ema
 {{< /tab >}}
 {{< /tabpane >}}
 
-### Chaining relative lcoators
+### Chaining relative locators
 
 You can also chain locators if needed. Sometimes the element is most easily identified as being both above/below one
 element and right/left of another.

--- a/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
@@ -195,7 +195,7 @@ val emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-ema
 {{< /tab >}}
 {{< /tabpane >}}
 
-### Chaining relative lcoators
+### Chaining relative locators
 
 You can also chain locators if needed. Sometimes the element is most easily identified as being both above/below one
 element and right/left of another.


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

I've found typo regarding `lcoators`->`locators`

As the following codeblock, all typos regarding `lcoators` are fixed.

```bash
# Before edit

$ grep lcoators -rl *
website_and_docs/content/documentation/webdriver/elements/locators.ja.md
website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md

# After edit
$ grep lcoators -rl *
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Make this more readable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
