### PR TITLE
fix broken link

### DIFF
--- a/website_and_docs/content/documentation/overview/components.ja.md
+++ b/website_and_docs/content/documentation/overview/components.ja.md
@@ -49,6 +49,6 @@ WebDriverには1つのジョブしかありません:　上記の任意のメソ
 テストフレームワークは、WebDriverおよびテストの関連手順の実行を担当します。
 それは下記図に似ていると考えることができます。
 
-{{< figure src="/images/documentation/webdriver/remote_comms_test_frameworkserver.png" class="img-responsive text-center" alt="テストフレームワーク">}}
+{{< figure src="/images/documentation/webdriver/test_framework.png" class="img-responsive text-center" alt="テストフレームワーク">}}
 
 上図でCucumberなどの自然言語のフレームワーク/ツールがテストフレームワークボックスの一部として存在する場合があります、またはテストフレームワークを独自の実装で完全に密閉する場合があります。


### PR DESCRIPTION

### Description
<!--- Describe your changes in detail -->
The link to the image was broken, so changed to the appropriate image URL.

![image](https://user-images.githubusercontent.com/1114078/195607248-d472135e-f9d6-400b-950e-2394c2207d81.png)

website_and_docs\content\documentation\overview\components.ja.md

### Motivation and Context

Viewers can see the images.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
