### PR TITLE
Fix incorrect example code for Safari written in Python

### DIFF
--- a/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
@@ -29,7 +29,7 @@ Starting a Safari session with basic defined options looks like this:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/SafariTest.java#21-L22" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L10-L11" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_safari.py#L10-L11" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/SafariTest.cs#L14-L15" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
@@ -29,7 +29,7 @@ Starting a Safari session with basic defined options looks like this:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/SafariTest.java#21-L22" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L10-L11" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_safari.py#L10-L11" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/SafariTest.cs#L14-L15" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
@@ -29,7 +29,7 @@ Este é um exemplo de como iniciar uma sessão Safari com um conjunto de opçõe
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/SafariTest.java#21-L22" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L10-L11" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_safari.py#L10-L11" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/SafariTest.cs#L14-L15" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
@@ -29,7 +29,7 @@ Safari独有的Capabilities可以在Apple的页面[关于Safari的WebDriver](htt
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/SafariTest.java#21-L22" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L10-L11" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_safari.py#L10-L11" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/SafariTest.cs#L14-L15" >}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fix the incorrect Python example code in this page: https://www.selenium.dev/documentation/webdriver/browsers/safari/#options

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The sample code for Python is pointed to the wrong test class.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
