### PR TITLE
Fixed missing await in finders.en.md

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/finders.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.en.md
@@ -55,7 +55,7 @@ var vegetable = driver.FindElement(By.ClassName("tomatoes"));
 vegetable = driver.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const vegetable = driver.findElement(By.className('tomatoes'));
+const vegetable = await driver.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
@@ -90,7 +90,7 @@ fruits = driver.find_element(id: 'fruits')
 fruit = fruits.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruits = driver.findElement(By.id('fruits'));
+const fruits = await driver.findElement(By.id('fruits'));
 const fruit = fruits.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
@@ -132,7 +132,7 @@ var fruit = driver.FindElement(By.CssSelector("#fruits .tomatoes"));
 fruit = driver.find_element(css: '#fruits .tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruit = driver.findElement(By.css('#fruits .tomatoes'));
+const fruit = await driver.findElement(By.css('#fruits .tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
@@ -161,7 +161,7 @@ IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));
 plants = driver.find_elements(tag_name: 'li')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const plants = driver.findElements(By.tagName('li'));
+const plants = await driver.findElements(By.tagName('li'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val plants: List<WebElement> = driver.findElements(By.tagName("li"))

--- a/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
@@ -53,7 +53,7 @@ var vegetable = driver.FindElement(By.ClassName("tomatoes"));
 vegetable = driver.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const vegetable = driver.findElement(By.className('tomatoes'));
+const vegetable = await driver.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
@@ -86,7 +86,7 @@ fruits = driver.find_element(id: 'fruits')
 fruit = fruits.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruits = driver.findElement(By.id('fruits'));
+const fruits = await driver.findElement(By.id('fruits'));
 const fruit = fruits.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
@@ -125,7 +125,7 @@ var fruit = driver.FindElement(By.CssSelector("#fruits .tomatoes"));
 fruit = driver.find_element(css: '#fruits .tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruit = driver.findElement(By.css('#fruits .tomatoes'));
+const fruit = await driver.findElement(By.css('#fruits .tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
@@ -154,7 +154,7 @@ IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));
 plants = driver.find_elements(tag_name: 'li')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const plants = driver.findElements(By.tagName('li'));
+const plants = await driver.findElements(By.tagName('li'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val plants: List<WebElement> = driver.findElements(By.tagName("li"))

--- a/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
@@ -54,7 +54,7 @@ var vegetable = driver.FindElement(By.ClassName("tomatoes"));
 vegetable = driver.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const vegetable = driver.findElement(By.className('tomatoes'));
+const vegetable = await driver.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
@@ -88,7 +88,7 @@ fruits = driver.find_element(id: 'fruits')
 fruit = fruits.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruits = driver.findElement(By.id('fruits'));
+const fruits = await driver.findElement(By.id('fruits'));
 const fruit = fruits.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
@@ -129,7 +129,7 @@ var fruit = driver.FindElement(By.CssSelector("#fruits .tomatoes"));
 fruit = driver.find_element(css: '#fruits .tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruit = driver.findElement(By.css('#fruits .tomatoes'));
+const fruit = await driver.findElement(By.css('#fruits .tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
@@ -157,7 +157,7 @@ IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));
 plants = driver.find_elements(tag_name: 'li')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const plants = driver.findElements(By.tagName('li'));
+const plants = await driver.findElements(By.tagName('li'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val plants: List<WebElement> = driver.findElements(By.tagName("li"))

--- a/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
@@ -56,7 +56,7 @@ var vegetable = driver.FindElement(By.ClassName("tomatoes"));
 vegetable = driver.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const vegetable = driver.findElement(By.className('tomatoes'));
+const vegetable = await driver.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
@@ -91,7 +91,7 @@ fruits = driver.find_element(id: 'fruits')
 fruit = fruits.find_element(class: 'tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruits = driver.findElement(By.id('fruits'));
+const fruits = await driver.findElement(By.id('fruits'));
 const fruit = fruits.findElement(By.className('tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
@@ -133,7 +133,7 @@ var fruit = driver.FindElement(By.CssSelector("#fruits .tomatoes"));
 fruit = driver.find_element(css: '#fruits .tomatoes')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruit = driver.findElement(By.css('#fruits .tomatoes'));
+const fruit = await driver.findElement(By.css('#fruits .tomatoes'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
@@ -162,7 +162,7 @@ IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));
 plants = driver.find_elements(tag_name: 'li')
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const plants = driver.findElements(By.tagName('li'));
+const plants = await driver.findElements(By.tagName('li'));
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 val plants: List<WebElement> = driver.findElements(By.tagName("li"))


### PR DESCRIPTION

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.



### Description

findElements method in selenium javascript actually returns a promise which which is supposed to be full-filled in future without this promise being resolved the the other code in the further lines will throw an error. so await should be a compulsion or the code that is supposed to be executed should be put in a then block like shown below.

```
driver.findElements(By.tagName("p")).then(() => {
    // The code that depends on the above element should lie here.
})

```
this can be avoided by simply adding an await as shown. 
```
let element = await driver.findElements(By.tagName("p"))
```


### Motivation and Context

This pull request when merged improves the clarity that exists in selenium doc website. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
