### PR TITLE
highlight what the documentation applies to

### DIFF
--- a/website_and_docs/layouts/partials/breadcrumb.html
+++ b/website_and_docs/layouts/partials/breadcrumb.html
@@ -1,0 +1,33 @@
+{{ $isSingle := true -}}
+{{ with .Parent -}}
+  {{ $isSingle = .IsHome -}}
+{{ end -}}
+<nav aria-label="breadcrumb" class="td-breadcrumbs
+    {{- if $isSingle }} td-breadcrumbs__single {{- end }}">
+  <ol class="breadcrumb">
+    {{- template "breadcrumbnav" (dict "p1" . "p2" .) }}
+
+    {{ if (in . "legacy") }}
+    <div class="ml-auto mr-3 font-weight-bold" data-toggle="tooltip" data-placement="bottom"
+         title="This code is for outdated versions of Selenium.">Legacy Code!</div>
+    {{ else }}
+    <div class="ml-auto mr-3 font-weight-bold" data-toggle="tooltip" data-placement="bottom"
+         title="All examples work in Selenium 4.0+ unless otherwise indicated.">v4.0</div>
+    {{ end }}
+  </ol>
+</nav>
+
+{{- define "breadcrumbnav" -}}
+  {{ if .p1.Parent -}}
+    {{ if not .p1.Parent.IsHome -}}
+      {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 )  -}}
+    {{ end -}}
+  {{ else if not .p1.IsHome -}}
+    {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  -}}
+  {{ end -}}
+  {{ $isActive :=  eq .p1 .p2 }}
+  <li class="breadcrumb-item{{ if $isActive }} active{{ end }}"
+      {{- if $isActive }} aria-current="page"{{ end }}>
+    <a href="{{ .p1.Permalink }}">{{ .p1.LinkTitle }}</a>
+  </li>
+{{- end -}}


### PR DESCRIPTION
At the Test Automation Summit it was suggested that it was not clear what version the example code applies to.

Is this marking sufficient? It's not ideal because I'm overriding the default docsy breadcrumbs template, and if anything other than "documentation" wants to use breadcrumbs, it'll cause an issue.

I did figure out how to make a note that the "Legacy" section is not going to have valid examples.