### PR TITLE
use lambda expression in the Fluent Wait example

### DIFF
--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -437,10 +437,8 @@ Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
   .pollingEvery(Duration.ofSeconds(5))
   .ignoring(NoSuchElementException.class);
 
-WebElement foo = wait.until(new Function<WebDriver, WebElement>() {
-  public WebElement apply(WebDriver driver) {
-    return driver.findElement(By.id("foo"));
-  }
+WebElement foo = wait.until(driver -> {
+  return driver.findElement(By.id("foo"));
 });
   {{< /tab >}}
   {{< tab header="Python" >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -358,10 +358,8 @@ Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
   .pollingEvery(Duration.ofSeconds(5))
   .ignoring(NoSuchElementException.class);
 
-WebElement foo = wait.until(new Function<WebDriver, WebElement>() {
-  public WebElement apply(WebDriver driver) {
-    return driver.findElement(By.id("foo"));
-  }
+WebElement foo = wait.until(driver -> {
+  return driver.findElement(By.id("foo"));
 });
   {{< /tab >}}
   {{< tab header="Python" >}}

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -444,10 +444,8 @@ Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
   .pollingEvery(Duration.ofSeconds(5))
   .ignoring(NoSuchElementException.class);
 
-WebElement foo = wait.until(new Function<WebDriver, WebElement>() {
-  public WebElement apply(WebDriver driver) {
-    return driver.findElement(By.id("foo"));
-  }
+WebElement foo = wait.until(driver -> {
+  return driver.findElement(By.id("foo"));
 });
   {{< /tab >}}
   {{< tab header="Python" >}}

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -336,10 +336,8 @@ Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
   .pollingEvery(Duration.ofSeconds(5))
   .ignoring(NoSuchElementException.class);
 
-WebElement foo = wait.until(new Function<WebDriver, WebElement>() {
-  public WebElement apply(WebDriver driver) {
-    return driver.findElement(By.id("foo"));
-  }
+WebElement foo = wait.until(driver -> {
+  return driver.findElement(By.id("foo"));
 });
   {{< /tab >}}
   {{< tab header="Python" >}}


### PR DESCRIPTION
Thanks for contributing to the Selenium site and documentation!
A PR well described will help maintainers to quickly review and merge it

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, help reviewers by making them as simple and short as possible.

### Description
This change modifies the example in Java for the Fluent Wait.
It used an anonymous inner classes and now the example uses a lambda expression.

### Motivation and Context
Anonymous inner classes containing only one method should become lambdas (java:S1604)
Before Java 8, the only way to partially support closures in Java was by using anonymous inner classes. But the syntax of anonymous classes may seem unwieldy and unclear. With Java 8, most uses of anonymous inner classes should be replaced by lambdas to highly increase the readability of the source code.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [X] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [X] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
