### PR TITLE
updated ruby bindings version to reflect actual version + updated link to work

### DIFF
--- a/website_and_docs/layouts/partials/selenium-clients-and-webdriver-bindings.html
+++ b/website_and_docs/layouts/partials/selenium-clients-and-webdriver-bindings.html
@@ -54,8 +54,8 @@
         </p>
         <p class="card-text m-0 pb-1">
           Stable:
-          <a href="https://rubygems.org/gems/selenium-webdriver/versions/4.2.2" class="card-link">
-              4.2.2 (June 9, 2022)
+          <a href="https://rubygems.org/gems/selenium-webdriver/versions/4.2.1" class="card-link">
+              4.2.1 (May 31, 2022)
           </a>
         </p>
         <p class="card-text m-0 pb-1">


### PR DESCRIPTION

### Fixed a broken link
if you go to https://www.selenium.dev/downloads/
you can see ruby bindings listed as 4.2.2
when you click it the url 404s as the latest version is 4.2.1

### Motivation and Context
It solves the ruby bindings giving a 404 and updates the bindings to reflect its current version

### Types of changes
I updated the layout located at /layouts/partials/selenium-clents-and-webdriver-bindings.html

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

