### PR TITLE
Remove passing id explicitly in devtools Javascript examples

### DIFF
--- a/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools.en.md
@@ -121,7 +121,6 @@ const { Builder } = require("selenium-webdriver");
     };
       await pageCdpConnection.execute(
         "Emulation.setGeolocationOverride",
-        1,
         coordinates
       );
   } catch (e) {
@@ -262,7 +261,6 @@ async function executeCDPCommands () {
   };
   await cdpConnection.execute(
     "Emulation.setGeolocationOverride",
-    1,
     coordinates
   );
  await driver.quit();
@@ -414,7 +412,6 @@ options.enableDebugger();
     };
     await pageCdpConnection.execute(
       "Emulation.setDeviceMetricsOverride",
-      1,
       metrics
     );
     await driver.get("https://www.google.com");

--- a/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools.ja.md
@@ -130,7 +130,6 @@ const { Builder } = require("selenium-webdriver");
     };
       await pageCdpConnection.execute(
         "Emulation.setGeolocationOverride",
-        1,
         coordinates
       );
   } catch (e) {
@@ -271,7 +270,6 @@ async function executeCDPCommands () {
   };
   await cdpConnection.execute(
     "Emulation.setGeolocationOverride",
-    1,
     coordinates
   );
  await driver.quit();
@@ -423,7 +421,6 @@ options.enableDebugger();
     };
     await pageCdpConnection.execute(
       "Emulation.setDeviceMetricsOverride",
-      1,
       metrics
     );
     await driver.get("https://www.google.com");

--- a/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools.pt-br.md
@@ -130,7 +130,6 @@ const { Builder } = require("selenium-webdriver");
     };
       await pageCdpConnection.execute(
         "Emulation.setGeolocationOverride",
-        1,
         coordinates
       );
   } catch (e) {
@@ -271,7 +270,6 @@ async function executeCDPCommands () {
   };
   await cdpConnection.execute(
     "Emulation.setGeolocationOverride",
-    1,
     coordinates
   );
  await driver.quit();
@@ -423,7 +421,6 @@ options.enableDebugger();
     };
     await pageCdpConnection.execute(
       "Emulation.setDeviceMetricsOverride",
-      1,
       metrics
     );
     await driver.get("https://www.google.com");

--- a/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools.zh-cn.md
@@ -128,7 +128,6 @@ const { Builder } = require("selenium-webdriver");
     };
       await pageCdpConnection.execute(
         "Emulation.setGeolocationOverride",
-        1,
         coordinates
       );
   } catch (e) {
@@ -269,7 +268,6 @@ async function executeCDPCommands () {
   };
   await cdpConnection.execute(
     "Emulation.setGeolocationOverride",
-    1,
     coordinates
   );
  await driver.quit();
@@ -423,7 +421,6 @@ options.enableDebugger();
     };
     await pageCdpConnection.execute(
       "Emulation.setDeviceMetricsOverride",
-      1,
       metrics
     );
     await driver.get("https://www.google.com");


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The chrome dev tools Javascript examples were passing id explicitly and hence the example was not working for the latest Javascript Selenium binding.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix code example to ensure it works correctly

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [X] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [X] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
