### PR TITLE
GitHub action workflow scripts: bump actions to their latest versions

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -36,7 +36,7 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Compress Images
         id: calibre
         uses: calibreapp/image-actions@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Hugo

--- a/.github/workflows/dotnet-examples.yml
+++ b/.github/workflows/dotnet-examples.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout GitHub repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Start Xvfb
       if: matrix.os == 'ubuntu-latest'
       run: Xvfb :99 &
     - name: Set up .Net
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 5.0.x
     - name: Install Chrome
@@ -42,12 +42,12 @@ jobs:
     - name: Install Edge
       uses: browser-actions/setup-edge@latest
     - name: Install Firefox
-      uses: abhi1693/setup-browser@v0.3.4
+      uses: abhi1693/setup-browser@v0.3.5
       with:
         browser: firefox
         version: latest
     - name: Run tests
-      uses: nick-invision/retry@v2.8.2
+      uses: nick-invision/retry@v2.8.3
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/java-examples.yml
+++ b/.github/workflows/java-examples.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout GitHub repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Start Xvfb
       if: matrix.os == 'ubuntu-latest'
       run: Xvfb :99 &
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 8
@@ -43,12 +43,12 @@ jobs:
     - name: Install Edge
       uses: browser-actions/setup-edge@latest
     - name: Install Firefox
-      uses: abhi1693/setup-browser@v0.3.4
+      uses: abhi1693/setup-browser@v0.3.5
       with:
         browser: firefox
         version: latest
     - name: Run Tests
-      uses: nick-invision/retry@v2.8.2
+      uses: nick-invision/retry@v2.8.3
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/js-examples.yml
+++ b/.github/workflows/js-examples.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout GitHub repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Start Xvfb
       if: matrix.os == 'ubuntu-latest'
       run: Xvfb :99 &
@@ -38,7 +38,7 @@ jobs:
     - name: Install Edge
       uses: browser-actions/setup-edge@latest
     - name: Install Firefox
-      uses: abhi1693/setup-browser@v0.3.4
+      uses: abhi1693/setup-browser@v0.3.5
       with:
         browser: firefox
         version: latest
@@ -46,7 +46,7 @@ jobs:
       working-directory: ./examples/javascript
       run: npm install
     - name: Run tests
-      uses: nick-invision/retry@v2.8.2
+      uses: nick-invision/retry@v2.8.3
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/kotlin-examples.yml
+++ b/.github/workflows/kotlin-examples.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout GitHub repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Start Xvfb
       if: matrix.os == 'ubuntu-latest'
       run: Xvfb :99 &
@@ -43,12 +43,12 @@ jobs:
     - name: Install Edge
       uses: browser-actions/setup-edge@latest
     - name: Install Firefox
-      uses: abhi1693/setup-browser@v0.3.4
+      uses: abhi1693/setup-browser@v0.3.5
       with:
         browser: firefox
         version: latest
     - name: Run tests
-      uses: nick-invision/retry@v2.8.2
+      uses: nick-invision/retry@v2.8.3
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v4
         with:
           process-only: 'issues'
           issue-lock-inactive-days: '30'

--- a/.github/workflows/python-examples.yml
+++ b/.github/workflows/python-examples.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout GitHub repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Start Xvfb
       if: matrix.os == 'ubuntu-latest'
       run: Xvfb :99 &
@@ -38,7 +38,7 @@ jobs:
     - name: Install Edge
       uses: browser-actions/setup-edge@latest
     - name: Install Firefox
-      uses: abhi1693/setup-browser@v0.3.4
+      uses: abhi1693/setup-browser@v0.3.5
       with:
         browser: firefox
         version: latest
@@ -52,7 +52,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Run tests
-      uses: nick-invision/retry@v2.8.2
+      uses: nick-invision/retry@v2.8.3
       with:
         timeout_minutes: 20
         max_attempts: 3

--- a/.github/workflows/ruby-examples.yml
+++ b/.github/workflows/ruby-examples.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Start Xvfb
         if: matrix.os == 'ubuntu-latest'
         run: Xvfb :99 &
@@ -43,7 +43,7 @@ jobs:
       - name: Install Edge
         uses: browser-actions/setup-edge@latest
       - name: Install Firefox
-        uses: abhi1693/setup-browser@v0.3.4
+        uses: abhi1693/setup-browser@v0.3.5
         with:
           browser: firefox
           version: latest
@@ -51,7 +51,7 @@ jobs:
         working-directory: ./examples/ruby
         run: bundle install
       - name: Run tests
-        uses: nick-invision/retry@v2.8.2
+        uses: nick-invision/retry@v2.8.3
         with:
           timeout_minutes: 20
           max_attempts: 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:


### PR DESCRIPTION
This PR bumps actions used inside GitHub action workflow scripts to their latest versions, thus avoiding deprecation warnings when running the scripts.