### PR TITLE
Fix wrong link to EdgeDriver instead of GeckoDriver

### DIFF
--- a/website_and_docs/content/ecosystem/_index.html
+++ b/website_and_docs/content/ecosystem/_index.html
@@ -71,7 +71,7 @@ aliases:
           </a>
         </p>
         <p class="card-text text-center m-0 pb-1">
-          <a href="https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads" class="card-link">
+          <a href="https://github.com/mozilla/geckodriver/releases" class="card-link">
             Releases
           </a>
         </p>


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
