### PR TITLE
Japanese Translation of "Firefox specific functionality"

### DIFF
--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
@@ -62,9 +62,6 @@ options.add_argument("/path/to/profile")
 
 ### 指定したロケーションでブラウザを起動する
 
-The `binary` parameter takes the path of an alternate location of browser to use. For example, with this parameter you can
-use geckodriver to drive Firefox Nightly instead of the production version when both are present on your computer.
-
 `binary` パラメーターは、使用するブラウザーの別のロケーションのパスを取ります。
 たとえば、このパラメーターを使用すると、geckodriver を使用して、製品版とFirefox Nightlyの両方がコンピューターに存在する場合、
 製品版の代わりに Firefox Nightly を駆動できます 。

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
@@ -1,23 +1,24 @@
 ---
-title: "Firefox specific functionality"
+title: "Firefox 固有のCapability"
 linkTitle: "Firefox"
 weight: 6
 description: >-
-    These are capabilities and features specific to Mozilla Firefox browsers.
+    Mozilla Firefox ブラウザーに固有のCapabilityです。
 aliases: [
 "/ja/documentation/capabilities/firefox"
 ]
 ---
 
-Selenium 4 requires Firefox 78 or greater. It is recommended to always use the latest version of geckodriver.
+Selenium 4 には Firefox 78 以降が必要です。 
+常に最新バージョンの geckodriver を使用することをお勧めします。
 
-## Options
+## オプション
 
-Capabilities common to all browsers are described on the [Options page]({{< ref "../drivers/options.md" >}}).
+全ブラウザに共通のCapabilityについては、[オプションページ]({{< ref "../drivers/options.md" >}})で説明しています。
 
-Capabilities unique to Firefox can be found at Mozilla's page for [firefoxOptions](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions)
+Firefox に固有のCapabilityは、Mozilla のページの [firefoxOptions](https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/firefoxOptions) にあります。
 
-Starting a Firefox session with basic defined options looks like this:
+基本的な定義済みのオプションを使用して Firefox セッションを開始すると、以下のようになります。
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}
@@ -40,14 +41,14 @@ Starting a Firefox session with basic defined options looks like this:
 {{< /tab >}}
 {{< /tabpane >}}
 
-Here are a few common use cases with different capabilities:
+さまざまなCapabilityを備えた一般的な使用例をいくつか示します。
 
-### Arguments
+### 引数
 
-The `args` parameter is for a list of Command line switches used when starting the browser.  
-Commonly used args include `-headless` and `"-profile", "/path/to/profile"`
+`args` パラメータは、ブラウザの起動時に使用するコマンドラインスイッチのリストです。
+一般的に使用される引数には、 `-headless` と `"-profile"` 、`"/path/to/profile"` が含まれます。
 
-Add an argument to options:
+オプションに引数を追加します。
 
 <div>
 {{< tabpane langEqualsHeader=true >}}
@@ -59,18 +60,22 @@ options.add_argument("/path/to/profile")
 {{< /tabpane >}}
 </div>
 
-### Start browser in a specified location
+### 指定したロケーションでブラウザを起動する
 
 The `binary` parameter takes the path of an alternate location of browser to use. For example, with this parameter you can
 use geckodriver to drive Firefox Nightly instead of the production version when both are present on your computer.
 
-Add a browser location to options:
+`binary` パラメーターは、使用するブラウザーの別のロケーションのパスを取ります。
+たとえば、このパラメーターを使用すると、geckodriver を使用して、製品版とFirefox Nightlyの両方がコンピューターに存在する場合、
+製品版の代わりに Firefox Nightly を駆動できます 。
+
+オプションにブラウザーのロケーションを追加します。
 
 {{< alert-code />}}
 
-### Profiles
+### プロファイル
 
-There are several ways to work with Firefox profiles
+Firefoxプロファイルを操作するにはいくつかの方法があります。
 
 <div>
 {{< tabpane langEqualsHeader=true >}}
@@ -120,13 +125,13 @@ driver = RemoteWebDriver(options)
 {{< /tabpane >}}
 </div>
 
-## Add-ons
+## アドオン
 
-Unlike Chrome, Firefox extensions are not added as part of capabilities, they are created after starting the driver.
+Chromeとは異なり、Firefoxの拡張機能はCapabilityの一部として追加されるのではなく、ドライバーの起動後に作成されます。
 
-### Installation
+### インストール
 
-A signed xpi file you would get from [Mozilla Addon page](https://addons.mozilla.org/en-US/firefox/) 
+[Mozilla Add-Onsページ](https://addons.mozilla.org/ja/firefox/) から取得する署名付きxpiファイル
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}
@@ -149,9 +154,10 @@ A signed xpi file you would get from [Mozilla Addon page](https://addons.mozilla
 {{< /tab >}}
 {{< /tabpane >}}
 
-### Uninstallation
+### アンインストール
 
-Uninstalling an addon requires knowing its id. The id can be obtained from the return value when installing the add-on.
+アドオンをアンインストールするには、そのIDを知る必要があります。
+IDはアドオンインストール時の戻り値から取得できます。
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}
@@ -175,11 +181,11 @@ Uninstalling an addon requires knowing its id. The id can be obtained from the r
 {{< /tab >}}
 {{< /tabpane >}}
 
-### Unsigned installation
+### 署名なしのインストール
 
-When working with an unfinished or unpublished extension, it will likely not be signed. As such, it can only
-be installed as "temporary." This can be done by passing in either a zip file or a directory, here's an 
-example with a directory:
+未完成または未公開の拡張機能を使用する場合、署名されていない可能性があります。
+そのため、"一時的なもの" としてのみインストールできます。
+これは、zipファイルまたはディレクトリを渡すことで実行できます。ディレクトリの例を次に示します。
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}
@@ -204,10 +210,10 @@ example with a directory:
 {{< /tab >}}
 {{< /tabpane >}}
 
-## Full page screenshots
+## ページ全体のスクリーンショット
 
 {{< alert-code />}}
 
-## Context
+## コンテキスト
 
 {{< alert-code />}}


### PR DESCRIPTION
### Description
Japanese Translation of "Firefox specific functionality"
- content/documentation/webdriver/browsers/firefox.ja.md

### Motivation and Context

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
