### PR TITLE
[dotnet] Restore pen test logic to calculate x,y coordinates

### DIFF
--- a/examples/dotnet/SeleniumDocs/ActionsAPI/PenTest.cs
+++ b/examples/dotnet/SeleniumDocs/ActionsAPI/PenTest.cs
@@ -35,8 +35,8 @@ namespace SeleniumDocs.ActionsAPI
 
             Point location = pointerArea.Location;
             Size size = pointerArea.Size;
-            int centerX = (int) Math.Floor((decimal) location.X + size.Width / 2);
-            int centerY = (int) Math.Floor((decimal) location.Y + size.Height / 2);
+            int centerX = location.X + size.Width / 2;
+            int centerY = location.Y + size.Height / 2;
 
             Assert.AreEqual("-1", moveTo["button"]);
             Assert.AreEqual("pen", moveTo["pointerType"]);


### PR DESCRIPTION
### Description
This PR tries to fix `PenTest.cs` (.Net).

### Motivation and Context
Due to a change in the logic an assertion of a dotnet tests, `PenTest` is failing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [X] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
