### PR TITLE
Japanese Translation of Browsers - chrome,edge

### DIFF
--- a/website_and_docs/content/documentation/webdriver/browsers/_index.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/_index.ja.md
@@ -1,6 +1,6 @@
 ---
-title: "Supported Browsers"
-linkTitle: "Browsers"
+title: "対応ブラウザ"
+linkTitle: "ブラウザ"
 weight: 4
 aliases: [
 "/documentation/ja/driver_idiosyncrasies/",
@@ -11,4 +11,4 @@ aliases: [
 ]
 ---
 
-Each browser has custom capabilities and unique features.
+各ブラウザには、カスタムCapabilityと固有の機能があります。

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
@@ -1,24 +1,24 @@
 ---
-title: "Chrome specific functionality"
+title: "Chrome固有の機能"
 linkTitle: "Chrome"
 weight: 4
 description: >-
-    These are capabilities and features specific to Google Chrome browsers.
+    これらは、Google Chrome ブラウザに固有のCapabilityです。
 aliases: [
 "/ja/documentation/capabilities/chromium"
 ]
 ---
 
-By default, Selenium 4 is compatible with Chrome v75 and greater. Note that the version of
-the Chrome browser and the version of chromedriver must match the major version.
+デフォルトでは、Selenium 4 は Chrome v75 以降と互換性があります。 
+Chromeブラウザのバージョンと chromedriverのバージョンは、メジャーバージョンと一致する必要があることに注意してください。
 
 ## Options
 
-Capabilities common to all browsers are described on the [Options page]({{< ref "../drivers/options.md" >}}).
+全てのブラウザに共通のCapabilityについては、[オプション ページ]({{< ref "../drivers/options.md" >}})で説明しています。
 
-Capabilities unique to Chrome can be found at Google's page for [Capabilities & ChromeOptions](https://chromedriver.chromium.org/capabilities)
+Chrome に固有のCapabilityは、Google の[Capabilities & ChromeOptions](https://chromedriver.chromium.org/capabilities)ページにあります。
 
-Starting a Chrome session with basic defined options looks like this:
+基本的な定義済みオプションを使用してChromeセッションを開始すると、次のようになります。
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}
@@ -42,72 +42,72 @@ Note that Python must specify service class to use [Driver Manager]({{< ref "../
 {{< /tab >}}
 {{< /tabpane >}}
 
-Here are a few common use cases with different capabilities:
+さまざまなCapabilityを備えた一般的な使用例をいくつか示します。
 
-### Arguments
+### 引数
 
-The `args` parameter is for a list of [Command Line Switches](https://peter.sh/experiments/chromium-command-line-switches/)
-used when starting the browser.
-Commonly used args include `--start-maximized` and `user-data-dir=/tmp/temp_profile`
+`args` パラメータは、ブラウザの起動時に使用される[コマンドラインスイッチ](https://peter.sh/experiments/chromium-command-line-switches/)のリストです。  
+一般的に使用される引数には、`--start-maximized` および `user-data-dir=/tmp/temp_profile` が含まれます。
 
-Add an argument to options:
-
-{{< alert-code />}}
-
-### Start browser in a specified location
-
-The `binary` parameter takes the path of an alternate location of browser to use. With this parameter you can
-use chromedriver to drive various Chromium based browsers.
-
-Add a browser location to options:
+オプションに引数を追加します。
 
 {{< alert-code />}}
 
-### Add extensions
+### 指定したロケーションでブラウザを起動する
 
-The `extensions` parameter accepts crx files
+`binary`パラメーターは、使用するブラウザの別のロケーションのパスを取ります。 
+このパラメーターを使用すると、chromedriver を使用して、さまざまな Chromium ベースのブラウザを駆動できます。
 
-Add an extension to options:
-
-{{< alert-code />}}
-
-### Keeping browser open
-
-Setting the `detach` parameter to true will keep the browser open after the driver process has been quit.
-
-Ad a binary to options:
+オプションにブラウザのロケーションを追加します。
 
 {{< alert-code />}}
 
-### Excluding arguments
+### 拡張機能を追加する
 
-Chrome adds various arguments, if you do not want those arguments added, pass them into `excludeSwitches`.
-A common example is to turn the popup blocker back on.
+`extensions` パラメーターはcrxファイルを受け入れます
 
-Set excluded arguments on options:
-
-{{< alert-code />}}
-
-## Casting
-
-You can drive Chrome Cast devices, including sharing tabs
+オプションに拡張機能を追加します。
 
 {{< alert-code />}}
 
-## Network conditions
+### ブラウザを開いたままにする
 
-You can simulate various network conditions.
+`detach` パラメータをtrueに設定すると、ドライバープロセスが終了した後もブラウザを開いたままにできます。
 
-{{< alert-code />}}
-
-## Logs
+オプションにバイナリを追加します。
 
 {{< alert-code />}}
 
-## Permissions
+### 引数を除外する
+
+Chrome はさまざまな引数を追加します。
+これらの引数を追加したくない場合は、それらを `excludeSwitches` に渡します。 
+一般的な例は、ポップアップブロッカーをオンに設定することです。
+
+オプションに除外された引数を設定します。
 
 {{< alert-code />}}
 
-## DevTools
+## キャスティング
 
-See the [Chrome DevTools]({{< ref "../bidirectional/chrome_devtools.md" >}}) section for more information about using Chrome DevTools
+タブの共有など、Chrome Castデバイスを操作できます。
+
+{{< alert-code />}}
+
+## ネットワークの状態
+
+さまざまなネットワークの状態をシミュレートできます。
+
+{{< alert-code />}}
+
+## ログ
+
+{{< alert-code />}}
+
+## パーミッション
+
+{{< alert-code />}}
+
+## デベロッパー ツール
+
+Chromeデベロッパーツールの使用に関する詳細については、[Chromeデベロッパー ツール]({{< ref "../bidirectional/chrome_devtools.md" >}})セクションを参照してください。

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
@@ -1,19 +1,19 @@
 ---
-title: "Edge specific functionality"
+title: "Edge固有の機能"
 linkTitle: "Edge"
 weight: 5
 description: >-
-    These are capabilities and features specific to Microsoft Edge browsers.
+    これらは、Microsoft Edgeブラウザに固有のCapabilityです。
 ---
 
-Microsoft Edge is implemented with Chromium, with the earliest supported version of v79. Similar to Chrome,
-the major version number of edgedriver must match the major version of the Edge browser.
+Microsoft EdgeはChromiumで実装されており、サポートされている最も古いバージョンはv79です。
+Chromeと同様に、edgedriverのメジャー バージョン番号は、Edgeブラウザのメジャーバージョンと一致する必要があります。
 
-All capabilities and options found on the [Chrome page]({{< ref "chrome.md" >}}) work for Edge as well.
+[Chromeページ]({{< ref "chrome.md" >}}) にあるすべての機能とオプションは、Edgeでも機能します。
 
-## Options
+## オプション
 
-Starting an Edge session with basic defined options looks like this:
+基本的な定義済みオプションを使用して Edgeセッションを開始すると、次のようになります。
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}
@@ -37,8 +37,8 @@ Note that Python must specify service class to use [Driver Manager]({{< ref "../
 {{< /tab >}}
 {{< /tabpane >}}
 
-## Internet Explorer Compatibility Mode
+## Internet Explorer Compatibility モード
 
-Microsoft Edge can be driven in "Internet Explorer Compatibility Mode," which uses
-the Internet Explorer Driver classes in conjunction with Microsoft Edge.
-Read the [Internet Explorer page]({{< ref "internet_explorer.md" >}}) for more details.
+Microsoft Edge は、Internet Explorer ドライバークラスを Microsoft Edgeと組み合わせて使用する 
+"Internet Explorer 互換モード"で動かすことができます。 
+詳細については、[Internet Explorerページ]({{< ref "internet_explorer.md" >}})を参照してください。


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Japanese Translation of Browsers
- content/documentation/webdriver/browsers/_index.ja.md
- content/documentation/webdriver/browsers/chrome.ja.md
- content/documentation/webdriver/browsers/edge.ja.md

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
