### PR TITLE
Added Portuguese translation in WebDriver/Getting Started and fixed s…

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/_index.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/_index.pt-br.md
@@ -57,7 +57,6 @@ A instalação do Selenium é dividida nas etapas:
 Se você deseja iniciar com ferramenta low-code / gravação e reprodução, por favor veja:
 [Selenium IDE](https://selenium.dev/selenium-ide)
 
-After completing the setup, you can run the code snippet shown at the 
 Depois de completar as etapas de configuração, você pode executar o snippet de codigo em
 [starting page](/pt-br/documentation) na documentação. Então siga para seção
 [WebDriver]({{< ref "/webdriver.md" >}}) para aprender mais sobre automação de navegadores com Selenium.

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
@@ -247,12 +247,13 @@ Vamos combinar essas 8 coisas em um script completo com asserções que podem se
 {{< /tab >}}
 {{< /tabpane >}}
 
-## Test Runners
-If you are using Selenium for testing,
-you will want to execute your Selenium code using test runner tools.
+## Executando Testes
+Se você esta usando selenium para realizar testes,
+você deverá executar seu código usando feramentas para executar testes.
 
-Many of the code examples in this documentation can be found in our example repositories.
-There are multiple options in each language, but here is what we are using in our examples:
+Muitos exemplos de código encontrado nessa documentação podem ser encontrado no nosso repositório de exemplos. 
+Existem múltiplas opções em cada linguagem, mas esta será qual usaremos em nossos exemplos:
+
 
 {{< tabpane code=false langEqualsHeader=true >}}
 {{< tab header="Java" >}}
@@ -288,6 +289,6 @@ mocha firstScript.spec.js
 
 ## Próximos Passos
 
-Use oque você aprendeu e construa o seu proprio código Selenium.
+Use o que você aprendeu e construa o seu proprio código Selenium.
 
 À medida que você encontrar mais funcionalidades de que necessita, leia o restante da nossa [documentação do WebDriver]({{< ref "/documentation/webdriver/" >}}).

--- a/website_and_docs/content/documentation/webdriver/getting_started/install_drivers.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/install_drivers.pt-br.md
@@ -33,18 +33,19 @@ Leia mais sobre opções avançadas para iniciar um driver
 </p>
 {{% /pageinfo %}}
 
-## QuatroTrês maneiras diferentes de usar os drivers
+## Quatro maneiras diferentes de usar os drivers
 
-### 1. Selenium Manager <small>(Beta)</small>
+### 1. Gerenciador Selenium <small>(Beta)</small>
 
 {{< badge-version version="4.6" >}}
 
-Selenium Manager helps you to get a working environment to run Selenium out of the box. Beta 1
-of Selenium Manager will configure the drivers for Chrome, Firefox, and Edge if they are not 
-found on the `PATH`. No extra configuration is needed. Future releases of Selenium Manager 
-will eventually even download browsers if necessary.
+O Gerenciador Selenium te ajuda a ter um ambiente de desenvolvimento rodando Selenium mais facilmente.
+O primeiro Beta irá configurar os drivers para Chrome, Firefox e Edge se eles não forem
+encontrados no `PATH`. Nem uma configuração extra será necessária. Versões futuras do Gerenciador Selenium
+irão eventualmente poder realizar o download dos browsers se necessário.
 
-Read more at the blog announcement for [Selenium Manager ](/blog/2022/introducing-selenium-manager/).
+Leia mais no anúncio feito no blog sobre o [Gerenciador Selenium](/blog/2022/introducing-selenium-manager/).
+
 
 ### 2. Software de gerenciamento de Driver 
 

--- a/website_and_docs/content/documentation/webdriver/getting_started/install_library.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/install_library.pt-br.md
@@ -4,7 +4,7 @@ linkTitle: "Instalando bibliotecas do Selenium"
 weight: 2
 needsTranslation: true
 description: >
-  Setting up the Selenium library for your favourite programming language.
+  Configurando a biblioteca Selenium para sua linguagem de programação favorita.
 aliases: [
 "/documentation/pt-br/selenium_installation/installing_selenium_libraries/",
 "/pt-br/documentation/getting_started/installing_selenium_libraries/",
@@ -15,30 +15,31 @@ aliases: [
 Primeiro você precisa instalar as bibliotecas Selenium para seu projeto de automação.
 O processo de instalação de bibliotecas depende da linguagem que você escolher usar.
 
-## Requirements by language
+## Requisitos por linguagem
 
 {{< tabpane code=false langEqualsHeader=true >}}
   {{% tab header="Java" %}}
-View the minimum supported Java version [here](https://github.com/SeleniumHQ/selenium/blob/trunk/.bazelrc#L13).
+Veja a mínima versão do Java suportada [aqui](https://github.com/SeleniumHQ/selenium/blob/trunk/.bazelrc#L13).
 
-Installation of Selenium libraries for Java is accomplished using a build tool.
+A instalação da biblioteca Selenium para Java é feita a partir de uma build tool.
+
 
 ### Maven
-Specify the dependency in the project's `pom.xml` file:
+Especifique a dependência no `pom.xml` do seu projeto.
 
 {{< gh-codeblock path="examples/java/pom.xml#L22-L26" >}}
 
 ### Gradle
-Specify the dependency in the project `build.gradle` file as `testImplementation`:
+Especifique a dependência no `build.gradle` do seu projeto como `testImplementation`:
 
 {{< gh-codeblock path="examples/java/build.gradle#L13" >}}
 
   {{% /tab %}}
   {{% tab header="Python" %}}
-The minimum supported Python version for each Selenium version can be found
-in `Supported Python Versions` on [PyPi](https://pypi.org/project/selenium/)
+A mínima versão suportada do Python para cada versão do Selenium pode ser encontrada 
+em `Supported Python Versions` no [PyPi](https://pypi.org/project/selenium/)
 
-There are a couple different ways to install Selenium.
+Existe muitas formas diferentes de instalar Selenium.
 
 ### Pip
 
@@ -48,24 +49,24 @@ pip install selenium
 
 ### Download
 
-Alternatively you can download the [PyPI source archive](https://pypi.org/project/selenium/#files)
-(selenium-x.x.x.tar.gz) and install it using _setup.py_:
+Como uma alternativa você pode baixar o [código fonte PyPI](https://pypi.org/project/selenium/#files)
+(selenium-x.x.x.tar.gz) e instalar usando _setup.py_:
 
 ```shell
 python setup.py install
 ```
 
-### Require in project
+### Exigir em um projeto
 
-To use it in a project, add it to the `requirements.txt` file:
+Para usar em um projeto, adicione no arquivo `requirements.txt`.
 {{< gh-codeblock path="examples/python/requirements.txt#L1" >}}
 
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-A list of all supported frameworks for each version of Selenium 
-is available on [Nuget](https://www.nuget.org/packages/Selenium.WebDriver)
+Uma lista com todos os frameworks suportados para cada versão do Selenium
+pode ser encontrada em [Nuget](https://www.nuget.org/packages/Selenium.WebDriver)
 
-There are a few options for installing Selenium.
+Existe algumas opções para instalar o Selenium.
 
 ### Packet Manager
 
@@ -81,22 +82,23 @@ dotnet add package Selenium.WebDriver
 
 ### CSProj
 
-in the project's `csproj` file, specify the dependency as a `PackageReference` in `ItemGroup`:
+No arquivo `csproj` do seu projeto, especifique a dependência como `PackageReference` no `ItemGroup`:
 
 {{< gh-codeblock language="xml" path="examples/dotnet/SeleniumDocs/SeleniumDocs.csproj#L14" >}}
 
-### Additional considerations
+### Considerações adicionais
 
-Further items of note for using Visual Studio Code (vscode) and C#
+Outras observações para usar o Visual Studio Code (vscode) e C#
 
-Install the compatible .NET SDK as per the section above.
-Also install the vscode extensions (Ctrl-Shift-X) for C# and NuGet.
-Follow the [instruction here](https://docs.microsoft.com/en-us/dotnet/core/tutorials/with-visual-studio-code?pivots=dotnet-5-0)
-to create and run the "Hello World" console project using C#.
-You may also create a NUnit starter project using the command line `dotnet new NUnit`.
-Make sure the file `%appdata%\NuGet\nuget.config` is configured properly as some developers reported that it will be empty due to some issues.
-If `nuget.config` is empty, or not configured properly, then .NET builds will fail for Selenium Projects.
-Add the following section to the file `nuget.config` if it is empty:
+Instale a versão compatível do .NET SDK conforme a seção acima.
+Instale também as extensões do vscode (Ctrl-Shift-X) para C# e NuGet.
+Siga as instruções [aqui ](https://docs.microsoft.com/en-us/dotnet/core/tutorials/with-visual-studio-code?pivots=dotnet-5-0)para criar e rodar o seu projeto de "Hello World" no console usando C#.
+
+Você também pode criar um projeto inicial do NUnit usando a linha de comando `dotnet new NUnit`.
+Certifique-se de que o arquivo `%appdata%\NuGet\nuget.config` esteja configurado corretamente, pois alguns desenvolvedores relataram que ele estará vazio devido a alguns problemas.
+Se o `nuget.config` estiver vazio ou não estiver configurado corretamente, as compilações .NET falharão para projetos que estiverem usando Selenium.
+Adicione a seguinte seção ao arquivo `nuget.config` se esse estiver vazio:
+
 ```
 <configuration>
   <packageSources>
@@ -105,52 +107,53 @@ Add the following section to the file `nuget.config` if it is empty:
   </packageSources>
 ...
 ```
-For more info about `nuget.config` [click here](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file).
-You may have to customize `nuget.config` to meet you needs.
+Para mais informações sobre `nuget.config` [clique aqui](https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file).
+Você pode ter que customizar `nuget.config` para atender às suas necessidades.
 
-Now, go back to vscode, press Ctrl-Shift-P, and type "NuGet Add Package", and enter the required Selenium packages such as `Selenium.WebDriver`.
-Press Enter and select the version.
-Now you can use the examples in the documentation related to C# with vscode.
+Agora, volte para o vscode, aperte Ctrl-Shift-P, e digite "NuGet Add Package", e adicione os pacotes necessários para
+o Selenium como o `Selenium.WebDriver`.
+Aperte Enter e selecione a versão.
+Agora você pode usar os exemplos da documentação relacionados ao C# com o vscode.
 
   {{% /tab %}}
   {{% tab header="Ruby" %}}
-You can see the minimum required version of Ruby for any given Selenium version 
-on [rubygems.org](https://rubygems.org/gems/selenium-webdriver/)
+Você pode ver a minima versão suportada do Ruby para cada versão do Selenium em 
+[rubygems.org](https://rubygems.org/gems/selenium-webdriver/)
 
-Selenium can be installed two different ways.
+O Selenium pode ser instalado de duas formas diferentes.
 
-### Install manually
+### Instalação manual
 
 ```shell
 gem install selenium-webdriver
 ```
 
-### Add to project's gemfile
+### Adicione para o gemfile do projeto
 
 {{< gh-codeblock language="ruby" path="examples/ruby/Gemfile#L10" >}}
 
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-You can find the minimum required version of Node for any given version of Selenium in the
-`Node Support Policy` section on [npmjs](https://www.npmjs.com/package/selenium-webdriver)
+Você pode encontrar a mínima versão suportada do Node para cada versão do Selenium 
+na seção `Node Support Policy` no site [npmjs](https://www.npmjs.com/package/selenium-webdriver)
 
-Selenium is typically installed using npm.
+Selenium é normalmente instalado usando npm.
 
-### Install locally
+### Instalação local
 
 ```shell
 npm install selenium-webdriver
 ```
 
-### Add to project
+### Adicione ao seu projeto
 
-In your project's `package.json`, add requirement to `dependencies`:
+No `package.json` do seu projeto, adicione os requisitos em `dependencies`:
 
 {{< gh-codeblock path="examples/javascript/package.json#L14" >}}
 
   {{% /tab %}}
-  {{< tab header="Kotlin" >}}
-    Use the Java bindings for Kotlin.
+  {{< tab header="Kotlin" >}}   
+    Use as ligações Java para Kotlin.
   {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Added and fixed translation errors in Getting Started and its children like: Install Library, Install Drivers, First Script and 'Upgrade to Selenium 4'

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I was reading the documentation and I came across some parts of it in English, as I'm Brazilian, I thought I'd help translate that part, I think I'd help translate more parts in the future.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [x] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
