### PR TITLE
Use retries mechanism for running Java examples

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -29,7 +29,10 @@ jobs:
     - name: Start Xvfb
       run: Xvfb :99 &
     - name: Run tests
-      run: |
-        cd examples/java
-        mvn -B test
-
+      uses: nick-invision/retry@v2.7.1
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        command: |
+          cd examples/java
+          mvn -B test

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -13,8 +13,8 @@
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.11</logback.version>
 
-        <junit5.version>5.8.2</junit5.version>
-        <wdm.version>5.2.1</wdm.version>
+        <junit5.version>5.9.0</junit5.version>
+        <wdm.version>5.2.2</wdm.version>
 
         <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
 


### PR DESCRIPTION
### Description
This PR implements a retries mechanism in GH Actions (using [nick-fields/retry](https://github.com/nick-fields/retry)) for running Java examples.

### Motivation and Context
This PR complements #1081 (about running Java test examples in CI) for retrying tests in case of failure.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [X] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
