### PR TITLE
[dotnet] Update IJavascriptEngine usage

### DIFF
--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidi_api.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidi_api.en.md
@@ -125,7 +125,7 @@ List<DomMutationData> attributeValueChanges = new List<DomMutationData>();
 DefaultWait<List<DomMutationData>> wait = new DefaultWait<List<DomMutationData>>(attributeValueChanges);
 wait.Timeout = TimeSpan.FromSeconds(3);
 
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 monitor.DomMutated += (sender, e) =>
 {
     attributeValueChanges.Add(e.AttributeData);
@@ -238,7 +238,7 @@ async def printConsoleLogs():
 trio.run(printConsoleLogs)
 {{< /tab >}}
 {{< tab header="CSharp" >}}
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 List<string> consoleMessages = new List<string>();
 monitor.JavaScriptConsoleApiCalled += (sender, e) =>
 {
@@ -355,7 +355,7 @@ async def catchJSException():
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 List<string> exceptionMessages = new List<string>();
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 monitor.JavaScriptExceptionThrown += (sender, e) =>
 {
     exceptionMessages.Add(e.Message);

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidi_api.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidi_api.ja.md
@@ -134,7 +134,7 @@ List<DomMutationData> attributeValueChanges = new List<DomMutationData>();
 DefaultWait<List<DomMutationData>> wait = new DefaultWait<List<DomMutationData>>(attributeValueChanges);
 wait.Timeout = TimeSpan.FromSeconds(3);
 
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 monitor.DomMutated += (sender, e) =>
 {
     attributeValueChanges.Add(e.AttributeData);
@@ -247,7 +247,7 @@ async def printConsoleLogs():
 trio.run(printConsoleLogs)
 {{< /tab >}}
 {{< tab header="CSharp" >}}
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 List<string> consoleMessages = new List<string>();
 monitor.JavaScriptConsoleApiCalled += (sender, e) =>
 {
@@ -364,7 +364,7 @@ async def catchJSException():
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 List<string> exceptionMessages = new List<string>();
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 monitor.JavaScriptExceptionThrown += (sender, e) =>
 {
     exceptionMessages.Add(e.Message);

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidi_api.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidi_api.pt-br.md
@@ -120,7 +120,7 @@ List<DomMutationData> attributeValueChanges = new List<DomMutationData>();
 DefaultWait<List<DomMutationData>> wait = new DefaultWait<List<DomMutationData>>(attributeValueChanges);
 wait.Timeout = TimeSpan.FromSeconds(3);
 
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 monitor.DomMutated += (sender, e) =>
 {
     attributeValueChanges.Add(e.AttributeData);
@@ -232,7 +232,7 @@ async def printConsoleLogs():
 trio.run(printConsoleLogs)
 {{< /tab >}}
 {{< tab header="CSharp" >}}
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 List<string> consoleMessages = new List<string>();
 monitor.JavaScriptConsoleApiCalled += (sender, e) =>
 {
@@ -349,7 +349,7 @@ async def catchJSException():
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 List<string> exceptionMessages = new List<string>();
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 monitor.JavaScriptExceptionThrown += (sender, e) =>
 {
     exceptionMessages.Add(e.Message);

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidi_api.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidi_api.zh-cn.md
@@ -136,7 +136,7 @@ List<DomMutationData> attributeValueChanges = new List<DomMutationData>();
 DefaultWait<List<DomMutationData>> wait = new DefaultWait<List<DomMutationData>>(attributeValueChanges);
 wait.Timeout = TimeSpan.FromSeconds(3);
 
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 monitor.DomMutated += (sender, e) =>
 {
     attributeValueChanges.Add(e.AttributeData);
@@ -249,7 +249,7 @@ async def printConsoleLogs():
 trio.run(printConsoleLogs)
 {{< /tab >}}
 {{< tab header="CSharp" >}}
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 List<string> consoleMessages = new List<string>();
 monitor.JavaScriptConsoleApiCalled += (sender, e) =>
 {
@@ -366,7 +366,7 @@ async def catchJSException():
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 List<string> exceptionMessages = new List<string>();
-IJavaScriptEngine monitor = new JavaScriptEngine(driver);
+using IJavaScriptEngine monitor = new JavaScriptEngine(driver);
 monitor.JavaScriptExceptionThrown += (sender, e) =>
 {
     exceptionMessages.Add(e.Message);


### PR DESCRIPTION
After https://github.com/SeleniumHQ/selenium/pull/11594 was merged in v4.8.1, IJavascriptEngine now implements IDisposable and should be disposed of with the `using` statement, as is standard practice.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
