### PR TITLE
Selenium grid hub status path has been changed.

### DIFF
--- a/website_and_docs/content/blog/2022/scaling-grid-with-keda.md
+++ b/website_and_docs/content/blog/2022/scaling-grid-with-keda.md
@@ -47,7 +47,7 @@ that will tie into our grid to get the information it needs. Example of the used
 triggers:
   - type: selenium-grid
     metadata:
-      url: 'http://selenium-grid-url-or-ip:4444/graphql'
+      url: 'http://selenium-grid-url-or-ip:4444/status'
       browserName: 'chrome'
 ```
 
@@ -69,7 +69,7 @@ spec:
   triggers:
     - type: selenium-grid
       metadata:
-        url: 'https://selenium-grid-url-or-ip:4444/graphql'
+        url: 'https://selenium-grid-url-or-ip:4444/status'
         browserName: 'chrome'
 ```
 
@@ -155,7 +155,7 @@ spec:
   triggers:
     - type: selenium-grid
       metadata:
-        url: 'https://selenium-grid-url-or-ip:4444/graphql'
+        url: 'https://selenium-grid-url-or-ip:4444/status'
         browserName: 'chrome'
 ```
 You will need one of these for every browser you wish to scale.
@@ -176,7 +176,7 @@ need to include `sessionBrowserName` as well in the trigger metadata:
 triggers:
     - type: selenium-grid
       metadata:
-        url: 'https://selenium-grid-url-or-ip:4444/graphql'
+        url: 'https://selenium-grid-url-or-ip:4444/status'
         browserName: 'MicrosoftEdge'
         sessionBrowserName: 'msedge'
 ```


### PR DESCRIPTION
The /graphql doesn't work anymore, new path ends with /status instead.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
