### PR TITLE
Fixed incorrect variable name in C# example

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/upgrade_to_selenium_4.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/upgrade_to_selenium_4.en.md
@@ -129,7 +129,7 @@ var cloudOptions = new Dictionary<string, object>();
 cloudOptions.Add("build", myTestBuild);
 cloudOptions.Add("name", myTestName);
 browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
-var driver = new RemoteWebDriver(new Uri(CloudURL), options);
+var driver = new RemoteWebDriver(new Uri(CloudURL), browserOptions);
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 options = Selenium::WebDriver::Options.firefox

--- a/website_and_docs/content/documentation/webdriver/getting_started/upgrade_to_selenium_4.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/upgrade_to_selenium_4.ja.md
@@ -125,7 +125,7 @@ var cloudOptions = new Dictionary<string, object>();
 cloudOptions.Add("build", myTestBuild);
 cloudOptions.Add("name", myTestName);
 browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
-var driver = new RemoteWebDriver(new Uri(CloudURL), options);
+var driver = new RemoteWebDriver(new Uri(CloudURL), browserOptions);
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 options = Selenium::WebDriver::Options.firefox

--- a/website_and_docs/content/documentation/webdriver/getting_started/upgrade_to_selenium_4.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/upgrade_to_selenium_4.pt-br.md
@@ -143,7 +143,7 @@ var cloudOptions = new Dictionary<string, object>();
 cloudOptions.Add("build", myTestBuild);
 cloudOptions.Add("name", myTestName);
 browserOptions.AddAdditionalOption("cloud:options", cloudOptions);
-var driver = new RemoteWebDriver(new Uri(CloudURL), options);
+var driver = new RemoteWebDriver(new Uri(CloudURL), browserOptions);
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 options = Selenium::WebDriver::Options.firefox

--- a/website_and_docs/content/documentation/webdriver/getting_started/upgrade_to_selenium_4.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/upgrade_to_selenium_4.zh-cn.md
@@ -139,7 +139,7 @@ var cloudOptions = new Dictionary<string, object>();
 cloudOptions.Add("build", myTestBuild);
 cloudOptions.Add("name", myTestName);
 browserOptions.AddAdditionalOption("cloud: options", cloudOptions);
-var driver = new RemoteWebDriver(new Uri(CloudURL), options);
+var driver = new RemoteWebDriver(new Uri(CloudURL), browserOptions);
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 options = Selenium: : WebDriver: : Options.firefox


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
The after C# example showed the driver being initiated with a missing parameter called `options`, the object being built in the example is called `browserOptions` so have updated the example to save confusion.

### Motivation and Context
Fixes documentation

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
