### PR TITLE
Add Python and Ruby example for Offset from Element (Center Origin)

### DIFF
--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
@@ -218,45 +218,10 @@ These methods first move the mouse to the designated origin and then
 by the number of pixels in the provided offset.
 Note that the position of the mouse must be in the viewport or else the command will error.
 
-### Offset from Element (Top Left Origin)
+### Offset from Element
 
-This method moves the mouse to the in-view center point of the element
-then attempts to move to the upper left corner of the element and then moves by the
-provided offset.
-
-This will be removed as an option in Selenium 4.3, and only an offset from center of the element
-will be supported. As of Selenium 4.2, this is the default behavior for Ruby, .NET and Python in order
-to be backwards compatible with previous versions of Selenium.
-This approach does not work correctly when the element is not entirely inside the viewport.
-
-{{< tabpane code=false langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-**Not Implemented in Selenium 4**
-{{< /tab >}}
-{{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
-{{< /tab >}}
-{{< tab header="CSharp" >}}
-{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L118-L121" >}}
-{{< /tab >}}
-{{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L97-L100" >}}
-{{< /tab >}}
-{{< tab header="JavaScript" >}}
-{{< gh-codeblock path="/examples/javascript/test/actionsApi/mouse/moveByOffset.spec.js#L18-L19" >}}
-{{< /tab >}}
-{{< tab header="Kotlin" >}}
-{{< badge-code >}}
-{{< /tab >}}
-{{< /tabpane >}}
-
-### Offset from Element (Center Origin)
-
-This method moves to the in-view center point of the element, 
-then moves the mouse by the provided offset
-
-This is the default behavior in Java as of Selenium 4.0, and will be the default
-for the remaining languages as of Selenium 4.3.
+This method moves the mouse to the in-view center point of the element,
+then moves by the provided offset.
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
@@ -263,13 +263,13 @@ for the remaining languages as of Selenium 4.3.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L118-L121" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-**Coming in Selenium 4.3**
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L132-L135" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-**Coming in Selenium 4.3**
+{{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L97-L100" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md
@@ -218,45 +218,10 @@ These methods first move the mouse to the designated origin and then
 by the number of pixels in the provided offset.
 Note that the position of the mouse must be in the viewport or else the command will error.
 
-### Offset from Element (Top Left Origin)
+### Offset from Element
 
-This method moves the mouse to the in-view center point of the element
-then attempts to move to the upper left corner of the element and then moves by the
-provided offset.
-
-This will be removed as an option in Selenium 4.3, and only an offset from center of the element
-will be supported. As of Selenium 4.2, this is the default behavior for Ruby, .NET and Python in order
-to be backwards compatible with previous versions of Selenium.
-This approach does not work correctly when the element is not entirely inside the viewport.
-
-{{< tabpane code=false langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-**Not Implemented in Selenium 4**
-{{< /tab >}}
-{{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
-{{< /tab >}}
-{{< tab header="CSharp" >}}
-{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L118-L121" >}}
-{{< /tab >}}
-{{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L97-L100" >}}
-{{< /tab >}}
-{{< tab header="JavaScript" >}}
-{{< gh-codeblock path="/examples/javascript/test/actionsApi/mouse/moveByOffset.spec.js#L18-L19" >}}
-{{< /tab >}}
-{{< tab header="Kotlin" >}}
-{{< badge-code >}}
-{{< /tab >}}
-{{< /tabpane >}}
-
-### Offset from Element (Center Origin)
-
-This method moves to the in-view center point of the element, 
-then moves the mouse by the provided offset
-
-This is the default behavior in Java as of Selenium 4.0, and will be the default
-for the remaining languages as of Selenium 4.3.
+This method moves the mouse to the in-view center point of the element,
+then moves by the provided offset.
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md
@@ -263,13 +263,13 @@ for the remaining languages as of Selenium 4.3.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L118-L121" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-**Coming in Selenium 4.3**
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L132-L135" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-**Coming in Selenium 4.3**
+{{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L97-L100" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md
@@ -218,45 +218,10 @@ These methods first move the mouse to the designated origin and then
 by the number of pixels in the provided offset.
 Note that the position of the mouse must be in the viewport or else the command will error.
 
-### Offset from Element (Top Left Origin)
+### Offset from Element
 
-This method moves the mouse to the in-view center point of the element
-then attempts to move to the upper left corner of the element and then moves by the
-provided offset.
-
-This will be removed as an option in Selenium 4.3, and only an offset from center of the element
-will be supported. As of Selenium 4.2, this is the default behavior for Ruby, .NET and Python in order
-to be backwards compatible with previous versions of Selenium.
-This approach does not work correctly when the element is not entirely inside the viewport.
-
-{{< tabpane code=false langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-**Not Implemented in Selenium 4**
-{{< /tab >}}
-{{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
-{{< /tab >}}
-{{< tab header="CSharp" >}}
-{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L118-L121" >}}
-{{< /tab >}}
-{{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L97-L100" >}}
-{{< /tab >}}
-{{< tab header="JavaScript" >}}
-{{< gh-codeblock path="/examples/javascript/test/actionsApi/mouse/moveByOffset.spec.js#L18-L19" >}}
-{{< /tab >}}
-{{< tab header="Kotlin" >}}
-{{< badge-code >}}
-{{< /tab >}}
-{{< /tabpane >}}
-
-### Offset from Element (Center Origin)
-
-This method moves to the in-view center point of the element, 
-then moves the mouse by the provided offset
-
-This is the default behavior in Java as of Selenium 4.0, and will be the default
-for the remaining languages as of Selenium 4.3.
+This method moves the mouse to the in-view center point of the element,
+then moves by the provided offset.
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md
@@ -263,13 +263,13 @@ for the remaining languages as of Selenium 4.3.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L118-L121" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-**Coming in Selenium 4.3**
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L132-L135" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-**Coming in Selenium 4.3**
+{{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L97-L100" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md
@@ -123,7 +123,7 @@ There is no convenience method for this, it is just pressing and releasing mouse
 {{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L47-L50" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-version version="4.5.0" >}}     
+{{< badge-version version="4.5.0" >}}
 {{< gh-codeblock path="/examples/javascript/test/actionsApi/mouse/backAndForwardClick.spec.js#L21-L22" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
@@ -218,45 +218,10 @@ These methods first move the mouse to the designated origin and then
 by the number of pixels in the provided offset.
 Note that the position of the mouse must be in the viewport or else the command will error.
 
-### Offset from Element (Top Left Origin)
+### Offset from Element
 
-This method moves the mouse to the in-view center point of the element
-then attempts to move to the upper left corner of the element and then moves by the
-provided offset.
-
-This will be removed as an option in Selenium 4.3, and only an offset from center of the element
-will be supported. As of Selenium 4.2, this is the default behavior for Ruby, .NET and Python in order
-to be backwards compatible with previous versions of Selenium.
-This approach does not work correctly when the element is not entirely inside the viewport.
-
-{{< tabpane code=false langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-**Not Implemented in Selenium 4**
-{{< /tab >}}
-{{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
-{{< /tab >}}
-{{< tab header="CSharp" >}}
-{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L118-L121" >}}
-{{< /tab >}}
-{{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L97-L100" >}}
-{{< /tab >}}
-{{< tab header="JavaScript" >}}
-{{< gh-codeblock path="/examples/javascript/test/actionsApi/mouse/moveByOffset.spec.js#L18-L19" >}}
-{{< /tab >}}
-{{< tab header="Kotlin" >}}
-{{< badge-code >}}
-{{< /tab >}}
-{{< /tabpane >}}
-
-### Offset from Element (Center Origin)
-
-This method moves to the in-view center point of the element, 
-then moves the mouse by the provided offset
-
-This is the default behavior in Java as of Selenium 4.0, and will be the default
-for the remaining languages as of Selenium 4.3.
+This method moves the mouse to the in-view center point of the element,
+then moves by the provided offset.
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md
@@ -263,13 +263,13 @@ for the remaining languages as of Selenium 4.3.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L118-L121" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-**Coming in Selenium 4.3**
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L132-L135" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-**Coming in Selenium 4.3**
+{{< gh-codeblock path="/examples/ruby/spec/actions_api/mouse_spec.rb#L97-L100" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
Related: SeleniumHQ/selenium#10261

### Description

Add examples for `move_to_element_with_offset` for Selenium >= 4.3.

Link: https://www.selenium.dev/documentation/webdriver/actions_api/mouse/#move-by-offset

### Motivation and Context

Correspond to the fix: SeleniumHQ/selenium#11402

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
