### PR TITLE
Add Logic in SignInPage class Constructor to check that the expected …

### DIFF
--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.en.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.en.md
@@ -96,6 +96,10 @@ public class SignInPage {
 
   public SignInPage(WebDriver driver){
     this.driver = driver;
+     if (!driver.getTitle().equals("Sign In Page")) {
+      throw new IllegalStateException("This is not Sign In Page," +
+            " current page is: " + driver.getCurrentUrl());
+    }
   }
 
   /**

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.ja.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.ja.md
@@ -75,6 +75,10 @@ public class SignInPage {
 
   public SignInPage(WebDriver driver){
     this.driver = driver;
+    if (!driver.getTitle().equals("Sign In Page")) {
+      throw new IllegalStateException("This is not Sign In Page," +
+            " current page is: " + driver.getCurrentUrl());
+    }
   }
 
   /**

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.pt-br.md
@@ -86,6 +86,10 @@ public class SignInPage {
 
   public SignInPage(WebDriver driver){
     this.driver = driver;
+    if (!driver.getTitle().equals("Sign In Page")) {
+      throw new IllegalStateException("This is not Sign In Page," +
+            " current page is: " + driver.getCurrentUrl());
+    }
   }
 
   /**

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.zh-cn.md
@@ -69,6 +69,10 @@ public class SignInPage {
 
   public SignInPage(WebDriver driver){
     this.driver = driver;
+    if (!driver.getTitle().equals("Sign In Page")) {
+      throw new IllegalStateException("This is not Sign In Page," +
+            " current page is: " + driver.getCurrentUrl());
+    }
   }
 
   /**


### PR DESCRIPTION
…page is available and ready for requests from the test

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
In website_and_docs > content > documentation > test_practices > encouraged > page_object_models.*.md I have added logic in the "SignInPage" class constructor to check that the expected page is available and ready for requests from the test.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because on your website " https://www.selenium.dev/documentation/test_practices/encouraged/page_object_models/#assertions-in-page-objects" it is mentioned in "Assertions in Page Objects" paragraph that "In the examples above, both the SignInPage and HomePage constructors check that the expected page is available and ready for requests from the test." but there is no logic for that in SignInPage class constructor. So I have added that.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
