### PR TITLE
Fix em dashes in "--ext" examples

### DIFF
--- a/website_and_docs/content/documentation/grid/getting_started.en.md
+++ b/website_and_docs/content/documentation/grid/getting_started.en.md
@@ -239,17 +239,17 @@ The jar file can be downloaded directly from [repo1.maven.org](https://repo1.mav
 and then start the Grid in the following way:
 
 ```bash
-java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar -—ext selenium-http-jdk-client-<version>.jar standalone
+java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar --ext selenium-http-jdk-client-<version>.jar standalone
 ```
 
 An alternative to downloading the `selenium-http-jdk-client` jar file is to use [Coursier](https://get-coursier.io/docs/cli-installation).
 
 ```bash
-java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar —-ext $(coursier fetch -p org.seleniumhq.selenium:selenium-http-jdk-client:<version>) standalone
+java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar --ext $(coursier fetch -p org.seleniumhq.selenium:selenium-http-jdk-client:<version>) standalone
 ```
 
 If you are using the Hub/Node(s) mode or the Distributed mode, setting the `-Dwebdriver.http.factory=jdk-http-client` 
-and `—-ext` flags needs to be done for each one of the components.
+and `--ext` flags needs to be done for each one of the components.
 
 ## Grid sizes
 

--- a/website_and_docs/content/documentation/grid/getting_started.ja.md
+++ b/website_and_docs/content/documentation/grid/getting_started.ja.md
@@ -247,17 +247,17 @@ jar ファイルは[repo1.maven.org](https://repo1.maven.org/maven2/org/selenium
 Grid を起動する方法は以下の通りです:
 
 ```bash
-java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar -—ext selenium-http-jdk-client-<version>.jar standalone
+java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar --ext selenium-http-jdk-client-<version>.jar standalone
 ```
 
 `selenium-http-jdk-client`をダウンロードする別の方法として[Coursier](https://get-coursier.io/docs/cli-installation)を使う方法があります。
 
 ```bash
-java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar —-ext $(coursier fetch -p org.seleniumhq.selenium:selenium-http-jdk-client:<version>) standalone
+java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar --ext $(coursier fetch -p org.seleniumhq.selenium:selenium-http-jdk-client:<version>) standalone
 ```
 
 ハブ&ノードか分散モードで動かす場合、`-Dwebdriver.http.factory=jdk-http-client`と
-`—-ext`フラグの設定が各コンポーネントに必要になります。
+`--ext`フラグの設定が各コンポーネントに必要になります。
 
 ## Grid サイズ
 

--- a/website_and_docs/content/documentation/grid/getting_started.pt-br.md
+++ b/website_and_docs/content/documentation/grid/getting_started.pt-br.md
@@ -235,17 +235,17 @@ Este ficheiro pode ser obtido directamente de [repo1.maven.org](https://repo1.ma
 e depois pode iniciar a Grid com:
 
 ```bash
-java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar -—ext selenium-http-jdk-client-<version>.jar standalone
+java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar --ext selenium-http-jdk-client-<version>.jar standalone
 ```
 
 Uma alternativa a baixar o ficheiro jar `selenium-http-jdk-client` é usar [Coursier](https://get-coursier.io/docs/cli-installation).
 
 ```bash
-java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar —-ext $(coursier fetch -p org.seleniumhq.selenium:selenium-http-jdk-client:<version>) standalone
+java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar --ext $(coursier fetch -p org.seleniumhq.selenium:selenium-http-jdk-client:<version>) standalone
 ```
 
 Se está a usar a Grid em modo **Hub/Node** ou **Distributed**, terá que usar as flags 
-`-Dwebdriver.http.factory=jdk-http-client` e `—-ext` em cada um dos componentes.
+`-Dwebdriver.http.factory=jdk-http-client` e `--ext` em cada um dos componentes.
 
 ## Dimensionar Grid
 

--- a/website_and_docs/content/documentation/grid/getting_started.zh-cn.md
+++ b/website_and_docs/content/documentation/grid/getting_started.zh-cn.md
@@ -249,17 +249,17 @@ The jar file can be downloaded directly from [repo1.maven.org](https://repo1.mav
 and then start the Grid in the following way:
 
 ```bash
-java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar -—ext selenium-http-jdk-client-<version>.jar standalone
+java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar --ext selenium-http-jdk-client-<version>.jar standalone
 ```
 
 An alternative to downloading the `selenium-http-jdk-client` jar file is to use [Coursier](https://get-coursier.io/docs/cli-installation).
 
 ```bash
-java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar —-ext $(coursier fetch -p org.seleniumhq.selenium:selenium-http-jdk-client:<version>) standalone
+java -Dwebdriver.http.factory=jdk-http-client -jar selenium-server-<version>.jar --ext $(coursier fetch -p org.seleniumhq.selenium:selenium-http-jdk-client:<version>) standalone
 ```
 
 If you are using the Hub/Node(s) mode or the Distributed mode, setting the `-Dwebdriver.http.factory=jdk-http-client` 
-and `—-ext` flags needs to be done for each one of the components.
+and `--ext` flags needs to be done for each one of the components.
 
 ## Grid sizes
 


### PR DESCRIPTION
One can guess how I found out that the "--ext" argument examples turned out to be invalid command lines.  :)

### Description

The "--ext" example command-lines in this page previously included an em dash, instead of a hyphen, which caused the commands to be unparseable/invalid.

### Motivation and Context

In my own upgrade to a recent Selenium Server, I copied-and-pasted an "--ext" example, inadvertently breaking my startup commands (which began printing help text instead of executing selenium).

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

Edits were done within GitHub's live text editor.