### PR TITLE
Method in Doc-Getting CSS Value-Python Corrected

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/information.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/information.en.md
@@ -310,7 +310,7 @@ String cssValue = driver.findElement(By.linkText("More information...")).getCssV
 driver.get('https://www.example.com')
 
     # Retrieves the computed style property 'color' of linktext
-cssValue = driver.findElement(By.LINK_TEXT, "More information...").value_of_css_property('color')
+cssValue = driver.find_element(By.LINK_TEXT, "More information...").value_of_css_property('color')
 
   {{< /tab >}}
   {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/elements/information.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/information.ja.md
@@ -306,7 +306,7 @@ String cssValue = driver.findElement(By.linkText("More information...")).getCssV
 driver.get('https://www.example.com')
 
 # Retrieves the computed style property 'color' of linktext
-cssValue = driver.findElement(By.LINK_TEXT, "More information...").value_of_css_property('color')
+cssValue = driver.find_element(By.LINK_TEXT, "More information...").value_of_css_property('color')
 
 {{< /tab >}}
 {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/elements/information.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/information.pt-br.md
@@ -259,7 +259,7 @@ String cssValue = driver.findElement(By.linkText("More information...")).getCssV
 driver.get('https://www.example.com')
 
 # Retrieves the computed style property 'color' of linktext
-cssValue = driver.findElement(By.LINK_TEXT, "More information...").value_of_css_property('color')
+cssValue = driver.find_element(By.LINK_TEXT, "More information...").value_of_css_property('color')
 
 {{< /tab >}}
 {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/elements/information.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/information.zh-cn.md
@@ -296,7 +296,7 @@ String cssValue = driver.findElement(By.linkText("More information...")).getCssV
 driver.get('https://www.example.com')
 
 # Retrieves the computed style property 'color' of linktext
-cssValue = driver.findElement(By.LINK_TEXT, "More information...").value_of_css_property('color')
+cssValue = driver.find_element(By.LINK_TEXT, "More information...").value_of_css_property('color')
 
 {{< /tab >}}
 {{< tab header="CSharp" >}}


### PR DESCRIPTION
### Description
The method for finding element in Python should be "find_element", which now is wrongly spelled as "findElement" in below: https://www.selenium.dev/documentation/webdriver/elements/information#get-css-value
All the "information.*.md" files in 4 languages are corrected.

### Motivation and Context
People who read documentation about how to get css value in python may get confused due to the erratum above.
I am one of them.
### Types of changes
- [x ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [ x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

