### PR TITLE
Fix first Java script example and doc

### DIFF
--- a/examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java
+++ b/examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java
@@ -1,12 +1,17 @@
 package dev.selenium.getting_started;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
@@ -31,11 +36,23 @@ public class FirstScriptTest {
     }
 
     @Test
-    public void test() {
-        driver.get("https://google.com");
+    public void eightComponents() {
+        driver.get("https://duckduckgo.com/");
 
         String title = driver.getTitle();
-        assertEquals("Google", title);
+        assertTrue(title.contains("DuckDuckGo"));
+
+        driver.manage().timeouts().implicitlyWait(Duration.ofMillis(500));
+
+        WebElement searchBox = driver.findElement(By.name("q"));
+        WebElement searchButton = driver.findElement(By.id("search_button_homepage"));
+
+        searchBox.sendKeys("Selenium");
+        searchButton.click();
+
+        searchBox = driver.findElement(By.name("q"));
+        String value = searchBox.getAttribute("value");
+        assertEquals("Selenium", value);
     }
 
 }

--- a/website_and_docs/content/documentation/about/style.en.md
+++ b/website_and_docs/content/documentation/about/style.en.md
@@ -166,7 +166,7 @@ shortcode. This is an example of the `gh-codeblock` shortcode usage:
 
     {{</* tabpane */>}}
       {{</* tab header="Link" disableCodeBlock=true */>}}
-        {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L15-L37" */>}}
+        {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" */>}}
       {{</* /tab */>}}
       {{</* tab header="No Link" */>}}
         This content should not get linked to GitHub
@@ -177,7 +177,7 @@ Which looks like this:
 
 {{< tabpane >}}
   {{< tab header="Link" disableCodeBlock=true >}}
-    {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L15-L37" >}}
+    {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" >}}
   {{< /tab >}}
   {{< tab header="No Link" >}}
     This content should not get linked to GitHub
@@ -239,12 +239,12 @@ All code examples should be present and linked to in our example
 With the `gh-codeblock` shortcode, it is possible to render code hosted in a GitHub
 repository. This is an example of the `gh-codeblock` shortcode usage:
 
-    {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L15-L37" */>}}
+    {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" */>}}
 
 Which looks like this:
 
 <span class="tab-pane">
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L15-L37" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" >}}
 </span>
 
 ### Consistent Heights

--- a/website_and_docs/content/documentation/about/style.ja.md
+++ b/website_and_docs/content/documentation/about/style.ja.md
@@ -167,7 +167,7 @@ shortcode. This is an example of the `gh-codeblock` shortcode usage:
 
     {{</* tabpane */>}}
       {{</* tab header="Link" disableCodeBlock=true */>}}
-        {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" */>}}
+        {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" */>}}
       {{</* /tab */>}}
       {{</* tab header="No Link" */>}}
         This content should not get linked to GitHub
@@ -178,7 +178,7 @@ Which looks like this:
 
 {{< tabpane >}}
   {{< tab header="Link" disableCodeBlock=true >}}
-    {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" >}}
+    {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" >}}
   {{< /tab >}}
   {{< tab header="No Link" >}}
     This content should not get linked to GitHub
@@ -239,12 +239,12 @@ All code examples should be present and linked to in our example
 With the `gh-codeblock` shortcode, it is possible to render code hosted in a GitHub
 repository. This is an example of the `gh-codeblock` shortcode usage:
 
-    {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" */>}}
+    {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" */>}}
 
 Which looks like this:
 
 <span class="tab-pane">
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" >}}
 </span>
 
 ### Code Comments

--- a/website_and_docs/content/documentation/about/style.pt-br.md
+++ b/website_and_docs/content/documentation/about/style.pt-br.md
@@ -167,7 +167,7 @@ shortcode. This is an example of the `gh-codeblock` shortcode usage:
 
     {{</* tabpane */>}}
       {{</* tab header="Link" disableCodeBlock=true */>}}
-        {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" */>}}
+        {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" */>}}
       {{</* /tab */>}}
       {{</* tab header="No Link" */>}}
         This content should not get linked to GitHub
@@ -178,7 +178,7 @@ Which looks like this:
 
 {{< tabpane >}}
   {{< tab header="Link" disableCodeBlock=true >}}
-    {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" >}}
+    {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" >}}
   {{< /tab >}}
   {{< tab header="No Link" >}}
     This content should not get linked to GitHub
@@ -239,12 +239,12 @@ All code examples should be present and linked to in our example
 With the `gh-codeblock` shortcode, it is possible to render code hosted in a GitHub
 repository. This is an example of the `gh-codeblock` shortcode usage:
 
-    {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" */>}}
+    {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" */>}}
 
 Which looks like this:
 
 <span class="tab-pane">
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" >}}
 </span>
 
 ### Code Comments

--- a/website_and_docs/content/documentation/about/style.zh-cn.md
+++ b/website_and_docs/content/documentation/about/style.zh-cn.md
@@ -167,7 +167,7 @@ shortcode. This is an example of the `gh-codeblock` shortcode usage:
 
     {{</* tabpane */>}}
       {{</* tab header="Link" disableCodeBlock=true */>}}
-        {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" */>}}
+        {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" */>}}
       {{</* /tab */>}}
       {{</* tab header="No Link" */>}}
         This content should not get linked to GitHub
@@ -178,7 +178,7 @@ Which looks like this:
 
 {{< tabpane >}}
   {{< tab header="Link" disableCodeBlock=true >}}
-    {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" >}}
+    {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" >}}
   {{< /tab >}}
   {{< tab header="No Link" >}}
     This content should not get linked to GitHub
@@ -239,12 +239,12 @@ All code examples should be present and linked to in our example
 With the `gh-codeblock` shortcode, it is possible to render code hosted in a GitHub
 repository. This is an example of the `gh-codeblock` shortcode usage:
 
-    {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" */>}}
+    {{</* gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" */>}}
 
 Which looks like this:
 
 <span class="tab-pane">
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17-L37" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L38-L56" >}}
 </span>
 
 ### Code Comments

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
@@ -20,7 +20,7 @@ For more details on starting a session read our documentation on [opening and cl
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L30" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L6" >}}
@@ -44,7 +44,7 @@ In this example we are [navigating]({{< ref "/documentation/webdriver/browser/na
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L19" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L40" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L8" >}}
@@ -70,7 +70,7 @@ can request, including window handles, browser size / position, cookies, alerts,
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L21" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L42" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L10" >}}
@@ -104,7 +104,7 @@ Read more about [Waiting strategies]({{< ref "/documentation/webdriver/waits.md"
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L24" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L45" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L13" >}}
@@ -129,7 +129,7 @@ with one without first [finding an element]({{< ref "/documentation/webdriver/el
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L26-L27" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L47-L48" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L15-L16" >}}
@@ -154,7 +154,7 @@ but you will use them frequently.
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L29-L30" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L50-L51" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L18-L19" >}}
@@ -179,7 +179,7 @@ Notice that we need to relocate the search box because the DOM has changed since
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L33" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L54" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L22" >}}
@@ -205,7 +205,7 @@ No more commands can be sent to this driver instance.
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L36" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L35" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L25" >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
@@ -21,7 +21,7 @@ For more details on starting a session read our documentation on [opening and cl
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L30" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L6" >}}
@@ -45,7 +45,7 @@ In this example we are ブラウザが[ナビゲート]({{< ref "/documentation/
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L19" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L40" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L8" >}}
@@ -71,7 +71,7 @@ can request, including window handles, browser size / position, cookies, alerts,
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L21" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L42" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L10" >}}
@@ -105,7 +105,7 @@ Read more about [Waiting strategies]({{< ref "/documentation/webdriver/waits.md"
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L24" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L45" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L13" >}}
@@ -130,7 +130,7 @@ with one without first [finding an element]({{< ref "/documentation/webdriver/el
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L26-L27" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L47-L48" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L15-L16" >}}
@@ -155,7 +155,7 @@ but you will use them frequently.
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L29-L30" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L50-L51" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L18-L19" >}}
@@ -180,7 +180,7 @@ Notice that we need to relocate the search box because the DOM has changed since
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L33" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L54" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L22" >}}
@@ -206,7 +206,7 @@ No more commands can be sent to this driver instance.
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L36" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L35" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L25" >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
@@ -19,7 +19,7 @@ Para ter mais detalhes sobre como iniciar uma sessão, leia nossa documentação
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L30" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L6" >}}
@@ -43,7 +43,7 @@ Nesse exemplo estamos [navegando]({{< ref "/documentation/webdriver/browser/navi
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L19" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L40" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L8" >}}
@@ -68,7 +68,7 @@ pode solicitar, incluindo window handles, tamanho / posição do navegador, cook
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L21" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L42" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L10" >}}
@@ -103,7 +103,7 @@ Leia mais sobre [Estratégias de espera]({{< ref "/documentation/webdriver/waits
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L24" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L45" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L13" >}}
@@ -129,7 +129,7 @@ com um sem o primeiro [encontrando um elemento]({{< ref "/documentation/webdrive
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L26-L27" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L47-L48" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L15-L16" >}}
@@ -154,7 +154,7 @@ mas você irá usá-las com frequência.
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L29-L30" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L50-L51" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L18-L19" >}}
@@ -178,7 +178,7 @@ Elementos podem guardar muitas [informações que podem ser solicitadas]({{< ref
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L33" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L54" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L22" >}}
@@ -204,7 +204,7 @@ Nenhum outro comando pode ser enviado para esta instância do driver.
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L36" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L35" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L25" >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
@@ -24,7 +24,7 @@ Selenium所做的一切,
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L17" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L30" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L6" >}}
@@ -51,7 +51,7 @@ Selenium所做的一切,
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L19" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L40" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L8" >}}
@@ -77,7 +77,7 @@ Selenium所做的一切,
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L21" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L42" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L10" >}}
@@ -116,7 +116,7 @@ Selenium所做的一切,
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L24" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L45" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L13" >}}
@@ -142,7 +142,7 @@ Selenium所做的一切,
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L26-L27" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L47-L48" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L15-L16" >}}
@@ -168,7 +168,7 @@ Selenium所做的一切,
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L29-L30" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L50-L51" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L18-L19" >}}
@@ -195,7 +195,7 @@ DOM已经发生了变化.
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L33" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L54" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L22" >}}
@@ -222,7 +222,7 @@ DOM已经发生了变化.
 
 {{< tabpane disableCodeBlock=true >}}
     {{< tab header="Java" >}}
-        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L36" >}}
+        {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScriptTest.java#L35" >}}
     {{< /tab >}}
     {{< tab header="Python" >}}
         {{< gh-codeblock path="examples/python/tests/getting_started/test_first_script.py#L25" >}}


### PR DESCRIPTION
### Description
This PR fix the first Java script example and [page](https://www.selenium.dev/documentation/webdriver/getting_started/first_script/), currently broken.

### Motivation and Context
I broke this page on #1081, sorry.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [X] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [X] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
