### PR TITLE
Bump to WebDriverManager 5.2.3

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -14,7 +14,7 @@
         <logback.version>1.2.11</logback.version>
 
         <junit5.version>5.9.0</junit5.version>
-        <wdm.version>5.2.2</wdm.version>
+        <wdm.version>5.2.3</wdm.version>
 
         <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
 


### PR DESCRIPTION
### Description
This PR bumps the version of WebDriverManager to 5.2.3, released on August 3, 2022.

### Motivation and Context
WebDriverManager 5.2.3 aims to mitigate the occurrence of the HTTP 403 error (forbidden), due to consecutive requests to GitHub. In the Selenium tests, it might happen when trying to resolve geckodriver, which is hosted on GitHub.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [X] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
