### PR TITLE
Added more details on moveByOffset to make it clear which directions the mouse moves

### DIFF
--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
@@ -310,6 +310,10 @@ If the mouse has not previously been moved, the position will be in the upper le
 corner of the viewport.
 Note that the pointer position does not change when the page is scrolled.
 
+Note that the first argument X specifies to move right when positive, while the second argument
+Y specifies to move down when positive. So `moveByOffset(30, -10)` moves right 30 and up 10 from
+the current mouse position.
+
 {{< tabpane disableCodeBlock=true height="3" >}}
     {{< tab header="Java" >}}
         {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L153-L155" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md
@@ -310,6 +310,10 @@ If the mouse has not previously been moved, the position will be in the upper le
 corner of the viewport.
 Note that the pointer position does not change when the page is scrolled.
 
+Note that the first argument X specifies to move right when positive, while the second argument
+Y specifies to move down when positive. So `moveByOffset(30, -10)` moves right 30 and up 10 from
+the current mouse position.
+
 {{< tabpane disableCodeBlock=true height="3" >}}
     {{< tab header="Java" >}}
         {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L153-L155" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md
@@ -310,6 +310,10 @@ If the mouse has not previously been moved, the position will be in the upper le
 corner of the viewport.
 Note that the pointer position does not change when the page is scrolled.
 
+Note that the first argument X specifies to move right when positive, while the second argument
+Y specifies to move down when positive. So `moveByOffset(30, -10)` moves right 30 and up 10 from
+the current mouse position.
+
 {{< tabpane disableCodeBlock=true height="3" >}}
     {{< tab header="Java" >}}
         {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L153-L155" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md
@@ -310,6 +310,10 @@ If the mouse has not previously been moved, the position will be in the upper le
 corner of the viewport.
 Note that the pointer position does not change when the page is scrolled.
 
+Note that the first argument X specifies to move right when positive, while the second argument
+Y specifies to move down when positive. So `moveByOffset(30, -10)` moves right 30 and up 10 from
+the current mouse position.
+
 {{< tabpane disableCodeBlock=true height="3" >}}
     {{< tab header="Java" >}}
         {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L153-L155" >}}


### PR DESCRIPTION
Fixes #1087

I felt the documentation for moveByOffset wasn't clear in terms of how the mouse moves based on X and Y inputs.  So I propose this change to make it clear how a positive X and a positive Y moves the mouse pointer.

### Description
This is a simple addition to the moveByOffset documentation.

### Motivation and Context
I myself experienced some confusion on this. I incorrectly assumed a positive Y would move the mouse up.  But after experimenting I realized a positive Y moves the mouse down.  So I documented that in this PR.  I have also seen other QA engineers struggle with the mouse portion of the Actions API. I hope these changes will make it more clear.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ X] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
