### PR TITLE
Ecosystem addition: Parasol, the language binding for Selenium in Pharo Smalltalk

### DIFF
--- a/website_and_docs/content/ecosystem/_index.html
+++ b/website_and_docs/content/ecosystem/_index.html
@@ -272,6 +272,17 @@ aliases:
           <td>Dart</td>
           <td>Google</td>
         </tr>
+        <tr>
+          <th scope="row">
+            <p>
+              <a href="https://github.com/SeasideSt/Parasol">
+                Parasol
+              </a>
+            </p>
+          </th>
+          <td>Pharo Smalltalk</td>
+          <td>Pharo Seaside community</td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
### Description
Added a link to the github project for the Parasol project: a selenium language binding for the Pharo Smalltalk language (https://pharo.org/)

### Motivation and Context
We have been maintaining and using this binding to selenium over 10 years. Would be nice to have it listed here ;-)

### Types of changes
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

