### PR TITLE
fix capitalization of iframe

### DIFF
--- a/website_and_docs/content/documentation/webdriver/interactions/frames.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/frames.en.md
@@ -1,5 +1,5 @@
 ---
-title: "Working with iframes and frames"
+title: "Working with IFrames and frames"
 linkTitle: "Frames"
 weight: 6
 aliases: [

--- a/website_and_docs/content/documentation/webdriver/interactions/frames.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/frames.en.md
@@ -1,5 +1,5 @@
 ---
-title: "Working with iFrames and frames"
+title: "Working with iframes and frames"
 linkTitle: "Frames"
 weight: 6
 aliases: [

--- a/website_and_docs/content/documentation/webdriver/interactions/frames.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/frames.ja.md
@@ -1,5 +1,5 @@
 ---
-title: "iFrame と Frame の操作"
+title: "IFrame と Frame の操作"
 linkTitle: "フレーム"
 weight: 6
 aliases: [

--- a/website_and_docs/content/documentation/webdriver/interactions/frames.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/frames.pt-br.md
@@ -1,5 +1,5 @@
 ---
-title: "Working with iFrames and frames"
+title: "Working with IFrames and frames"
 linkTitle: "Frames"
 weight: 6
 aliases: [

--- a/website_and_docs/content/documentation/webdriver/interactions/frames.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/frames.zh-cn.md
@@ -1,5 +1,5 @@
 ---
-title: "与iFrames和frames一起工作"
+title: "与IFrames和frames一起工作"
 linkTitle: "Frames"
 weight: 6
 aliases: [


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description

Capitalization fix for iframe, lowercase in title to match frame.

iFrame is not correct, it can be iframe or IFrame, but not iFrame.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Capitalization was incorrect in docs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
