### PR TITLE
Minor fix in WebDriverManager name

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/install_drivers.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/install_drivers.en.md
@@ -46,7 +46,7 @@ the correct driver for your browser, there are many third party libraries to ass
 {{< tabpane disableCodeBlock=true >}}
 {{< tab header="Java" >}}
 
-1. Import [WebDriver Manager](https://github.com/bonigarcia/webdrivermanager)
+1. Import [WebDriverManager](https://github.com/bonigarcia/webdrivermanager)
 ```java
 import io.github.bonigarcia.wdm.WebDriverManager;
 ```


### PR DESCRIPTION
### Description
The project WebDriverManager does not contains an space in between.

### Motivation and Context
Documentation minor fix.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
