### PR TITLE
Fix-correction-in-"FInding-web-elements"

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/finders.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.en.md
@@ -75,27 +75,27 @@ ancestor of the undesired element, then call find element on that object:
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
 WebElement fruits = driver.findElement(By.id("fruits"));
-WebElement fruit = fruits.findElement(By.id("tomatoes"));
+WebElement fruit = fruits.findElement(By.className("tomatoes"));
   {{< /tab >}}
   {{< tab header="Python" >}}
 fruits = driver.find_element(By.ID, "fruits")
-fruit = fruits.find_elements(By.ID,"tomatoes")
+fruit = fruits.find_element(By.CLASS_NAME,"tomatoes")
   {{< /tab >}}
   {{< tab header="CSharp" >}}
 IWebElement fruits = driver.FindElement(By.Id("fruits"));
-IWebElement fruit = fruits.FindElement(By.Id("tomatoes"));
+IWebElement fruit = fruits.FindElement(By.ClassName("tomatoes"));
   {{< /tab >}}
   {{< tab header="Ruby" >}}
 fruits = driver.find_element(id: 'fruits')
-fruit = fruits.find_element(id: 'tomatoes')
+fruit = fruits.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 const fruits = driver.findElement(By.id('fruits'));
-const fruit = fruits.findElement(By.id('tomatoes'));
+const fruit = fruits.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val fruits = driver.findElement(By.id("fruits"))
-val fruit = fruits.findElement(By.id("tomatoes"))
+val fruit = fruits.findElement(By.className("tomatoes"))
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -523,5 +523,4 @@ It is used to track (or) find DOM element which has the focus in the current bro
   }
   {{< /tab >}}
 {{< /tabpane >}}
-
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
@@ -71,27 +71,27 @@ DOM全体で一意のロケーターを見つけるのではなく、検索を�
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
 WebElement fruits = driver.findElement(By.id("fruits"));
-WebElement fruit = fruits.findElement(By.id("tomatoes"));
+WebElement fruit = fruits.findElement(By.className("tomatoes"));
   {{< /tab >}}
   {{< tab header="Python" >}}
 fruits = driver.find_element(By.ID, "fruits")
-fruit = fruits.find_elements(By.ID,"tomatoes")
+fruit = fruits.find_element(By.CLASS_NAME,"tomatoes")
   {{< /tab >}}
   {{< tab header="CSharp" >}}
 IWebElement fruits = driver.FindElement(By.Id("fruits"));
-IWebElement fruit = fruits.FindElement(By.Id("tomatoes"));
+IWebElement fruit = fruits.FindElement(By.ClassName("tomatoes"));
   {{< /tab >}}
   {{< tab header="Ruby" >}}
 fruits = driver.find_element(id: 'fruits')
-fruit = fruits.find_element(id: 'tomatoes')
+fruit = fruits.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 const fruits = driver.findElement(By.id('fruits'));
-const fruit = fruits.findElement(By.id('tomatoes'));
+const fruit = fruits.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val fruits = driver.findElement(By.id("fruits"))
-val fruit = fruits.findElement(By.id("tomatoes"))
+val fruit = fruits.findElement(By.className("tomatoes"))
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
@@ -73,27 +73,27 @@ ancestral do elemento indesejado, então invoque o find element nesse objeto:
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
 WebElement fruits = driver.findElement(By.id("fruits"));
-WebElement fruit = fruits.findElement(By.id("tomatoes"));
+WebElement fruit = fruits.findElement(By.className("tomatoes"));
   {{< /tab >}}
   {{< tab header="Python" >}}
 fruits = driver.find_element(By.ID, "fruits")
-fruit = fruits.find_elements(By.ID,"tomatoes")
+fruit = fruits.find_element(By.CLASS_NAME,"tomatoes")
   {{< /tab >}}
   {{< tab header="CSharp" >}}
 IWebElement fruits = driver.FindElement(By.Id("fruits"));
-IWebElement fruit = fruits.FindElement(By.Id("tomatoes"));
+IWebElement fruit = fruits.FindElement(By.ClassName("tomatoes"));
   {{< /tab >}}
   {{< tab header="Ruby" >}}
 fruits = driver.find_element(id: 'fruits')
-fruit = fruits.find_element(id: 'tomatoes')
+fruit = fruits.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 const fruits = driver.findElement(By.id('fruits'));
-const fruit = fruits.findElement(By.id('tomatoes'));
+const fruit = fruits.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val fruits = driver.findElement(By.id("fruits"))
-val fruit = fruits.findElement(By.id("tomatoes"))
+val fruit = fruits.findElement(By.className("tomatoes"))
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
@@ -76,27 +76,27 @@ ancestor of the undesired element, then call find element on that object:
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
 WebElement fruits = driver.findElement(By.id("fruits"));
-WebElement fruit = fruits.findElement(By.id("tomatoes"));
+WebElement fruit = fruits.findElement(By.className("tomatoes"));
   {{< /tab >}}
   {{< tab header="Python" >}}
 fruits = driver.find_element(By.ID, "fruits")
-fruit = fruits.find_elements(By.ID,"tomatoes")
+fruit = fruits.find_element(By.CLASS_NAME,"tomatoes")
   {{< /tab >}}
   {{< tab header="CSharp" >}}
 IWebElement fruits = driver.FindElement(By.Id("fruits"));
-IWebElement fruit = fruits.FindElement(By.Id("tomatoes"));
+IWebElement fruit = fruits.FindElement(By.ClassName("tomatoes"));
   {{< /tab >}}
   {{< tab header="Ruby" >}}
 fruits = driver.find_element(id: 'fruits')
-fruit = fruits.find_element(id: 'tomatoes')
+fruit = fruits.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 const fruits = driver.findElement(By.id('fruits'));
-const fruit = fruits.findElement(By.id('tomatoes'));
+const fruit = fruits.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val fruits = driver.findElement(By.id("fruits"))
-val fruit = fruits.findElement(By.id("tomatoes"))
+val fruit = fruits.findElement(By.className("tomatoes"))
   {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
Fix-correction-in-"FInding-web-elements"

In [Evaluating a subset of the DOM](https://www.selenium.dev/documentation/webdriver/elements/finders/#evaluating-a-subset-of-the-dom) section, classes are accessed as ids.