### PR TITLE
Add Logic to check expected page is Available and ready for requests …

### DIFF
--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.en.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.en.md
@@ -96,6 +96,10 @@ public class SignInPage {
 
   public SignInPage(WebDriver driver){
     this.driver = driver;
+    if (!driver.getTitle().equals("Sign In Page")) {
+      throw new IllegalStateException("This is not Sign In Page," +
+            " current page is: " + driver.getCurrentUrl());
+    }
   }
 
   /**

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.ja.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.ja.md
@@ -75,6 +75,10 @@ public class SignInPage {
 
   public SignInPage(WebDriver driver){
     this.driver = driver;
+    if (!driver.getTitle().equals("Home Page of logged in user")) {
+      throw new IllegalStateException("This is not Home Page of logged in user," +
+            " current page is: " + driver.getCurrentUrl());
+    }
   }
 
   /**

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.pt-br.md
@@ -86,6 +86,10 @@ public class SignInPage {
 
   public SignInPage(WebDriver driver){
     this.driver = driver;
+    if (!driver.getTitle().equals("Home Page of logged in user")) {
+      throw new IllegalStateException("This is not Home Page of logged in user," +
+            " current page is: " + driver.getCurrentUrl());
+    }
   }
 
   /**

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.zh-cn.md
@@ -69,6 +69,10 @@ public class SignInPage {
 
   public SignInPage(WebDriver driver){
     this.driver = driver;
+    if (!driver.getTitle().equals("Home Page of logged in user")) {
+      throw new IllegalStateException("This is not Home Page of logged in user," +
+            " current page is: " + driver.getCurrentUrl());
+    }
   }
 
   /**


### PR DESCRIPTION
…in SignInPage Class constructor

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
In website_and_docs > content > documentation > test_practices > encouraged > page_object_models.*.md, inside SignInPage Class constructor there is no logic to check that the expected page is available and ready for requests from the test, but it is mentioned in "Assertions in Page Objects" Paragraph that such logic exists.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I have added the required logic in "page_object_models.*.md" files so that it is in line with what is mentioned in "Assertions in Page Objects" Paragraph.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
