### PR TITLE
Task Keep browser open example added

### DIFF
--- a/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
@@ -26,4 +26,11 @@ public class ChromeTest {
         driver = new ChromeDriver(options);
     }
 
+    @Test
+    public void test_keep_browser_open() {
+        ChromeOptions options = new ChromeOptions();
+        options.setExperimentalOption("detach", true);
+        driver = new ChromeDriver(options);
+    }
+
 }

--- a/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
@@ -27,7 +27,7 @@ public class ChromeTest {
     }
 
     @Test
-    public void test_keep_browser_open() {
+    public void keepBrowserOpen() {
         ChromeOptions options = new ChromeOptions();
         options.setExperimentalOption("detach", true);
         driver = new ChromeDriver(options);

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
@@ -118,7 +118,7 @@ Add a binary to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L31-L33" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
 {{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L12-L13">}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
@@ -119,7 +119,7 @@ please use the `load-extension` argument instead, as mentioned in
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L31-L33" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
 {{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L12-L13">}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
@@ -115,7 +115,7 @@ Adicionar detach:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L31-L33" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
 {{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L12-L13">}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
@@ -115,7 +115,7 @@ please use the `load-extension` argument instead, as mentioned in
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L31-L33" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
 {{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L12-L13">}}


### PR DESCRIPTION
Example added.
Setting the detach parameter to true will keep the browser open after the driver process has been quit.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
