### PR TITLE
Start browser from specified location Example added

### DIFF
--- a/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
@@ -25,5 +25,10 @@ public class ChromeTest {
         options.addArguments("--headless=new");
         driver = new ChromeDriver(options);
     }
+    @Test
+    public void browserStartInspecifiedLocation() {
+        ChromeOptions options = new ChromeOptions().setBinary("Path to chrome binary");
+        driver = new ChromeDriver(options);
+    }
 
 }


### PR DESCRIPTION
The binary parameter takes the path of an alternate location of the browser to use. With this parameter, you can use chromedriver to drive various Chromium-based browsers.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
