### PR TITLE
update wait documentation

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/interactions.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/interactions.en.md
@@ -14,7 +14,7 @@ There are only 5 basic commands that can be executed on an element:
 * [send keys](https://w3c.github.io/webdriver/#element-send-keys) (only applies to text fields and content editable elements)
 * [clear](https://w3c.github.io/webdriver/#element-send-keys) (only applies to text fields and content editable elements)
 * submit (only applies to form elements)
-* select (see [Select List Elements]({{< ref "select_lists.md" >}}))
+* select (see [Select List Elements]({{< ref "select_lists.md" >}})
 
 ## Additional validations
 

--- a/website_and_docs/content/documentation/webdriver/elements/interactions.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/interactions.ja.md
@@ -12,7 +12,7 @@ There are only 5 basic commands that can be executed on an element:
 * [send keys](https://w3c.github.io/webdriver/#element-send-keys) (only applies to text fields and content editable elements)
 * [clear](https://w3c.github.io/webdriver/#element-send-keys) (only applies to text fields and content editable elements)
 * submit (only applies to form elements)
-* select (see [Select List Elements]({{< ref "select_lists.md" >}}))
+* select (see [Select List Elements]({{< ref "select_lists.md" >}})
 
 ## Additional validations
 

--- a/website_and_docs/content/documentation/webdriver/elements/interactions.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/interactions.pt-br.md
@@ -12,7 +12,7 @@ There are only 5 basic commands that can be executed on an element:
 * [send keys](https://w3c.github.io/webdriver/#element-send-keys) (only applies to text fields and content editable elements)
 * [clear](https://w3c.github.io/webdriver/#element-send-keys) (only applies to text fields and content editable elements)
 * submit (only applies to form elements)
-* select (see [Select List Elements]({{< ref "select_lists.md" >}}))
+* select (see [Select List Elements]({{< ref "select_lists.md" >}})
 
 ## Additional validations
 

--- a/website_and_docs/content/documentation/webdriver/elements/interactions.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/interactions.zh-cn.md
@@ -12,7 +12,7 @@ description: >
 * [发送键位](https://w3c.github.io/webdriver/#element-send-keys) (仅适用于文本字段和内容可编辑元素)
 * [清除](https://w3c.github.io/webdriver/#element-send-keys) (仅适用于文本字段和内容可编辑元素)
 * 提交 (仅适用于表单元素)
-* 选择 (参见 [选择列表元素]({{< ref "select_lists.md" >}}))
+* 选择 (参见 [选择列表元素]({{< ref "select_lists.md" >}})
 
 ## 附加验证
 

--- a/website_and_docs/content/documentation/webdriver/support_features/colors.en.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/colors.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Working With Colors"
 linkTitle: "Colors"
-weight: 1
+weight: 3
 aliases: [
 "/documentation/en/support_packages/working_with_colours/",
 "/documentation/support_packages/working_with_colours/",

--- a/website_and_docs/content/documentation/webdriver/support_features/colors.ja.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/colors.ja.md
@@ -1,7 +1,7 @@
 ---
 title: "色を扱う"
 linkTitle: "色を扱う"
-weight: 1
+weight: 3
 aliases: [
 "/documentation/ja/support_packages/working_with_colours/",
 "/ja/documentation/support_packages/working_with_colours/",

--- a/website_and_docs/content/documentation/webdriver/support_features/colors.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/colors.pt-br.md
@@ -1,7 +1,7 @@
 ---
 title: "Trabalhando com cores"
 linkTitle: "Trabalhando com cores"
-weight: 1
+weight: 3
 aliases: [
 "/documentation/pt-br/support_packages/working_with_colours/",
 "/pt-br/documentation/support_packages/working_with_colours/",

--- a/website_and_docs/content/documentation/webdriver/support_features/colors.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/colors.zh-cn.md
@@ -1,7 +1,7 @@
 ---
 title: "同颜色一起工作"
 linkTitle: "颜色"
-weight: 1
+weight: 3
 aliases: [
 "/documentation/zh-cn/support_packages/working_with_colours/",
 "/zh-cn/documentation/support_packages/working_with_colours/",

--- a/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.en.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.en.md
@@ -1,0 +1,43 @@
+---
+title: "Waiting with Expected Conditions"
+linkTitle: "Expected Conditions"
+weight: 1
+description: >
+  These are classes used to describe what needs to be waited for.
+---
+
+Expected Conditions are used with [Explicit Waits](({{< ref "waits#explicit-waits" >}})).
+Instead of defining the block of code to be executed with a _lambda_, an expected
+conditions method can be created to represent common things that get waited on. Some
+methods take locators as arguments, others take elements as arguments.
+
+These methods can include conditions such as:
+
+* element exists
+* element is stale
+* element is visible
+* text is visible
+* title contains specified value
+
+{{< tabpane text=true langEqualsHeader=true >}}
+{{% tab header="Java" %}}
+[Expected Conditions Documentation](https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html)
+{{< badge-code >}}
+{{% /tab %}}
+{{< tab header="Python" >}}
+[Expected Conditions Documentation](https://www.selenium.dev/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html)
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+.NET stopped supporting Expected Conditions in Selenium 4 to minimize maintenance hassle and redundancy.
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+Ruby makes frequent use of blocks, procs and lambdas and does not need Expected Conditions classes
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.en.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.en.md
@@ -6,7 +6,7 @@ description: >
   These are classes used to describe what needs to be waited for.
 ---
 
-Expected Conditions are used with [Explicit Waits](({{< ref "waits#explicit-waits" >}})).
+Expected Conditions are used with [Explicit Waits]({{< ref "../waits#explicit-waits" >}}).
 Instead of defining the block of code to be executed with a _lambda_, an expected
 conditions method can be created to represent common things that get waited on. Some
 methods take locators as arguments, others take elements as arguments.

--- a/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.ja.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.ja.md
@@ -1,0 +1,43 @@
+---
+title: "Waiting with Expected Conditions"
+linkTitle: "Expected Conditions"
+weight: 1
+description: >
+  These are classes used to describe what needs to be waited for.
+---
+
+Expected Conditions are used with [Explicit Waits](({{< ref "waits#explicit-waits" >}})).
+Instead of defining the block of code to be executed with a _lambda_, an expected
+conditions method can be created to represent common things that get waited on. Some
+methods take locators as arguments, others take elements as arguments.
+
+These methods can include conditions such as:
+
+* element exists
+* element is stale
+* element is visible
+* text is visible
+* title contains specified value
+
+{{< tabpane text=true langEqualsHeader=true >}}
+{{% tab header="Java" %}}
+[Expected Conditions Documentation](https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html)
+{{< badge-code >}}
+{{% /tab %}}
+{{< tab header="Python" >}}
+[Expected Conditions Documentation](https://www.selenium.dev/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html)
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+.NET stopped supporting Expected Conditions in Selenium 4 to minimize maintenance hassle and redundancy.
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+Ruby makes frequent use of blocks, procs and lambdas and does not need Expected Conditions classes
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.ja.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.ja.md
@@ -6,7 +6,7 @@ description: >
   These are classes used to describe what needs to be waited for.
 ---
 
-Expected Conditions are used with [Explicit Waits](({{< ref "waits#explicit-waits" >}})).
+Expected Conditions are used with [Explicit Waits]({{< ref "../waits#explicit-waits" >}}).
 Instead of defining the block of code to be executed with a _lambda_, an expected
 conditions method can be created to represent common things that get waited on. Some
 methods take locators as arguments, others take elements as arguments.

--- a/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.pt-br.md
@@ -1,0 +1,43 @@
+[expected_conditions.ja.md](expected_conditions.ja.md)---
+title: "Waiting with Expected Conditions"
+linkTitle: "Expected Conditions"
+weight: 1
+description: >
+  These are classes used to describe what needs to be waited for.
+---
+
+Expected Conditions are used with [Explicit Waits](({{< ref "waits#explicit-waits" >}})).
+Instead of defining the block of code to be executed with a _lambda_, an expected
+conditions method can be created to represent common things that get waited on. Some
+methods take locators as arguments, others take elements as arguments.
+
+These methods can include conditions such as:
+
+* element exists
+* element is stale
+* element is visible
+* text is visible
+* title contains specified value
+
+{{< tabpane text=true langEqualsHeader=true >}}
+{{% tab header="Java" %}}
+[Expected Conditions Documentation](https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html)
+{{< badge-code >}}
+{{% /tab %}}
+{{< tab header="Python" >}}
+[Expected Conditions Documentation](https://www.selenium.dev/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html)
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+.NET stopped supporting Expected Conditions in Selenium 4 to minimize maintenance hassle and redundancy.
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+Ruby makes frequent use of blocks, procs and lambdas and does not need Expected Conditions classes
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.pt-br.md
@@ -6,7 +6,7 @@ description: >
   These are classes used to describe what needs to be waited for.
 ---
 
-Expected Conditions are used with [Explicit Waits](({{< ref "waits#explicit-waits" >}})).
+Expected Conditions are used with [Explicit Waits]({{< ref "../waits#explicit-waits" >}}).
 Instead of defining the block of code to be executed with a _lambda_, an expected
 conditions method can be created to represent common things that get waited on. Some
 methods take locators as arguments, others take elements as arguments.

--- a/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.zh-cn.md
@@ -1,0 +1,43 @@
+---
+title: "Waiting with Expected Conditions"
+linkTitle: "Expected Conditions"
+weight: 1
+description: >
+  These are classes used to describe what needs to be waited for.
+---
+
+Expected Conditions are used with [Explicit Waits](({{< ref "waits#explicit-waits" >}})).
+Instead of defining the block of code to be executed with a _lambda_, an expected
+conditions method can be created to represent common things that get waited on. Some
+methods take locators as arguments, others take elements as arguments.
+
+These methods can include conditions such as:
+
+* element exists
+* element is stale
+* element is visible
+* text is visible
+* title contains specified value
+
+{{< tabpane text=true langEqualsHeader=true >}}
+{{% tab header="Java" %}}
+[Expected Conditions Documentation](https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html)
+{{< badge-code >}}
+{{% /tab %}}
+{{< tab header="Python" >}}
+[Expected Conditions Documentation](https://www.selenium.dev/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html)
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+.NET stopped supporting Expected Conditions in Selenium 4 to minimize maintenance hassle and redundancy.
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+Ruby makes frequent use of blocks, procs and lambdas and does not need Expected Conditions classes
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/support_features/expected_conditions.zh-cn.md
@@ -6,7 +6,7 @@ description: >
   These are classes used to describe what needs to be waited for.
 ---
 
-Expected Conditions are used with [Explicit Waits](({{< ref "waits#explicit-waits" >}})).
+Expected Conditions are used with [Explicit Waits]({{< ref "../waits#explicit-waits" >}}).
 Instead of defining the block of code to be executed with a _lambda_, an expected
 conditions method can be created to represent common things that get waited on. Some
 methods take locators as arguments, others take elements as arguments.

--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -1,359 +1,95 @@
 ---
-title: "Waits"
+title: "Waiting Strategies"
 linkTitle: "Waits"
 weight: 6
 aliases: ["/documentation/en/webdriver/waits/"]
 ---
 
-WebDriver can generally be said to have a blocking API.
-Because it is an out-of-process library that
-_instructs_ the browser what to do,
-and because the web platform has an intrinsically asynchronous nature,
-WebDriver does not track the active, real-time state of the DOM.
-This comes with some challenges that we will discuss here.
+Perhaps the most common challenge for browser automation is ensuring
+that the web application is in a state to execute a particular
+Selenium command as desired. the processes often end up in
+a _race condition_ where sometimes the browser gets into the right
+state first (things work as intended) and sometimes the Selenium code
+executes first (things do not work as intended). This is the
+primary cause of _flaky tests_.
 
-From experience,
-most intermittent issues that arise from use of Selenium and WebDriver
-are connected to _race conditions_ that occur between
-the browser and the user's instructions.
-An example could be that the user instructs the browser to navigate to a page,
-then gets a **no such element** error
-when trying to find an element.
+All navigation commands wait for a specific `readyState` value
+based on the [page load strategy]({{< ref "drivers/options#pageloadstrategy" >}}) (the 
+default is `"complete"`) before the driver returns control to the code.
+The `readyState` only concerns itself with loading assets defined in the HTML, 
+but loaded JavaScript assets often result in changes to the site,
+and elements you need to interact with may not yet be on the page
+when the code is ready to execute the next Selenium command.
 
-Consider the following document:
+Similarly, in a lot of single page applications, elements get dynamically
+added to a page or change visibility based on a click. For example, the box
+element takes a second to show up after clicking on the "adder" button, so
+even trying to locate that button will error without some form of synchronization: 
 
-```html
-<!doctype html>
-<meta charset=utf-8>
-<title>Race Condition Example</title>
-
-<script>
-  var initialised = false;
-  window.addEventListener("load", function() {
-    var newElement = document.createElement("p");
-    newElement.textContent = "Hello from JavaScript!";
-    document.body.appendChild(newElement);
-    initialised = true;
-  });
-</script>
-```
-
-The WebDriver instructions might look innocent enough:
-
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-driver.get("file:///race_condition.html");
-WebElement element = driver.findElement(By.tagName("p"));
-assertEquals(element.getText(), "Hello from JavaScript!");
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L23-L28" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-driver.navigate("file:///race_condition.html")
-el = driver.find_element(By.TAG_NAME, "p")
-assert el.text == "Hello from JavaScript!"
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L9-L13" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-driver.Navigate().GoToUrl("file:///race_condition.html");
-IWebElement element = driver.FindElement(By.TagName("p"));
-assertEquals(element.Text, "Hello from JavaScript!");
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L15-L20" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-begin
-  # Navigate to URL
-  driver.get 'file:///race_condition.html'
-
-  # Get and store Paragraph Text
-  search_form = driver.find_element(:css,'p').text
-
-  "Hello from JavaScript!".eql? search_form
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L9-L14" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-await driver.get('file:///race_condition.html');
-const element = driver.findElement(By.css('p'));
-assert.strictEqual(await element.getText(), 'Hello from JavaScript!');
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-driver.get("file:///race_condition.html")
-val element = driver.findElement(By.tagName("p"))
-assert(element.text == "Hello from JavaScript!")
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-The issue here is that the default
-[page load strategy]({{< ref "drivers/options#pageloadstrategy" >}})
-used in WebDriver listens for the `document.readyState`
-to change to `"complete"` before returning from the call to _navigate_.
-Because the `p` element is
-added _after_ the document has completed loading,
-this WebDriver script _might_ be intermittent.
-It “might” be intermittent because no guarantees can be made
-about elements or events that trigger asynchronously
-without explicitly waiting—or blocking—on those events.
+There are several synchronization strategies that can be used to properly wait for
+the application to be in the state you need it to be for the next Selenium command.
 
-Fortunately, the normal instruction set available on
-the [_WebElement_]({{< ref "elements" >}}) interface—such
- as _WebElement.click_ and _WebElement.sendKeys_—are
- guaranteed to be synchronous,
- in that the function calls will not return
- (or the callback will not trigger in callback-style languages)
- until the command has been completed in the browser.
- The advanced user interaction APIs,
- [_Keyboard_]({{< ref "actions_api/keyboard.md" >}})
- and [_Mouse_]({{< ref "actions_api/mouse.md" >}}),
- are exceptions as they are explicitly intended as
- “do what I say” asynchronous commands.
+## Hard-coded sleeps
 
-Waiting is having the automated task execution
-elapse a certain amount of time before continuing with the next step.
+This causes the code to stop executing for a set period of time.
+Because your code can't know exactly how long you need to wait, this
+will either fail when it doesn't sleep long enough, or will cause
+your sessions to take much longer than they need to. That said, putting in a sleep command is one way to keep
+the above code from failing:
 
-To overcome the problem of race conditions
-between the browser and your WebDriver script,
-most Selenium clients ship with a _wait_ package.
-When employing a wait,
-you are using what is commonly referred to
-as an [_explicit wait_](#explicit-wait).
-
-
-## Explicit wait
-
-_Explicit waits_ are available to Selenium clients
-for imperative, procedural languages.
-They allow your code to halt program execution,
-or freeze the thread,
-until the _condition_ you pass it resolves.
-The condition is called with a certain frequency
-until the timeout of the wait is elapsed.
-This means that for as long as the condition returns a falsy value,
-it will keep trying and waiting.
-
-Since explicit waits allow you to wait for a condition to occur,
-they make a good fit for synchronising the state between the browser and its DOM,
-and your WebDriver script.
-
-To remedy our buggy instruction set from earlier,
-we could employ a wait to have the _findElement_ call
-wait until the dynamically added element from the script
-has been added to the DOM:
-
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-WebDriver driver = new ChromeDriver();
-driver.get("https://google.com/ncr");
-driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER);
-// Initialize and wait till element(link) became clickable - timeout in 10 seconds
-WebElement firstResult = new WebDriverWait(driver, Duration.ofSeconds(10))
-        .until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")));
-// Print the first result
-System.out.println(firstResult.getText());
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L34-L38" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-from selenium.webdriver.support.wait import WebDriverWait
-def document_initialised(driver):
-    return driver.execute_script("return initialised")
-
-driver.navigate("file:///race_condition.html")
-WebDriverWait(driver, timeout=10).until(document_initialised)
-el = driver.find_element(By.TAG_NAME, "p")
-assert el.text == "Hello from JavaScript!"
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L18-L21" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-driver = new ChromeDriver();
-driver.Url = "https://www.google.com/ncr";
-driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
-
-WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-IWebElement firstResult = wait.Until(e => e.FindElement(By.XPath("//a/h3")));
-
-Console.WriteLine(firstResult.Text);
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L27-L31" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-
-def document_initialised(driver)
-  driver.execute_script('return initialised')
-end
-
-begin
-  driver.get 'file:///race_condition.html'
-  wait.until{document_initialised driver}
-  search_form = driver.find_element(:css,'p').text
-  "Hello from JavaScript!".eql? search_form
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L19-L22" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const documentInitialised = () =>
-    driver.executeScript('return initialised');
-
-await driver.get('file:///race_condition.html');
-await driver.wait(() => documentInitialised(), 10000);
-const element = driver.findElement(By.css('p'));
-assert.strictEqual(await element.getText(), 'Hello from JavaScript!');
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-driver.get("https://google.com/ncr")
-driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER)
-// Initialize and wait till element(link) became clickable - timeout in 10 seconds
-val firstResult = WebDriverWait(driver, Duration.ofSeconds(10))
-      .until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")))
-// Print the first result
-println(firstResult.text)
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-We pass in the _condition_ as a function reference
-that the _wait_ will run repeatedly until its return value is truthy.
-A “truthful” return value is anything that evaluates to boolean true
-in the language at hand, such as a string, number, a boolean,
-an object (including a _WebElement_),
-or a populated (non-empty) sequence or list.
-That means an _empty list_ evaluates to false.
-When the condition is truthful and the blocking wait is aborted,
-the return value from the condition becomes the return value of the wait.
+## Implicit waits
+Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
+You set an implicit wait either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+capability in the browser options, or with a driver method (as shown below).
 
-With this knowledge,
-and because the wait utility ignores _no such element_ errors by default,
-we can refactor our instructions to be more concise:
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebElement foo = new WebDriverWait(driver, Duration.ofSeconds(3))
-          .until(driver -> driver.findElement(By.tagName("p")));
-assertEquals(foo.getText(), "Hello from JavaScript!");
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.wait import WebDriverWait
-
-driver.navigate("file:///race_condition.html")
-el = WebDriverWait(driver, timeout=3).until(lambda d: d.find_element(By.TAG_NAME,"p"))
-assert el.text == "Hello from JavaScript!"
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-   using (var driver = new FirefoxDriver())
-    {
-        var foo = new WebDriverWait(driver, TimeSpan.FromSeconds(3))
-                        .Until(drv => drv.FindElement(By.Name("q")));
-        Debug.Assert(foo.Text.Equals("Hello from JavaScript!"));
-    }
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-  driver.get 'file:///race_condition.html'
-  wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-  ele = wait.until { driver.find_element(css: 'p')}
-  foo = ele.text
-  assert_match foo, 'Hello from JavaScript'
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let ele = await driver.wait(until.elementLocated(By.css('p')),10000);
-let foo = await ele.getText();
-assert(foo == "Hello from JavaScript");
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-driver.get("file:///race_condition.html")
-val ele = WebDriverWait(driver, Duration.ofSeconds(10))
-            .until(ExpectedConditions.presenceOfElementLocated(By.tagName("p")))
-assert(ele.text == "Hello from JavaScript!")
-  {{< /tab >}}
-{{< /tabpane >}}
-
-In that example, we pass in an anonymous function
-(but we could also define it explicitly as we did earlier so it may be reused).
-The first and only argument that is passed to our condition
-is always a reference to our driver object, _WebDriver_.
-In a multi-threaded environment, you should be careful
-to operate on the driver reference passed in to the condition
-rather than the reference to the driver in the outer scope.
-
-Because the wait will swallow _no such element_ errors
-that are raised when the element is not found,
-the condition will retry until the element is found.
-Then it will take the return value, a _WebElement_,
-and pass it back through to our script.
-
-If the condition fails,
-e.g. a truthful return value from the condition is never reached,
-the wait will throw/raise an error/exception called a _timeout error_.
-
-
-### Options
-
-The wait condition can be customised to match your needs.
-Sometimes it is unnecessary to wait the full extent of the default timeout,
-as the penalty for not hitting a successful condition can be expensive.
-
-The wait lets you pass in an argument to override the timeout:
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-new WebDriverWait(driver, Duration.ofSeconds(3)).until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-WebDriverWait(driver, timeout=3).until(some_condition)
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-new WebDriverWait(driver, TimeSpan.FromSeconds(3)).Until(driver => driver.FindElement(By.Name("q")));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-
-wait.until { driver.find_element(:id, 'message').displayed? }
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-  await driver.wait(until.elementLocated(By.id('foo')), 30000);
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-WebDriverWait(driver, Duration.ofSeconds(3)).until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")))
-  {{< /tab >}}
-{{< /tabpane >}}
-
-### Expected conditions
-
-Because it is quite a common occurrence
-to have to synchronise the DOM and your instructions,
-most clients also come with a set of predefined _expected conditions_.
-As might be obvious by the name,
-they are conditions that are predefined for frequent wait operations.
-
-The conditions available in the different language bindings vary,
-but this is a non-exhaustive list of a few:
-
-* alert is present
-* element exists
-* element is visible
-* title contains
-* title is
-* element staleness
-* visible text
-
-You can refer to the API documentation for each client binding
-to find an exhaustive list of expected conditions:
-
-* Java's [org.openqa.selenium.support.ui.ExpectedConditions](//seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html) class
-* Python's [selenium.webdriver.support.expected_conditions](//seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html?highlight=expected) class
-* JavaScript's [selenium-webdriver/lib/until](//seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/until.html) module
-
-
-## Implicit wait
-
-There is a second type of wait that is distinct from
-[explicit wait](#explicit-wait) called _implicit wait_.
-By implicitly waiting, WebDriver polls the DOM
-for a certain duration when trying to find _any_ element.
-This can be useful when certain elements on the webpage
-are not available immediately and need some time to load.
-
-Implicit waiting for elements to appear is disabled by default
-and will need to be manually enabled on a per-session basis.
-Mixing [explicit waits](#explicit-wait) and implicit waits
-will cause unintended consequences, namely waits sleeping for the maximum
-time even if the element is available or condition is true.
+This is a global setting that applies to every element location call for the entire session.
+The default value is `0`, which means that if the element is not found, it will
+immediately return an error. If an implicit wait is set, the driver will wait for the 
+duration of the provided value before returning the error. Note that as soon as the 
+element is located, the driver will return the value and your code may continue, so a larger
+implicit wait value won't necessarily increase the time of your session.
 
 *Warning:*
 Do not mix implicit and explicit waits.
@@ -362,134 +98,109 @@ For example, setting an implicit wait of 10 seconds
 and an explicit wait of 15 seconds
 could cause a timeout to occur after 20 seconds.
 
-An implicit wait is to tell WebDriver to poll the DOM
-for a certain amount of time when trying to find an element or elements
-if they are not immediately available.
-The default setting is 0, meaning disabled.
-Once set, the implicit wait is set for the life of the session.
+Solving our example with an implicit wait looks like this:
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-WebDriver driver = new FirefoxDriver();
-driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
-driver.get("http://somedomain/url_that_delays_loading");
-WebElement myDynamicElement = driver.findElement(By.id("myDynamicElement"));
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L45-L49" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-driver = Firefox()
-driver.implicitly_wait(10)
-driver.get("http://somedomain/url_that_delays_loading")
-my_dynamic_element = driver.find_element(By.ID, "myDynamicElement")
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27-L31" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IWebDriver driver = new ChromeDriver();
-driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
-driver.Url = "http://somedomain/url_that_delays_loading";
-IWebElement dynamicElement = driver.FindElement(By.Name("dynamicElement"));
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39-L44" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-driver.manage.timeouts.implicit_wait = 10
-
-begin
-  driver.get 'http://somedomain/url_that_delays_loading'
-  search_form = driver.find_element(:id,'dynamic_element')
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28-L32" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-(async function(){
-
-// Apply timeout for 10 seconds
-await driver.manage().setTimeouts( { implicit: 10000 } );
-
-// Navigate to url
-await driver.get('http://somedomain/url_that_delays_loading');
-
-let webElement = driver.findElement(By.id("myDynamicElement"));
-
-}());
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val driver = FirefoxDriver()
-driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10))
-driver.get("http://somedomain/url_that_delays_loading")
-val myDynamicElement = driver.findElement(By.id("myDynamicElement"))
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-## FluentWait
+## Explicit waits
 
-FluentWait instance defines the maximum amount of time to wait for a condition,
-as well as the frequency with which to check the condition.
+_Explicit waits_ are loops you add to your code that poll the application 
+for a specific condition to evaluate as true before it exits the loop and
+continues to the next command in your code. If the condition is not met before a designated timeout value, 
+the code will give a timeout error.
 
-Users may configure the wait to ignore specific types of exceptions whilst waiting,
-such as `NoSuchElementException` when searching for an element on the page.
+There are many ways for the application not to be in the desired state,
+so explicit waits are a great choice to specify exactly what is desired
+in each place they are needed. 
+For example, an element must be both present in the DOM and 
+[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+in order for Selenium to interact with it. 
 
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-// Waiting 30 seconds for an element to be present on the page, checking
-// for its presence once every 5 seconds.
-Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
-  .withTimeout(Duration.ofSeconds(30))
-  .pollingEvery(Duration.ofSeconds(5))
-  .ignoring(NoSuchElementException.class);
+In this example, clicking the
+"reveal" button displays an input field that is already present in the DOM.
+An explicit wait can be used to ensure the element is interactable before 
+sending keys to it. An important feature of the Wait class in Selenium is that it will automatically retry
+when a _no such element_ error happens, which makes it much easier to write succinct code.
+We do not need to handle whether the element is there and we can just focus on whether it
+evaluates as displayed:
 
-WebElement foo = wait.until(driver -> {
-  return driver.findElement(By.id("foo"));
-});
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-driver = Firefox()
-driver.get("http://somedomain/url_that_delays_loading")
-wait = WebDriverWait(driver, timeout=10, poll_frequency=1, ignored_exceptions=[ElementNotVisibleException, ElementNotSelectableException])
-element = wait.until(EC.element_to_be_clickable((By.XPATH, "//div")))
-  {{< /tab >}}
+{{< tabpane text=true langEqualsHeader=true >}}
+  {{% tab header="Java" %}}
+This example shows the condition being waited for as a _lambda_. Java also supports
+[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+This example shows the condition being waited for as a _lambda_. Python also supports
+[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
+  {{% /tab %}}
   {{< tab header="CSharp" >}}
-using (var driver = new FirefoxDriver())
-{
-  WebDriverWait wait = new WebDriverWait(driver, timeout: TimeSpan.FromSeconds(30))
-  {
-      PollingInterval = TimeSpan.FromSeconds(5),
-  };
-  wait.IgnoreExceptionTypes(typeof(NoSuchElementException));
-
-  var foo = wait.Until(drv => drv.FindElement(By.Id("foo")));
-}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L53-L59" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-exception = Selenium::WebDriver::Error::NoSuchElementError
-
-begin
-  driver.get 'http://somedomain/url_that_delays_loading'
-  wait = Selenium::WebDriver::Wait.new(timeout: 30, interval: 5, message: 'Timed out after 30 sec', ignore: exception)
-  foo = wait.until { driver.find_element(id: 'foo')}
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
   {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-const {Builder, until} = require('selenium-webdriver');
-
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    await driver.get('http://somedomain/url_that_delays_loading');
-    // Waiting 30 seconds for an element to be present on the page, checking
-    // for its presence once every 5 seconds.
-    let foo = await driver.wait(until.elementLocated(By.id('foo')), 30000, 'Timed out after 30 seconds', 5000);
-})();
-  {{< /tab >}}
+  {{% tab header="JavaScript" %}}
+JavaScript also supports [Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< badge-code >}}
+  {{% /tab %}}
   {{< tab header="Kotlin" >}}
-val wait = FluentWait<WebDriver>(driver)
-        .withTimeout(Duration.ofSeconds(30))
-        .pollingEvery(Duration.ofSeconds(3))
-        .ignoring(NoSuchElementException::class.java)
-
-val foo = wait.until {it.findElement(By.id("foo")) }
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
+### Customization
+
+The Wait class can be created with various parameters that will change how the conditions are evaluated.
+
+This can include:
+* Changing how often the code is evaluated (polling interval)
+* Specifying which exceptions should be retried
+* Changing the total timeout length
+* Customizing the timeout message
+
+For instance, if the _element not interactable_ error is retried by default, then we can
+add an action on a method inside the code getting executed (we just need to 
+make sure that the code returns `true` when it is successful):
+
+{{< tabpane text=true langEqualsHeader=true >}}
+  {{% tab header="Java" %}}
+The easiest way to customize Waits in Java is to use the `FluentWait` class:
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L70-L80" >}}
+  {{% /tab %}}
+  {{< tab header="Python" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L50-L55" >}}
+  {{< /tab >}}
+  {{< tab header="CSharp" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L67-L78" >}}
+  {{< /tab >}}
+  {{< tab header="Ruby" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L51-L59" >}}
+  {{< /tab >}}
+  {{< tab header="JavaScript" >}}
+{{< badge-code >}}
+  {{< /tab >}}
+  {{< tab header="Kotlin" >}}
+{{< badge-code >}}
+  {{< /tab >}}
+{{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -7,89 +7,54 @@ aliases: ["/documentation/en/webdriver/waits/"]
 
 Perhaps the most common challenge for browser automation is ensuring
 that the web application is in a state to execute a particular
-Selenium command as desired. the processes often end up in
+Selenium command as desired. The processes often end up in
 a _race condition_ where sometimes the browser gets into the right
 state first (things work as intended) and sometimes the Selenium code
-executes first (things do not work as intended). This is the
-primary cause of _flaky tests_.
+executes first (things do not work as intended). This is one of the
+primary causes of _flaky tests_.
 
 All navigation commands wait for a specific `readyState` value
 based on the [page load strategy]({{< ref "drivers/options#pageloadstrategy" >}}) (the 
-default is `"complete"`) before the driver returns control to the code.
+default value to wait for is `"complete"`) before the driver returns control to the code.
 The `readyState` only concerns itself with loading assets defined in the HTML, 
 but loaded JavaScript assets often result in changes to the site,
-and elements you need to interact with may not yet be on the page
+and elements that need to be interacted with may not yet be on the page
 when the code is ready to execute the next Selenium command.
 
 Similarly, in a lot of single page applications, elements get dynamically
-added to a page or change visibility based on a click. For example, the box
-element takes a second to show up after clicking on the "adder" button, so
-even trying to locate that button will error without some form of synchronization: 
+added to a page or change visibility based on a click.
+An element must be both present and
+[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+in order for Selenium to interact with it.
 
-{{< tabpane text=true langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L23-L28" >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L9-L13" >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L15-L20" >}}
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L9-L14" >}}
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-{{< badge-code >}}
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-{{< badge-code >}}
-  {{< /tab >}}
-{{< /tabpane >}}
+Take this page for example: https://www.selenium.dev/selenium/web/dynamic.html
+When the "Add a box!" button is clicked, a "div" element that does not exist is created.
+When the "Reveal a new input" button is clicked, a hidden text field element is displayed.
+In both cases the transition takes a couple seconds.
+If the Selenium code is to click one of these buttons and interact with the resulting element,
+it will do so before that element is ready and fail.
 
-There are several synchronization strategies that can be used to properly wait for
-the application to be in the state you need it to be for the next Selenium command.
+The first solution many people turn to is adding a sleep statement to
+pause the code execution for a set period of time.
+Because the code can't know exactly how long it needs to wait, this
+can fail when it doesn't sleep long enough. Alternately, if the value is set too high
+and a sleep statement is added in every place it is needed, the duration of
+the session can become prohibitive.
 
-## Hard-coded sleeps
+Selenium provides two different mechanisms for synchronization that are better.
 
-This causes the code to stop executing for a set period of time.
-Because your code can't know exactly how long you need to wait, this
-will either fail when it doesn't sleep long enough, or will cause
-your sessions to take much longer than they need to. That said, putting in a sleep command is one way to keep
-the above code from failing:
-
-{{< tabpane text=true langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L34-L38" >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L18-L21" >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L27-L31" >}}
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L19-L22" >}}
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-{{< badge-code >}}
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-{{< badge-code >}}
-  {{< /tab >}}
-{{< /tabpane >}}
 
 ## Implicit waits
 Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
-You set an implicit wait either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+An implicit wait value can be set either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
 capability in the browser options, or with a driver method (as shown below).
 
 This is a global setting that applies to every element location call for the entire session.
 The default value is `0`, which means that if the element is not found, it will
 immediately return an error. If an implicit wait is set, the driver will wait for the 
 duration of the provided value before returning the error. Note that as soon as the 
-element is located, the driver will return the value and your code may continue, so a larger
-implicit wait value won't necessarily increase the time of your session.
+element is located, the driver will return the element reference and the code will continue executing, 
+so a larger implicit wait value won't necessarily increase the duration of the session.
 
 *Warning:*
 Do not mix implicit and explicit waits.
@@ -123,25 +88,13 @@ Solving our example with an implicit wait looks like this:
 
 ## Explicit waits
 
-_Explicit waits_ are loops you add to your code that poll the application 
+_Explicit waits_ are loops added to the code that poll the application 
 for a specific condition to evaluate as true before it exits the loop and
-continues to the next command in your code. If the condition is not met before a designated timeout value, 
-the code will give a timeout error.
-
-There are many ways for the application not to be in the desired state,
-so explicit waits are a great choice to specify exactly what is desired
-in each place they are needed. 
-For example, an element must be both present in the DOM and 
-[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
-in order for Selenium to interact with it. 
-
-In this example, clicking the
-"reveal" button displays an input field that is already present in the DOM.
-An explicit wait can be used to ensure the element is interactable before 
-sending keys to it. An important feature of the Wait class in Selenium is that it will automatically retry
-when a _no such element_ error happens, which makes it much easier to write succinct code.
-We do not need to handle whether the element is there and we can just focus on whether it
-evaluates as displayed:
+continues to the next command in the code. If the condition is not met before a designated timeout value, 
+the code will give a timeout error. Since there are many ways for the application not to be in the desired state,
+so explicit waits are a great choice to specify the exact condition to wait for
+in each place it is needed. 
+Another nice feature is that, by default, the Selenium Wait class automatically waits for the designated element to exist.
 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
@@ -171,11 +124,11 @@ JavaScript also supports [Expected Conditions](({{< ref "support_features/expect
 
 ### Customization
 
-The Wait class can be created with various parameters that will change how the conditions are evaluated.
+The Wait class can be instantiated with various parameters that will change how the conditions are evaluated.
 
 This can include:
 * Changing how often the code is evaluated (polling interval)
-* Specifying which exceptions should be retried
+* Specifying which exceptions should be handled automatically
 * Changing the total timeout length
 * Customizing the timeout message
 

--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -24,7 +24,7 @@ when the code is ready to execute the next Selenium command.
 Similarly, in a lot of single page applications, elements get dynamically
 added to a page or change visibility based on a click.
 An element must be both present and
-[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+[displayed]({{< ref "elements/information/#is-displayed" >}}) on the page
 in order for Selenium to interact with it.
 
 Take this page for example: https://www.selenium.dev/selenium/web/dynamic.html
@@ -46,7 +46,7 @@ Selenium provides two different mechanisms for synchronization that are better.
 
 ## Implicit waits
 Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
-An implicit wait value can be set either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+An implicit wait value can be set either with the [timeouts]({{< ref "drivers/options#timeouts" >}})
 capability in the browser options, or with a driver method (as shown below).
 
 This is a global setting that applies to every element location call for the entire session.
@@ -99,12 +99,12 @@ Another nice feature is that, by default, the Selenium Wait class automatically 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
 This example shows the condition being waited for as a _lambda_. Java also supports
-[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+[Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
   {{% /tab %}}
   {{% tab header="Python" %}}
 This example shows the condition being waited for as a _lambda_. Python also supports
-[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+[Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
   {{% /tab %}}
   {{< tab header="CSharp" >}}
@@ -114,7 +114,7 @@ This example shows the condition being waited for as a _lambda_. Python also sup
 {{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
   {{< /tab >}}
   {{% tab header="JavaScript" %}}
-JavaScript also supports [Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+JavaScript also supports [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< badge-code >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -5,411 +5,155 @@ weight: 6
 aliases: ["/documentation/ja/webdriver/waits/"]
 ---
 
-WebDriverは一般にブロッキングAPIを持っていると言えます。
-ブラウザーに処理を _指示する_ Out-of-Processライブラリであり、Webプラットフォームは本質的に非同期の性質を持っているため、WebDriverはDOMのアクティブでリアルタイムな状態を追跡しません。
-このことは、ここで説明するいくつかの課題が出てきます。
+Perhaps the most common challenge for browser automation is ensuring
+that the web application is in a state to execute a particular
+Selenium command as desired. The processes often end up in
+a _race condition_ where sometimes the browser gets into the right
+state first (things work as intended) and sometimes the Selenium code
+executes first (things do not work as intended). This is one of the
+primary causes of _flaky tests_.
 
-経験から、SeleniumとWebDriverの使用から生じる断続的なもののほとんどは、ブラウザーとユーザーの指示の間で発生する _競合状態_ に関連しています。
-たとえば、ユーザーがブラウザーにページに移動するように指示し、要素を見つけようとすると、**no such element** エラーが表示される場合があります。
+All navigation commands wait for a specific `readyState` value
+based on the [page load strategy]({{< ref "drivers/options#pageloadstrategy" >}}) (the
+default value to wait for is `"complete"`) before the driver returns control to the code.
+The `readyState` only concerns itself with loading assets defined in the HTML, 
+but loaded JavaScript assets often result in changes to the site,
+and elements that need to be interacted with may not yet be on the page
+when the code is ready to execute the next Selenium command.
 
-次のドキュメントを考えてみましょう。
+Similarly, in a lot of single page applications, elements get dynamically
+added to a page or change visibility based on a click.
+An element must be both present and
+[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+in order for Selenium to interact with it.
 
-```html
-<!doctype html>
-<meta charset=utf-8>
-<title>Race Condition Example</title>
+Take this page for example: https://www.selenium.dev/selenium/web/dynamic.html
+When the "Add a box!" button is clicked, a "div" element that does not exist is created.
+When the "Reveal a new input" button is clicked, a hidden text field element is displayed.
+In both cases the transition takes a couple seconds.
+If the Selenium code is to click one of these buttons and interact with the resulting element,
+it will do so before that element is ready and fail.
 
-<script>
-  var initialised = false;
-  window.addEventListener("load", function() {
-    var newElement = document.createElement("p");
-    newElement.textContent = "Hello from JavaScript!";
-    document.body.appendChild(newElement);
-    initialised = true;
-  });
-</script>
-```
+The first solution many people turn to is adding a sleep statement to
+pause the code execution for a set period of time.
+Because the code can't know exactly how long it needs to wait, this
+can fail when it doesn't sleep long enough. Alternately, if the value is set too high
+and a sleep statement is added in every place it is needed, the duration of
+the session can become prohibitive.
 
-WebDriverの指示は十分問題なく見えるかもしれません。
+Selenium provides two different mechanisms for synchronization that are better.
 
-{{< tabpane langEqualsHeader=true >}}
+
+## Implicit waits
+Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
+An implicit wait value can be set either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+capability in the browser options, or with a driver method (as shown below).
+
+This is a global setting that applies to every element location call for the entire session.
+The default value is `0`, which means that if the element is not found, it will
+immediately return an error. If an implicit wait is set, the driver will wait for the 
+duration of the provided value before returning the error. Note that as soon as the 
+element is located, the driver will return the element reference and the code will continue executing, 
+so a larger implicit wait value won't necessarily increase the duration of the session.
+
+*Warning:*
+Do not mix implicit and explicit waits.
+Doing so can cause unpredictable wait times.
+For example, setting an implicit wait of 10 seconds
+and an explicit wait of 15 seconds
+could cause a timeout to occur after 20 seconds.
+
+Solving our example with an implicit wait looks like this:
+
+{{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-driver.get("file:///race_condition.html");
-WebElement element = driver.findElement(By.tagName("p"));
-assertEquals(element.getText(), "Hello from JavaScript!");
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L45-L49" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-driver.navigate("file:///race_condition.html")
-el = driver.find_element(By.TAG_NAME, "p")
-assert el.text == "Hello from JavaScript!"
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27-L31" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-driver.Navigate().GoToUrl("file:///race_condition.html");
-IWebElement element = driver.FindElement(By.TagName("p"));
-assertEquals(element.Text, "Hello from JavaScript!");
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39-L44" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-begin
-  # Navigate to URL
-  driver.get 'file:///race_condition.html'
-
-  # Get and store Paragraph Text
-  search_form = driver.find_element(:css,'p').text
-
-  "Hello from JavaScript!".eql? search_form
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28-L32" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-await driver.get('file:///race_condition.html');
-const element = driver.findElement(By.css('p'));
-assert.strictEqual(await element.getText(), 'Hello from JavaScript!');
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-driver.get("file:///race_condition.html")
-val element = driver.findElement(By.tagName("p"))
-assert(element.text == "Hello from JavaScript!")
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-ここでは、WebDriverで使用されるデフォルトの [ページロード戦略]({{< ref "drivers/options#pageloadstrategy" >}}) が`document.readyState`をリッスンして、ナビゲーションの呼び出しから戻る前に`"complete"`に変更することが問題です。ドキュメントの読み込みが完了した後に`p`要素が追加されるため、このWebDriverスクリプトは断続的になる _可能性があります。_ これらのイベントを明示的に待機（またはブロック）せずに非同期でトリガーする要素またはイベントについては保証できないため、断続的である可能性があります。
+## Explicit waits
 
-幸いなことに、 _WebElement.click_ や _WebElement.sendKeys_ などのWebElementインターフェイスで使用可能な通常の命令セットを使用すると、コマンドの呼び出しがブラウザーで完了するまで関数呼び出しが返されない（または、コールバックはコールバックスタイルの言語ではトリガーされない）ため、同期が保証されます。高度なユーザーインタラクションAPIである[_キーボード_]({{< ref "actions_api/keyboard.md" >}})と[_マウス_]({{< ref "actions_api/mouse.md" >}})は、 "言うことをする" 非同期コマンドとして明示的に意図されているため、例外です。
+_Explicit waits_ are loops added to the code that poll the application
+for a specific condition to evaluate as true before it exits the loop and
+continues to the next command in the code. If the condition is not met before a designated timeout value,
+the code will give a timeout error. Since there are many ways for the application not to be in the desired state,
+so explicit waits are a great choice to specify the exact condition to wait for
+in each place it is needed.
+Another nice feature is that, by default, the Selenium Wait class automatically waits for the designated element to exist.
 
-待機とは、自動化されたタスクの実行を一定時間経過させてから次のステップに進むことです。
-
-ブラウザーとWebDriverスクリプト間の競合状態の問題を克服するために、ほとんどのSeleniumクライアントには待機パッケージが付属しています。待機を使用する場合、一般に[_明示的な待機_](#明示的な待機)と呼ばれるものを使用しています。
-
-## 明示的な待機
-
-Seleniumクライアントは、命令型の手続き型言語の _明示的な待機_  を利用できます。
-これにより、 _条件_ が解決するまで、コードでプログラムの実行を停止したり、スレッドをフリーズしたりできます。
-条件は、明示的な待機のタイムアウトが経過するまで特定の頻度で呼び出されます。
-つまり、条件がfalseの値を返す限り、試行、待機し続けます。
-
-明示的な待機により条件が発生するのを待機できるため、ブラウザーとそのDOM、およびWebDriverスクリプトの間で状態を同期するのに適しています。
-
-以前のバグのある命令セットを修正するには、スクリプトから動的に追加された要素がDOMに追加されるまで、 _findElement_ 呼び出しを待機させるために待機を採用できます。
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebDriver driver = new ChromeDriver();
-driver.get("https://google.com/ncr");
-driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER);
-// Initialize and wait till element(link) became clickable - timeout in 10 seconds
-WebElement firstResult = new WebDriverWait(driver, Duration.ofSeconds(10))
-        .until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")));
-// Print the first result
-System.out.println(firstResult.getText());
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.wait import WebDriverWait
-def document_initialised(driver):
-    return driver.execute_script("return initialised")
-
-driver.navigate("file:///race_condition.html")
-WebDriverWait(driver, timeout=10).until(document_initialised)
-el = driver.find_element(By.TAG_NAME, "p")
-assert el.text == "Hello from JavaScript!"
-  {{< /tab >}}
+{{< tabpane text=true langEqualsHeader=true >}}
+  {{% tab header="Java" %}}
+This example shows the condition being waited for as a _lambda_. Java also supports
+[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+This example shows the condition being waited for as a _lambda_. Python also supports
+[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
+  {{% /tab %}}
   {{< tab header="CSharp" >}}
-driver = new ChromeDriver();
-driver.Url = "https://www.google.com/ncr";
-driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
-
-WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-IWebElement firstResult = wait.Until(e => e.FindElement(By.XPath("//a/h3")));
-
-Console.WriteLine(firstResult.Text);
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L53-L59" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-
-def document_initialised(driver)
-  driver.execute_script('return initialised')
-end
-
-begin
-  driver.get 'file:///race_condition.html'
-  wait.until{document_initialised driver}
-  search_form = driver.find_element(:css,'p').text
-  "Hello from JavaScript!".eql? search_form
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
   {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-const documentInitialised = () =>
-    driver.executeScript('return initialised');
-
-await driver.get('file:///race_condition.html');
-await driver.wait(() => documentInitialised(), 10000);
-const element = driver.findElement(By.css('p'));
-assert.strictEqual(await element.getText(), 'Hello from JavaScript!');
-  {{< /tab >}}
+  {{% tab header="JavaScript" %}}
+JavaScript also supports [Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< badge-code >}}
+  {{% /tab %}}
   {{< tab header="Kotlin" >}}
-driver.get("https://google.com/ncr")
-driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER)
-// Initialize and wait till element(link) became clickable - timeout in 10 seconds
-val firstResult = WebDriverWait(driver, Duration.ofSeconds(10))
-      .until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")))
-// Print the first result
-println(firstResult.text)
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-戻り値がtrueになるまで _待機_ が繰り返し実行される関数リファレンスとして _条件_ を渡します。
-"真の"戻り値とは、文字列、数値、ブール値、オブジェクト（ _WebElement_ を含む）、または入力された（空でない）シーケンスまたはリストなど、手元の言語でブール値trueと評価されるものです。
-つまり、 _空のリスト_ はfalseと評価されます。
-条件がtrueで、ブロッキング待機が中止されると、条件からの戻り値が待機の戻り値になります。
+### Customization
 
-このナレッジと、ウェイトユーティリティはデフォルトで _no such element_ エラーを無視するため、より簡潔になるように命令をリファクタリングできます。
+The Wait class can be instantiated with various parameters that will change how the conditions are evaluated.
 
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebElement foo = new WebDriverWait(driver, Duration.ofSeconds(3))
-            .until(driver -> driver.findElement(By.tagName("p")));
-assertEquals(foo.getText(), "Hello from JavaScript!");
-  {{< /tab >}}
+This can include:
+* Changing how often the code is evaluated (polling interval)
+* Specifying which exceptions should be handled automatically
+* Changing the total timeout length
+* Customizing the timeout message
+
+For instance, if the _element not interactable_ error is retried by default, then we can
+add an action on a method inside the code getting executed (we just need to 
+make sure that the code returns `true` when it is successful):
+
+{{< tabpane text=true langEqualsHeader=true >}}
+  {{% tab header="Java" %}}
+The easiest way to customize Waits in Java is to use the `FluentWait` class:
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L70-L80" >}}
+  {{% /tab %}}
   {{< tab header="Python" >}}
-from selenium.webdriver.support.wait import WebDriverWait
-
-driver.navigate("file:///race_condition.html")
-el = WebDriverWait(driver, timeout=3).until(lambda d: d.find_element(By.TAG_NAME,"p"))
-assert el.text == "Hello from JavaScript!"
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L50-L55" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using (var driver = new FirefoxDriver())
-{
-        var foo = new WebDriverWait(driver, TimeSpan.FromSeconds(3))
-                        .Until(drv => drv.FindElement(By.Name("q")));
-        Debug.Assert(foo.Text.Equals("Hello from JavaScript!"));
-}
-{{< /tab >}}
-  {{< tab header="Ruby" >}}
-  driver.get 'file:///race_condition.html'
-  wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-  ele = wait.until { driver.find_element(css: 'p')}
-  foo = ele.text
-  assert_match foo, 'Hello from JavaScript'
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let ele = await driver.wait(until.elementLocated(By.css('p')),10000);
-let foo = await ele.getText();
-assert(foo == "Hello from JavaScript");
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-driver.get("file:///race_condition.html")
-val ele = WebDriverWait(driver, Duration.ofSeconds(10))
-            .until(ExpectedConditions.presenceOfElementLocated(By.tagName("p")))
-assert(ele.text == "Hello from JavaScript!")
-  {{< /tab >}}
-{{< /tabpane >}}
-
-この例では、匿名関数を渡します（ただし、以前に行ったように明示的に定義して再利用できるようにすることもできます）。
-条件に渡される最初で唯一の引数は、常にドライバーオブジェクト　_WebDriver_　への参照です。
-マルチスレッド環境では、外部スコープ内のドライバーへのリファレンスではなく、条件に渡されたドライバーのリファレンスを操作するように注意する必要があります。
-
-待機は、要素が見つからないときに発生する _no such element_ エラーを飲み込むため、要素が見つかるまで条件は再試行されます。
-次に、戻り値である _WebElement_ を取得して、スクリプトに渡します。
-
-条件が失敗した場合、例えば条件からの真の戻り値に到達しない場合、待機は _timeout error_ と呼ばれるエラー/例外をスロー/発生させます。
-
-### オプション
-
-待機条件は、ニーズに合わせてカスタマイズできます。
-成功した条件にヒットしないことに対するペナルティは高額になる可能性があるため、デフォルトのタイムアウトの全範囲を待つ必要がない場合があります。
-
-WebDriverWaitに引数を渡してタイムアウトをオーバーライドできます。
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-new WebDriverWait(driver, Duration.ofSeconds(3)).until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-WebDriverWait(driver, timeout=3).until(some_condition)
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
- new WebDriverWait(driver, TimeSpan.FromSeconds(3)).Until(driver => driver.FindElement(By.Name("q")));
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L67-L78" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-
-wait.until { driver.find_element(:id, 'message').displayed? }
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L51-L59" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  await driver.wait(until.elementLocated(By.id('foo')), 30000);
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-WebDriverWait(driver, Duration.ofSeconds(3)).until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")))
-  {{< /tab >}}
-{{< /tabpane >}}
-
-### 期待される条件
-
-DOMと指示を同期しなければならないことは非常に一般的であるため、ほとんどのクライアントには事前に定義された一連の _期待される条件_もあります。
-名前から明らかなように、これらは頻繁な待機操作に対して事前定義されている条件です。
-
-異なる言語バインディングで利用可能な条件は異なりますが、これは少数の抜粋したリストです。
-
-* alert is present
-* element exists
-* element is visible
-* title contains
-* title is
-* element staleness
-* visible text
-
-各クライアントバインディングのAPIドキュメントを参照して、予想される条件の完全なリストを見つけることができます。
-
-* Java's [org.openqa.selenium.support.ui.ExpectedConditions](//seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html) class
-* Python's [selenium.webdriver.support.expected_conditions](//seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html?highlight=expected) class
-* JavaScript's [selenium-webdriver/lib/until](//seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/until.html) module
-
-
-## 暗黙的な待機
-
-_暗黙的な待機_ と呼ばれる[明示的な待機](#明示的な待機)とは異なる2番目の種類の待機があります。
-暗黙的に待機することにより、WebDriverは _何か_ 要素を見つけようとするときに特定の期間DOMをポーリングします。
-これは、Webページ上の特定の要素がすぐに利用できず、ロードに時間がかかる場合に役立ちます。
-
-要素の表示を暗黙的に待機することはデフォルトで無効になっており、セッションごとに手動で有効にする必要があります。
-[明示的な待機](#明示的な待機)と暗黙的な待機を混在させると、意図しない結果、すなわち、要素が利用可能または条件が真であっても、最大時間スリープする待機が発生します。
-
-*警告 :*
-暗黙的な待機と明示的な待機を混在させないでください。
-これを行うと、予測できない待機時間が発生する可能性があります。
-たとえば、10秒の暗黙的な待機と15秒の明示的な待機を設定すると、20秒後にタイムアウトが発生する可能性があります。
-
-暗黙的な待機は、1つまたは複数の要素がすぐに利用できない場合にそれらを見つけようとするときにWebDriverにDOMを一定時間ポーリングするように指示することです。
-デフォルト設定は0で、無効を意味します。
-設定すると、セッションの存続期間中、暗黙的な待機が設定されます。
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebDriver driver = new FirefoxDriver();
-driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
-driver.get("http://somedomain/url_that_delays_loading");
-WebElement myDynamicElement = driver.findElement(By.id("myDynamicElement"));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-driver = Firefox()
-driver.implicitly_wait(10)
-driver.get("http://somedomain/url_that_delays_loading")
-my_dynamic_element = driver.find_element(By.ID, "myDynamicElement")
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-IWebDriver driver = new ChromeDriver();
-driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
-driver.Url = "http://somedomain/url_that_delays_loading";
-IWebElement dynamicElement = driver.FindElement(By.Name("dynamicElement"));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-driver.manage.timeouts.implicit_wait = 10
-
-begin
-  driver.get 'http://somedomain/url_that_delays_loading'
-  search_form = driver.find_element(:id,'dynamic_element')
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-(async function(){
-
-// Apply timeout for 10 seconds
-await driver.manage().setTimeouts( { implicit: 10000 } );
-
-// Navigate to url
-await driver.get('http://somedomain/url_that_delays_loading');
-
-let webElement = driver.findElement(By.id("myDynamicElement"));
-
-}());
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val driver = FirefoxDriver()
-driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10))
-driver.get("http://somedomain/url_that_delays_loading")
-val myDynamicElement = driver.findElement(By.id("myDynamicElement"))
-  {{< /tab >}}
-{{< /tabpane >}}
-
-## FluentWait
-
-FluentWaitインスタンスは、条件を待機する最大時間を定義します。
-状態を確認する頻度も同様です。
-
-ユーザーは、ページ上の要素を検索するときの`NoSuchElementException`など、待機中に特定の種類の例外を無視するように待機を構成できます。
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-// Waiting 30 seconds for an element to be present on the page, checking
-// for its presence once every 5 seconds.
-Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
-  .withTimeout(Duration.ofSeconds(30))
-  .pollingEvery(Duration.ofSeconds(5))
-  .ignoring(NoSuchElementException.class);
-
-WebElement foo = wait.until(driver -> {
-  return driver.findElement(By.id("foo"));
-});
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-driver = Firefox()
-driver.get("http://somedomain/url_that_delays_loading")
-wait = WebDriverWait(driver, timeout=10, poll_frequency=1, ignored_exceptions=[ElementNotVisibleException, ElementNotSelectableException])
-element = wait.until(EC.element_to_be_clickable((By.XPATH, "//div")))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-using (var driver = new FirefoxDriver())
-{
-  WebDriverWait wait = new WebDriverWait(driver, timeout: TimeSpan.FromSeconds(30))
-  {
-      PollingInterval = TimeSpan.FromSeconds(5),
-  };
-  wait.IgnoreExceptionTypes(typeof(NoSuchElementException));
-
-  var foo = wait.Until(drv => drv.FindElement(By.Id("foo")));
-}
-{{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-exception = Selenium::WebDriver::Error::NoSuchElementError
-
-begin
-  driver.get 'http://somedomain/url_that_delays_loading'
-  wait = Selenium::WebDriver::Wait.new(timeout: 30, interval: 5, message: 'Timed out after 30 sec', ignore: exception)
-  foo = wait.until { driver.find_element(id: 'foo')}
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-const {Builder, until} = require('selenium-webdriver');
-
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    await driver.get('http://somedomain/url_that_delays_loading');
-    // Waiting 30 seconds for an element to be present on the page, checking
-    // for its presence once every 5 seconds.
-    let foo = await driver.wait(until.elementLocated(By.id('foo')), 30000, 'Timed out after 30 seconds', 5000);
-})();
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val wait = FluentWait<WebDriver>(driver)
-        .withTimeout(Duration.ofSeconds(30))
-        .pollingEvery(Duration.ofSeconds(3))
-        .ignoring(NoSuchElementException::class.java)
-
-val foo = wait.until {it.findElement(By.id("foo")) }
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -24,7 +24,7 @@ when the code is ready to execute the next Selenium command.
 Similarly, in a lot of single page applications, elements get dynamically
 added to a page or change visibility based on a click.
 An element must be both present and
-[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+[displayed]({{< ref "elements/information/#is-displayed" >}}) on the page
 in order for Selenium to interact with it.
 
 Take this page for example: https://www.selenium.dev/selenium/web/dynamic.html
@@ -46,7 +46,7 @@ Selenium provides two different mechanisms for synchronization that are better.
 
 ## Implicit waits
 Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
-An implicit wait value can be set either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+An implicit wait value can be set either with the [timeouts]({{< ref "drivers/options#timeouts" >}})
 capability in the browser options, or with a driver method (as shown below).
 
 This is a global setting that applies to every element location call for the entire session.
@@ -99,12 +99,12 @@ Another nice feature is that, by default, the Selenium Wait class automatically 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
 This example shows the condition being waited for as a _lambda_. Java also supports
-[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+[Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
   {{% /tab %}}
   {{% tab header="Python" %}}
 This example shows the condition being waited for as a _lambda_. Python also supports
-[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+[Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
   {{% /tab %}}
   {{< tab header="CSharp" >}}
@@ -114,7 +114,7 @@ This example shows the condition being waited for as a _lambda_. Python also sup
 {{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
   {{< /tab >}}
   {{% tab header="JavaScript" %}}
-JavaScript also supports [Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+JavaScript also supports [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< badge-code >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -5,498 +5,155 @@ weight: 6
 aliases: ["/documentation/pt-br/webdriver/waits/"]
 ---
 
-Geralmente, pode-se dizer que o WebDriver tem uma API de blocante.
-Porque é uma biblioteca fora de processo que
-_instrui_ ao navegador o que fazer,
-e porque a plataforma web tem uma natureza intrinsecamente assíncrona,
-O WebDriver não rastreia o estado ativo em tempo real do DOM.
-Isso traz alguns desafios que discutiremos aqui.
+Perhaps the most common challenge for browser automation is ensuring
+that the web application is in a state to execute a particular
+Selenium command as desired. The processes often end up in
+a _race condition_ where sometimes the browser gets into the right
+state first (things work as intended) and sometimes the Selenium code
+executes first (things do not work as intended). This is one of the
+primary causes of _flaky tests_.
 
-Por experiência,
-a maioria dos problemas intermitentes que surgem do uso de Selenium e WebDriver
-estão conectados a _condições de corrida_ que ocorrem entre
-o navegador e as instruções do usuário.
-Um exemplo pode ser que o usuário instrui o navegador a navegar para uma página,
-em seguida, obtém um erro **no such element**
-ao tentar encontrar um elemento.
+All navigation commands wait for a specific `readyState` value
+based on the [page load strategy]({{< ref "drivers/options#pageloadstrategy" >}}) (the
+default value to wait for is `"complete"`) before the driver returns control to the code.
+The `readyState` only concerns itself with loading assets defined in the HTML, 
+but loaded JavaScript assets often result in changes to the site,
+and elements that need to be interacted with may not yet be on the page
+when the code is ready to execute the next Selenium command.
 
-Considere o seguinte documento:
+Similarly, in a lot of single page applications, elements get dynamically
+added to a page or change visibility based on a click.
+An element must be both present and
+[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+in order for Selenium to interact with it.
 
-```html
-<!doctype html>
-<meta charset=utf-8>
-<title>Race Condition Example</title>
+Take this page for example: https://www.selenium.dev/selenium/web/dynamic.html
+When the "Add a box!" button is clicked, a "div" element that does not exist is created.
+When the "Reveal a new input" button is clicked, a hidden text field element is displayed.
+In both cases the transition takes a couple seconds.
+If the Selenium code is to click one of these buttons and interact with the resulting element,
+it will do so before that element is ready and fail.
 
-<script>
-  var initialised = false;
-  window.addEventListener("load", function() {
-    var newElement = document.createElement("p");
-    newElement.textContent = "Hello from JavaScript!";
-    document.body.appendChild(newElement);
-    initialised = true;
-  });
-</script>
-```
+The first solution many people turn to is adding a sleep statement to
+pause the code execution for a set period of time.
+Because the code can't know exactly how long it needs to wait, this
+can fail when it doesn't sleep long enough. Alternately, if the value is set too high
+and a sleep statement is added in every place it is needed, the duration of
+the session can become prohibitive.
 
-As instruções do WebDriver podem parecer inocentes:
+Selenium provides two different mechanisms for synchronization that are better.
 
-{{< tabpane langEqualsHeader=true >}}
+
+## Implicit waits
+Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
+An implicit wait value can be set either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+capability in the browser options, or with a driver method (as shown below).
+
+This is a global setting that applies to every element location call for the entire session.
+The default value is `0`, which means that if the element is not found, it will
+immediately return an error. If an implicit wait is set, the driver will wait for the 
+duration of the provided value before returning the error. Note that as soon as the 
+element is located, the driver will return the element reference and the code will continue executing, 
+so a larger implicit wait value won't necessarily increase the duration of the session.
+
+*Warning:*
+Do not mix implicit and explicit waits.
+Doing so can cause unpredictable wait times.
+For example, setting an implicit wait of 10 seconds
+and an explicit wait of 15 seconds
+could cause a timeout to occur after 20 seconds.
+
+Solving our example with an implicit wait looks like this:
+
+{{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-driver.get("file:///race_condition.html");
-WebElement element = driver.findElement(By.tagName("p"));
-assertEquals(element.getText(), "Hello from JavaScript!");
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L45-L49" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-driver.navigate("file:///race_condition.html")
-el = driver.find_element(By.TAG_NAME, "p")
-assert el.text == "Hello from JavaScript!"
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27-L31" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-driver.Navigate().GoToUrl("file:///race_condition.html");
-IWebElement element = driver.FindElement(By.TagName("p"));
-assertEquals(element.Text, "Hello from JavaScript!");
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39-L44" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-begin
-  # Navigate to URL
-  driver.get 'file:///race_condition.html'
-
-  # Get and store Paragraph Text
-  search_form = driver.find_element(:css,'p').text
-
-  "Hello from JavaScript!".eql? search_form
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28-L32" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-await driver.get('file:///race_condition.html');
-const element = driver.findElement(By.css('p'));
-assert.strictEqual(await element.getText(), 'Hello from JavaScript!');
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-driver.get("file:///race_condition.html")
-val element = driver.findElement(By.tagName("p"))
-assert(element.text == "Hello from JavaScript!")
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-O problema aqui é que a
-[estratégia de carregamento de página padrão]({{< ref "drivers/options#pageloadstrategy" >}})
-usado no WebDriver escuta o `document.readyState`
-para mudar para `"complete"` antes de retornar da chamada para _navigate_.
-Porque o elemento `p` é
-adicionado _após_ o carregamento do documento concluído,
-este script WebDriver _pode_ ser intermitente.
-"Pode" ser intermitente porque nenhuma garantia pode ser feita
-sobre elementos ou eventos que disparam de forma assíncrona
-sem esperar explicitamente - ou bloquear - nesses eventos.
+## Explicit waits
 
-Felizmente, o conjunto normal de instruções disponível na interface
-[_WebElement _]({{< ref "elements" >}}) - tal
-  como _WebElement.click_ e _WebElement.sendKeys_ — são
-  garantidamente síncrono,
-  em que as chamadas de função não retornarão
-  (ou o retorno de chamada não será acionado em linguagens de estilo de
-  retorno de chamada) até que o comando seja concluído no navegador.
-  As APIs avançadas de interação com o usuário,
-  [_Keyboard_]({{< ref "actions_api/keyboard.md" >}})
-  e [_Mouse_]({{< ref "actions_api/mouse.md">}}),
-  são exceções, pois são explicitamente pretendidas como
-  comandos assíncronos “faça o que eu digo”.
+_Explicit waits_ are loops added to the code that poll the application
+for a specific condition to evaluate as true before it exits the loop and
+continues to the next command in the code. If the condition is not met before a designated timeout value,
+the code will give a timeout error. Since there are many ways for the application not to be in the desired state,
+so explicit waits are a great choice to specify the exact condition to wait for
+in each place it is needed.
+Another nice feature is that, by default, the Selenium Wait class automatically waits for the designated element to exist.
 
-Esperar é fazer a execução de tarefa automatizada
-esperar passar um certo tempo antes de continuar com a próxima etapa.
-
-Para superar o problema das condições de corrida
-entre o navegador e o script WebDriver,
-a maioria dos clientes Selenium vem com um pacote _wait_.
-Ao empregar uma espera,
-você está usando o que é comumente referido
-como uma [_espera explícita_](#explicit-wait).
-
-
-## Espera explícita
-
-_Esperas explícitas_ estão disponíveis para clientes Selenium
-para linguagens procedurais imperativas.
-Eles permitem que seu código interrompa a execução do programa,
-ou congelar o tópico,
-até que a _condição_ que você passe resolva.
-A condição é chamada com uma certa frequência
-até que o tempo limite de espera tenha decorrido.
-Isso significa que, enquanto a condição retornar um valor falso,
-ele continuará tentando e esperando.
-
-Como as esperas explícitas permitem que você espere até que uma condição ocorra,
-eles são adequados para sincronizar o estado entre o navegador e seu DOM,
-e seu script WebDriver.
-
-Para remediar o nosso conjunto de instruções com erros de antes,
-poderíamos empregar um tempo de espera para que a chamada _findElement_
-espere até que o elemento adicionado dinamicamente do script
-seja adicionado ao DOM:
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebDriver driver = new ChromeDriver();
-driver.get("https://google.com/ncr");
-driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER);
-// Initialize and wait till element(link) became clickable - timeout in 10 seconds
-WebElement firstResult = new WebDriverWait(driver, Duration.ofSeconds(10))
-        .until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")));
-// Print the first result
-System.out.println(firstResult.getText());
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.wait import WebDriverWait
-def document_initialised(driver):
-    return driver.execute_script("return initialised")
-
-driver.navigate("file:///race_condition.html")
-WebDriverWait(driver, timeout=10).until(document_initialised)
-el = driver.find_element(By.TAG_NAME, "p")
-assert el.text == "Hello from JavaScript!"
-  {{< /tab >}}
+{{< tabpane text=true langEqualsHeader=true >}}
+  {{% tab header="Java" %}}
+This example shows the condition being waited for as a _lambda_. Java also supports
+[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+This example shows the condition being waited for as a _lambda_. Python also supports
+[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
+  {{% /tab %}}
   {{< tab header="CSharp" >}}
-driver = new ChromeDriver();
-driver.Url = "https://www.google.com/ncr";
-driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
-
-WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-IWebElement firstResult = wait.Until(e => e.FindElement(By.XPath("//a/h3")));
-
-Console.WriteLine(firstResult.Text);
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L53-L59" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-
-def document_initialised(driver)
-  driver.execute_script('return initialised')
-end
-
-begin
-  driver.get 'file:///race_condition.html'
-  wait.until{document_initialised driver}
-  search_form = driver.find_element(:css,'p').text
-  "Hello from JavaScript!".eql? search_form
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
   {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-const documentInitialised = () =>
-    driver.executeScript('return initialised');
-
-await driver.get('file:///race_condition.html');
-await driver.wait(() => documentInitialised(), 10000);
-const element = driver.findElement(By.css('p'));
-assert.strictEqual(await element.getText(), 'Hello from JavaScript!');
-  {{< /tab >}}
+  {{% tab header="JavaScript" %}}
+JavaScript also supports [Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< badge-code >}}
+  {{% /tab %}}
   {{< tab header="Kotlin" >}}
-driver.get("https://google.com/ncr")
-driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER)
-// Initialize and wait till element(link) became clickable - timeout in 10 seconds
-val firstResult = WebDriverWait(driver, Duration.ofSeconds(10))
-      .until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")))
-// Print the first result
-println(firstResult.text)
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-Passamos a _condição_ como uma referência de função
-que o _wait_ executará repetidamente até que seu valor de retorno seja verdadeiro.
-Um valor de retorno “verdadeiro” é qualquer coisa avaliada como booleana verdadeira
-na linguagem em questão, como string, número, booleano,
-um objeto (incluindo um _WebElement_),
-ou uma sequência ou lista preenchida (não vazia).
-Isso significa que uma _lista vazia_ é avaliada como falsa.
-Quando a condição é verdadeira e a espera de bloqueio é abortada,
-o valor de retorno da condição se torna o valor de retorno da espera.
+### Customization
 
-Com este conhecimento,
-e como o utilitário de espera ignora erros _no such element_ por padrão,
-podemos refatorar nossas instruções para sermos mais concisos:
+The Wait class can be instantiated with various parameters that will change how the conditions are evaluated.
 
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebElement foo = new WebDriverWait(driver, Duration.ofSeconds(3))
-          .until(driver -> driver.findElement(By.tagName("p")));
-assertEquals(foo.getText(), "Hello from JavaScript!");
-  {{< /tab >}}
+This can include:
+* Changing how often the code is evaluated (polling interval)
+* Specifying which exceptions should be handled automatically
+* Changing the total timeout length
+* Customizing the timeout message
+
+For instance, if the _element not interactable_ error is retried by default, then we can
+add an action on a method inside the code getting executed (we just need to 
+make sure that the code returns `true` when it is successful):
+
+{{< tabpane text=true langEqualsHeader=true >}}
+  {{% tab header="Java" %}}
+The easiest way to customize Waits in Java is to use the `FluentWait` class:
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L70-L80" >}}
+  {{% /tab %}}
   {{< tab header="Python" >}}
-from selenium.webdriver.support.wait import WebDriverWait
-
-driver.navigate("file:///race_condition.html")
-el = WebDriverWait(driver, timeout=3).until(lambda d: d.find_element(By.TAG_NAME,"p"))
-assert el.text == "Hello from JavaScript!"
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L50-L55" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-   using (var driver = new FirefoxDriver())
-    {
-        var foo = new WebDriverWait(driver, TimeSpan.FromSeconds(3))
-                        .Until(drv => drv.FindElement(By.Name("q")));
-        Debug.Assert(foo.Text.Equals("Hello from JavaScript!"));
-    }
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L67-L78" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-  driver.get 'file:///race_condition.html'
-  wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-  ele = wait.until { driver.find_element(css: 'p')}
-  foo = ele.text
-  assert_match foo, 'Hello from JavaScript'
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L51-L59" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-let ele = await driver.wait(until.elementLocated(By.css('p')),10000);
-let foo = await ele.getText();
-assert(foo == "Hello from JavaScript");
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-driver.get("file:///race_condition.html")
-val ele = WebDriverWait(driver, Duration.ofSeconds(10))
-            .until(ExpectedConditions.presenceOfElementLocated(By.tagName("p")))
-assert(ele.text == "Hello from JavaScript!")
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
-
-Nesse exemplo, passamos uma função anônima
-(mas também podemos definá-la explicitamente, como fizemos antes,
-para que possa ser reutilizado). O primeiro e único argumento que é
-passado para nossa condição é sempre uma referência ao nosso objeto
-driver, _WebDriver_. Em um ambiente multi-thread, você deve ter cuidado
-para operar na referência do driver passada para a condição
-em vez da referência ao driver no escopo externo.
-
-Dado que a espera vai engolir erros _no such element_
-que são gerados quando o elemento não é encontrado,
-a condição tentará novamente até que o elemento seja encontrado.
-Em seguida, ele receberá o valor de retorno, um _WebElement_,
-e o passará de volta para o nosso script.
-
-Se a condição falhar,
-por exemplo um valor de retorno verdadeiro da condição nunca for
-alcançado, a espera lançará/gerará um erro/exceção chamado
-_timeout error_.
-
-
-### Opções
-
-A condição de espera pode ser personalizada para atender às suas
-necessidades. Às vezes, é desnecessário esperar todo o tempo limite
-padrão, já que a penalidade por não atingir uma condição de sucesso pode
-ser cara.
-
-A espera permite que você passe um argumento para substituir o tempo
-limite:
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-new WebDriverWait(driver, Duration.ofSeconds(3)).until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-WebDriverWait(driver, timeout=3).until(some_condition)
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-new WebDriverWait(driver, TimeSpan.FromSeconds(3)).Until(driver => driver.FindElement(By.Name("q")));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-
-wait.until { driver.find_element(:id, 'message').displayed? }
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-  await driver.wait(until.elementLocated(By.id('foo')), 30000);
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-WebDriverWait(driver, Duration.ofSeconds(3)).until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")))
-  {{< /tab >}}
-{{< /tabpane >}}
-
-### Condições esperadas
-
-Já que é uma ocorrência bastante comum
-ter que sincronizar o DOM e suas instruções,
-a maioria dos clientes também vem com um conjunto de _condições esperadas_ predefinidas.
-Como pode ser óbvio pelo nome,
-são condições predefinidas para operações de espera frequentes.
-
-As condições disponíveis nas diferentes linguagens variam,
-mas esta é uma lista não exaustiva de alguns:
-
-* alert is present
-* element exists
-* element is visible
-* title contains
-* title is
-* element staleness
-* visible text
-
-Você pode consultar a documentação da API para cada biblioteca de cliente
-para encontrar uma lista exaustiva das condições esperadas:
-
-* Classe Java [org.openqa.selenium.support.ui.ExpectedConditions](//seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html)
-* Classe Python [selenium.webdriver.support.expected_conditions](//seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html?highlight=expected)
-* JavaScript's [selenium-webdriver/lib/until](//seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/until.html) module
-
-
-## Espera implícita
-
-Há um segundo tipo de espera que é diferente de
-[espera explícita](#explicit-wait) chamada _espera implícita_.
-Esperando implicitamente, o WebDriver pesquisa o DOM
-por um certo período ao tentar encontrar _qualquer_ elemento.
-Isso pode ser útil quando certos elementos da página da web
-não estão disponíveis imediatamente e precisam de algum tempo para
-carregar.
-
-A espera implícita pelo aparecimento de elementos está desativada por
-padrão e precisará ser habilitada manualmente por sessão.
-Misturar [esperas explícitas](#explicit-wait) e esperas implícitas
-irá causar consequências não intencionais, ou seja, espera dormir pelo
-máximo tempo mesmo se o elemento estiver disponível ou a condição for
-verdadeira.
-
-*Atenção:*
-Não misture esperas implícitas e explícitas.
-Isso pode causar tempos de espera imprevisíveis.
-Por exemplo, definir uma espera implícita de 10 segundos
-e uma espera explícita de 15 segundos
-pode causar um tempo limite após 20 segundos.
-
-Uma espera implícita é dizer ao WebDriver para pesquisar o DOM
-por um certo período de tempo ao tentar encontrar um elemento ou
-elementos se não estiverem imediatamente disponíveis.
-A configuração padrão é 0, o que significa desativado.
-Depois de definida, a espera implícita é definida para a duração da
-sessão.
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebDriver driver = new FirefoxDriver();
-driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
-driver.get("http://somedomain/url_that_delays_loading");
-WebElement myDynamicElement = driver.findElement(By.id("myDynamicElement"));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-driver = Firefox()
-driver.implicitly_wait(10)
-driver.get("http://somedomain/url_that_delays_loading")
-my_dynamic_element = driver.find_element(By.ID, "myDynamicElement")
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-IWebDriver driver = new ChromeDriver();
-driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
-driver.Url = "http://somedomain/url_that_delays_loading";
-IWebElement dynamicElement = driver.FindElement(By.Name("dynamicElement"));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-driver.manage.timeouts.implicit_wait = 10
-
-begin
-  driver.get 'http://somedomain/url_that_delays_loading'
-  search_form = driver.find_element(:id,'dynamic_element')
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-(async function(){
-
-// Apply timeout for 10 seconds
-await driver.manage().setTimeouts( { implicit: 10000 } );
-
-// Navigate to url
-await driver.get('http://somedomain/url_that_delays_loading');
-
-let webElement = driver.findElement(By.id("myDynamicElement"));
-
-}());
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val driver = FirefoxDriver()
-driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10))
-driver.get("http://somedomain/url_that_delays_loading")
-val myDynamicElement = driver.findElement(By.id("myDynamicElement"))
-  {{< /tab >}}
-{{< /tabpane >}}
-
-## FluentWait
-
-A instância FluentWait define a quantidade máxima de tempo de espera por
-uma condição, bem como a frequência com que verificar a condição.
-
-Os usuários podem configurar a espera para ignorar tipos específicos de
-exceções enquanto esperam, como `NoSuchElementException` ao pesquisar um
-elemento na página.
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-// Waiting 30 seconds for an element to be present on the page, checking
-// for its presence once every 5 seconds.
-Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
-  .withTimeout(Duration.ofSeconds(30))
-  .pollingEvery(Duration.ofSeconds(5))
-  .ignoring(NoSuchElementException.class);
-
-WebElement foo = wait.until(driver -> {
-  return driver.findElement(By.id("foo"));
-});
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-driver = Firefox()
-driver.get("http://somedomain/url_that_delays_loading")
-wait = WebDriverWait(driver, timeout=10, poll_frequency=1, ignored_exceptions=[ElementNotVisibleException, ElementNotSelectableException])
-element = wait.until(EC.element_to_be_clickable((By.XPATH, "//div")))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-using (var driver = new FirefoxDriver())
-{
-  WebDriverWait wait = new WebDriverWait(driver, timeout: TimeSpan.FromSeconds(30))
-  {
-      PollingInterval = TimeSpan.FromSeconds(5),
-  };
-  wait.IgnoreExceptionTypes(typeof(NoSuchElementException));
-
-  var foo = wait.Until(drv => drv.FindElement(By.Id("foo")));
-}
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-exception = Selenium::WebDriver::Error::NoSuchElementError
-
-begin
-  driver.get 'http://somedomain/url_that_delays_loading'
-  wait = Selenium::WebDriver::Wait.new(timeout: 30, interval: 5, message: 'Timed out after 30 sec', ignore: exception)
-  foo = wait.until { driver.find_element(id: 'foo')}
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-const {Builder, until} = require('selenium-webdriver');
-
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    await driver.get('http://somedomain/url_that_delays_loading');
-    // Waiting 30 seconds for an element to be present on the page, checking
-    // for its presence once every 5 seconds.
-    let foo = await driver.wait(until.elementLocated(By.id('foo')), 30000, 'Timed out after 30 seconds', 5000);
-})();
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val wait = FluentWait<WebDriver>(driver)
-        .withTimeout(Duration.ofSeconds(30))
-        .pollingEvery(Duration.ofSeconds(3))
-        .ignoring(NoSuchElementException::class.java)
-
-val foo = wait.until {it.findElement(By.id("foo")) }
-  {{< /tab >}}
-{{< /tabpane >}}
-

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -24,7 +24,7 @@ when the code is ready to execute the next Selenium command.
 Similarly, in a lot of single page applications, elements get dynamically
 added to a page or change visibility based on a click.
 An element must be both present and
-[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+[displayed]({{< ref "elements/information/#is-displayed" >}}) on the page
 in order for Selenium to interact with it.
 
 Take this page for example: https://www.selenium.dev/selenium/web/dynamic.html
@@ -46,7 +46,7 @@ Selenium provides two different mechanisms for synchronization that are better.
 
 ## Implicit waits
 Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
-An implicit wait value can be set either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+An implicit wait value can be set either with the [timeouts]({{< ref "drivers/options#timeouts" >}})
 capability in the browser options, or with a driver method (as shown below).
 
 This is a global setting that applies to every element location call for the entire session.
@@ -99,12 +99,12 @@ Another nice feature is that, by default, the Selenium Wait class automatically 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
 This example shows the condition being waited for as a _lambda_. Java also supports
-[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+[Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
   {{% /tab %}}
   {{% tab header="Python" %}}
 This example shows the condition being waited for as a _lambda_. Python also supports
-[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+[Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
   {{% /tab %}}
   {{< tab header="CSharp" >}}
@@ -114,7 +114,7 @@ This example shows the condition being waited for as a _lambda_. Python also sup
 {{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
   {{< /tab >}}
   {{% tab header="JavaScript" %}}
-JavaScript also supports [Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+JavaScript also supports [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< badge-code >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -24,7 +24,7 @@ when the code is ready to execute the next Selenium command.
 Similarly, in a lot of single page applications, elements get dynamically
 added to a page or change visibility based on a click.
 An element must be both present and
-[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+[displayed]({{< ref "elements/information/#is-displayed" >}}) on the page
 in order for Selenium to interact with it.
 
 Take this page for example: https://www.selenium.dev/selenium/web/dynamic.html
@@ -46,7 +46,7 @@ Selenium provides two different mechanisms for synchronization that are better.
 
 ## Implicit waits
 Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
-An implicit wait value can be set either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+An implicit wait value can be set either with the [timeouts]({{< ref "drivers/options#timeouts" >}})
 capability in the browser options, or with a driver method (as shown below).
 
 This is a global setting that applies to every element location call for the entire session.
@@ -99,12 +99,12 @@ Another nice feature is that, by default, the Selenium Wait class automatically 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
 This example shows the condition being waited for as a _lambda_. Java also supports
-[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+[Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
   {{% /tab %}}
   {{% tab header="Python" %}}
 This example shows the condition being waited for as a _lambda_. Python also supports
-[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+[Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
   {{% /tab %}}
   {{< tab header="CSharp" >}}
@@ -114,7 +114,7 @@ This example shows the condition being waited for as a _lambda_. Python also sup
 {{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
   {{< /tab >}}
   {{% tab header="JavaScript" %}}
-JavaScript also supports [Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+JavaScript also supports [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
 {{< badge-code >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -5,389 +5,155 @@ weight: 6
 aliases: ["/documentation/zh-cn/webdriver/waits/"]
 ---
 
-WebDriver通常可以说有一个阻塞API。因为它是一个指示浏览器做什么的进程外库，而且web平台本质上是异步的，所以WebDriver不跟踪DOM的实时活动状态。这伴随着一些我们将在这里讨论的挑战。
+Perhaps the most common challenge for browser automation is ensuring
+that the web application is in a state to execute a particular
+Selenium command as desired. The processes often end up in
+a _race condition_ where sometimes the browser gets into the right
+state first (things work as intended) and sometimes the Selenium code
+executes first (things do not work as intended). This is one of the
+primary causes of _flaky tests_.
 
-根据经验，大多数由于使用Selenium和WebDriver而产生的间歇性问题都与浏览器和用户指令之间的 _竞争条件_ 有关。例如，用户指示浏览器导航到一个页面，然后在试图查找元素时得到一个 **no such element** 的错误。
+All navigation commands wait for a specific `readyState` value
+based on the [page load strategy]({{< ref "drivers/options#pageloadstrategy" >}}) (the
+default value to wait for is `"complete"`) before the driver returns control to the code.
+The `readyState` only concerns itself with loading assets defined in the HTML, 
+but loaded JavaScript assets often result in changes to the site,
+and elements that need to be interacted with may not yet be on the page
+when the code is ready to execute the next Selenium command.
 
-考虑下面的文档：
+Similarly, in a lot of single page applications, elements get dynamically
+added to a page or change visibility based on a click.
+An element must be both present and
+[displayed](({{< ref "elements/information/#is-displayed" >}})) on the page
+in order for Selenium to interact with it.
 
-```html
-<!doctype html>
-<meta charset=utf-8>
-<title>Race Condition Example</title>
+Take this page for example: https://www.selenium.dev/selenium/web/dynamic.html
+When the "Add a box!" button is clicked, a "div" element that does not exist is created.
+When the "Reveal a new input" button is clicked, a hidden text field element is displayed.
+In both cases the transition takes a couple seconds.
+If the Selenium code is to click one of these buttons and interact with the resulting element,
+it will do so before that element is ready and fail.
 
-<script>
-  var initialised = false;
-  window.addEventListener("load", function() {
-    var newElement = document.createElement("p");
-    newElement.textContent = "Hello from JavaScript!";
-    document.body.appendChild(newElement);
-    initialised = true;
-  });
-</script>
-```
+The first solution many people turn to is adding a sleep statement to
+pause the code execution for a set period of time.
+Because the code can't know exactly how long it needs to wait, this
+can fail when it doesn't sleep long enough. Alternately, if the value is set too high
+and a sleep statement is added in every place it is needed, the duration of
+the session can become prohibitive.
 
-这个  WebDriver的说明可能看起来很简单:
+Selenium provides two different mechanisms for synchronization that are better.
 
-{{< tabpane langEqualsHeader=true >}}
+
+## Implicit waits
+Selenium has a built-in way to automatically wait for elements called an _implicit wait_.
+An implicit wait value can be set either with the [timeouts](({{< ref "drivers/options#timeouts" >}}))
+capability in the browser options, or with a driver method (as shown below).
+
+This is a global setting that applies to every element location call for the entire session.
+The default value is `0`, which means that if the element is not found, it will
+immediately return an error. If an implicit wait is set, the driver will wait for the 
+duration of the provided value before returning the error. Note that as soon as the 
+element is located, the driver will return the element reference and the code will continue executing, 
+so a larger implicit wait value won't necessarily increase the duration of the session.
+
+*Warning:*
+Do not mix implicit and explicit waits.
+Doing so can cause unpredictable wait times.
+For example, setting an implicit wait of 10 seconds
+and an explicit wait of 15 seconds
+could cause a timeout to occur after 20 seconds.
+
+Solving our example with an implicit wait looks like this:
+
+{{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-driver.get("file:///race_condition.html");
-WebElement element = driver.findElement(By.tagName("p"));
-assertEquals(element.getText(), "Hello from JavaScript!");
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L45-L49" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-driver.navigate("file:///race_condition.html")
-el = driver.find_element(By.TAG_NAME, "p")
-assert el.text == "Hello from JavaScript!"
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27-L31" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-driver.Navigate().GoToUrl("file:///race_condition.html");
-IWebElement element = driver.FindElement(By.TagName("p"));
-assertEquals(element.Text, "Hello from JavaScript!");
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39-L44" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-begin
-  # Navigate to URL
-  driver.get 'file:///race_condition.html'
-
-  # Get and store Paragraph Text
-  search_form = driver.find_element(:css,'p').text
-
-  "Hello from JavaScript!".eql? search_form
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28-L32" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-await driver.get('file:///race_condition.html');
-const element = driver.findElement(By.css('p'));
-assert.strictEqual(await element.getText(), 'Hello from JavaScript!');
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-driver.get("file:///race_condition.html")
-val element = driver.findElement(By.tagName("p"))
-assert(element.text == "Hello from JavaScript!")
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-这里的问题是WebDriver中使用的默认页面加载策略[页面加载策略]({{< ref "drivers/options#pageloadstrategy" >}})听从`document.readyState`在返回调用 _navigate_ 之前将状态改为`"complete"` 。因为`p`元素是在文档完成加载之后添加的，所以这个WebDriver脚本可能是间歇性的。它“可能”间歇性是因为无法做出保证说异步触发这些元素或事件不需要显式等待或阻塞这些事件。
+## Explicit waits
 
-幸运的是，[_WebElement_]({{< ref "elements" >}})接口上可用的正常指令集——例如 _WebElement.click_ 和 _WebElement.sendKeys_—是保证同步的，因为直到命令在浏览器中被完成之前函数调用是不会返回的(或者回调是不会在回调形式的语言中触发的)。高级用户交互APIs,[_键盘_]({{< ref "actions_api/keyboard.md" >}})和[_鼠标_]({{< ref "actions_api/mouse.md" >}})是例外的，因为它们被明确地设计为“按我说的做”的异步命令。
+_Explicit waits_ are loops added to the code that poll the application
+for a specific condition to evaluate as true before it exits the loop and
+continues to the next command in the code. If the condition is not met before a designated timeout value,
+the code will give a timeout error. Since there are many ways for the application not to be in the desired state,
+so explicit waits are a great choice to specify the exact condition to wait for
+in each place it is needed.
+Another nice feature is that, by default, the Selenium Wait class automatically waits for the designated element to exist.
 
-等待是在继续下一步之前会执行一个自动化任务来消耗一定的时间。
-
-为了克服浏览器和WebDriver脚本之间的竞争问题，大多数Selenium客户都附带了一个 _wait_ 包。在使用等待时，您使用的是通常所说的[_显式等待_](#明示的な待機)。
-
-## 显式等待
-
-_显示等待_ 是Selenium客户可以使用的命令式过程语言。它们允许您的代码暂停程序执行，或冻结线程，直到满足通过的 _条件_ 。这个条件会以一定的频率一直被调用，直到等待超时。这意味着只要条件返回一个假值，它就会一直尝试和等待
-
-由于显式等待允许您等待条件的发生，所以它们非常适合在浏览器及其DOM和WebDriver脚本之间同步状态。
-
-为了弥补我们之前的错误指令集，我们可以使用等待来让 _findElement_ 调用等待直到脚本中动态添加的元素被添加到DOM中:
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebDriver driver = new ChromeDriver();
-driver.get("https://google.com/ncr");
-driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER);
-// Initialize and wait till element(link) became clickable - timeout in 10 seconds
-WebElement firstResult = new WebDriverWait(driver, Duration.ofSeconds(10))
-        .until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")));
-// Print the first result
-System.out.println(firstResult.getText());
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium.webdriver.support.wait import WebDriverWait
-def document_initialised(driver):
-    return driver.execute_script("return initialised")
-
-driver.navigate("file:///race_condition.html")
-WebDriverWait(driver, timeout=10).until(document_initialised)
-el = driver.find_element(By.TAG_NAME, "p")
-assert el.text == "Hello from JavaScript!"
-  {{< /tab >}}
+{{< tabpane text=true langEqualsHeader=true >}}
+  {{% tab header="Java" %}}
+This example shows the condition being waited for as a _lambda_. Java also supports
+[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+This example shows the condition being waited for as a _lambda_. Python also supports
+[Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
+  {{% /tab %}}
   {{< tab header="CSharp" >}}
-driver = new ChromeDriver();
-driver.Url = "https://www.google.com/ncr";
-driver.FindElement(By.Name("q")).SendKeys("cheese" + Keys.Enter);
-
-WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
-IWebElement firstResult = wait.Until(e => e.FindElement(By.XPath("//a/h3")));
-
-Console.WriteLine(firstResult.Text);
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L53-L59" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-
-def document_initialised(driver)
-  driver.execute_script('return initialised')
-end
-
-begin
-  driver.get 'file:///race_condition.html'
-  wait.until{document_initialised driver}
-  search_form = driver.find_element(:css,'p').text
-  "Hello from JavaScript!".eql? search_form
-ensure
-  driver.quit
-end
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
   {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-const documentInitialised = () =>
-    driver.executeScript('return initialised');
-
-await driver.get('file:///race_condition.html');
-await driver.wait(() => documentInitialised(), 10000);
-const element = driver.findElement(By.css('p'));
-assert.strictEqual(await element.getText(), 'Hello from JavaScript!');
-  {{< /tab >}}
+  {{% tab header="JavaScript" %}}
+JavaScript also supports [Expected Conditions](({{< ref "support_features/expected_conditions" >}}))
+{{< badge-code >}}
+  {{% /tab %}}
   {{< tab header="Kotlin" >}}
-driver.get("https://google.com/ncr")
-driver.findElement(By.name("q")).sendKeys("cheese" + Keys.ENTER)
-// Initialize and wait till element(link) became clickable - timeout in 10 seconds
-val firstResult = WebDriverWait(driver, Duration.ofSeconds(10))
-      .until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")))
-// Print the first result
-println(firstResult.text)
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-我们将 _条件_ 作为函数引用传递， _等待_ 将会重复运行直到其返回值为true。“truthful”返回值是在当前语言中计算为boolean true的任何值，例如字符串、数字、boolean、对象(包括 _WebElement_ )或填充(非空)的序列或列表。这意味着 _空列表_ 的计算结果为false。当条件为true且阻塞等待终止时，条件的返回值将成为等待的返回值。
+### Customization
 
-有了这些知识，并且因为等待实用程序默认情况下会忽略 _no such element_ 的错误，所以我们可以重构我们的指令使其更简洁:
+The Wait class can be instantiated with various parameters that will change how the conditions are evaluated.
 
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebElement foo = new WebDriverWait(driver, Duration.ofSeconds(3))
-          .until(driver -> driver.findElement(By.tagName("p")));
-assertEquals(foo.getText(), "Hello from JavaScript!");         
-  {{< /tab >}}
+This can include:
+* Changing how often the code is evaluated (polling interval)
+* Specifying which exceptions should be handled automatically
+* Changing the total timeout length
+* Customizing the timeout message
+
+For instance, if the _element not interactable_ error is retried by default, then we can
+add an action on a method inside the code getting executed (we just need to 
+make sure that the code returns `true` when it is successful):
+
+{{< tabpane text=true langEqualsHeader=true >}}
+  {{% tab header="Java" %}}
+The easiest way to customize Waits in Java is to use the `FluentWait` class:
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L70-L80" >}}
+  {{% /tab %}}
   {{< tab header="Python" >}}
-from selenium.webdriver.support.wait import WebDriverWait
-
-driver.navigate("file:///race_condition.html")
-el = WebDriverWait(driver, timeout=3).until(lambda d: d.find_element(By.TAG_NAME,"p"))
-assert el.text == "Hello from JavaScript!"
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L50-L55" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using (var driver = new FirefoxDriver())
-{
-        var foo = new WebDriverWait(driver, TimeSpan.FromSeconds(3))
-                        .Until(drv => drv.FindElement(By.Name("q")));
-        Debug.Assert(foo.Text.Equals("Hello from JavaScript!"));
-}
-{{< /tab >}}
-  {{< tab header="Ruby" >}}
-  driver.get 'file:///race_condition.html'
-  wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-  ele = wait.until { driver.find_element(css: 'p')}
-  foo = ele.text
-  assert_match foo, 'Hello from JavaScript'
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-let ele = await driver.wait(until.elementLocated(By.css('p')),10000);
-let foo = await ele.getText();
-assert(foo == "Hello from JavaScript");
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-driver.get("file:///race_condition.html")
-val ele = WebDriverWait(driver, Duration.ofSeconds(10))
-            .until(ExpectedConditions.presenceOfElementLocated(By.tagName("p")))
-assert(ele.text == "Hello from JavaScript!")
-  {{< /tab >}}
-{{< /tabpane >}}
-
-在这个示例中，我们传递了一个匿名函数(但是我们也可以像前面那样显式地定义它，以便重用它)。传递给我们条件的第一个，也是唯一的一个参数始终是对驱动程序对象 _WebDriver_ 的引用。在多线程环境中，您应该小心操作传入条件的驱动程序引用，而不是外部范围中对驱动程序的引用。
-
-因为等待将会吞没在没有找到元素时引发的 _no such element_ 的错误，这个条件会一直重试直到找到元素为止。然后它将获取一个 _WebElement_ 的返回值，并将其传递回我们的脚本。
-
-如果条件失败，例如从未得到条件为真实的返回值，等待将会抛出/引发一个叫 _timeout error_ 的错误/异常。
-
-### 选项
-
-等待条件可以根据您的需要进行定制。有时候是没有必要等待缺省超时的全部范围，因为没有达到成功条件的代价可能很高。
-
-等待允许你传入一个参数来覆盖超时:
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-new WebDriverWait(driver, Duration.ofSeconds(3)).until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-WebDriverWait(driver, timeout=3).until(some_condition)
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
- new WebDriverWait(driver, TimeSpan.FromSeconds(3)).Until(driver => driver.FindElement(By.Name("q")));
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L67-L78" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-wait = Selenium::WebDriver::Wait.new(:timeout => 10)
-
-wait.until { driver.find_element(:id, 'message').displayed? }
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L51-L59" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  await driver.wait(until.elementLocated(By.id('foo')), 30000);
+{{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-WebDriverWait(driver, Duration.ofSeconds(3)).until(ExpectedConditions.elementToBeClickable(By.xpath("//a/h3")))
+{{< badge-code >}}
   {{< /tab >}}
 {{< /tabpane >}}
-
-### 预期的条件
-
-由于必须同步DOM和指令是相当常见的情况，所以大多数客户端还附带一组预定义的 _预期条件_ 。顾名思义，它们是为频繁等待操作预定义的条件。
-
-不同的语言绑定提供的条件各不相同，但这只是其中一些:
-
-* alert is present
-* element exists
-* element is visible
-* title contains
-* title is
-* element staleness
-* visible text
-
-您可以参考每个客户端绑定的API文档，以找到期望条件的详尽列表:
-
-* Java's [org.openqa.selenium.support.ui.ExpectedConditions](//seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/support/ui/ExpectedConditions.html) class
-* Python's [selenium.webdriver.support.expected_conditions](//seleniumhq.github.io/selenium/docs/api/py/webdriver_support/selenium.webdriver.support.expected_conditions.html?highlight=expected) class
-* JavaScript's [selenium-webdriver/lib/until](//seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/until.html) module
-
-
-## 隐式等待
-
-还有第二种区别于[显示等待](#明示的な待機) 类型的 _隐式等待_ 。通过隐式等待，WebDriver在试图查找_任何_元素时在一定时间内轮询DOM。当网页上的某些元素不是立即可用并且需要一些时间来加载时是很有用的。
-
-默认情况下隐式等待元素出现是禁用的，它需要在单个会话的基础上手动启用。将[显式等待](#明示的な待機)和隐式等待混合在一起会导致意想不到的结果，就是说即使元素可用或条件为真也要等待睡眠的最长时间。
-
-*警告:*
-不要混合使用隐式和显式等待。这样做会导致不可预测的等待时间。例如，将隐式等待设置为10秒，将显式等待设置为15秒，可能会导致在20秒后发生超时。
-
-隐式等待是告诉WebDriver如果在查找一个或多个不是立即可用的元素时轮询DOM一段时间。默认设置为0，表示禁用。一旦设置好，隐式等待就被设置为会话的生命周期。
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-WebDriver driver = new FirefoxDriver();
-driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
-driver.get("http://somedomain/url_that_delays_loading");
-WebElement myDynamicElement = driver.findElement(By.id("myDynamicElement"));
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-driver = Firefox()
-driver.implicitly_wait(10)
-driver.get("http://somedomain/url_that_delays_loading")
-my_dynamic_element = driver.find_element(By.ID, "myDynamicElement")
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-IWebDriver driver = new ChromeDriver();
-driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
-driver.Url = "http://somedomain/url_that_delays_loading";
-IWebElement dynamicElement = driver.FindElement(By.Name("dynamicElement"));
-  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-driver.manage.timeouts.implicit_wait = 10
-
-begin
-  driver.get 'http://somedomain/url_that_delays_loading'
-  search_form = driver.find_element(:id,'dynamic_element')
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-(async function(){
-
-// Apply timeout for 10 seconds
-await driver.manage().setTimeouts( { implicit: 10000 } );
-
-// Navigate to url
-await driver.get('http://somedomain/url_that_delays_loading');
-
-let webElement = driver.findElement(By.id("myDynamicElement"));
-
-}());
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val driver = FirefoxDriver()
-driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10))
-driver.get("http://somedomain/url_that_delays_loading")
-val myDynamicElement = driver.findElement(By.id("myDynamicElement"))
-  {{< /tab >}}
-{{< /tabpane >}}
-
-## 流畅等待
-
-流畅等待实例定义了等待条件的最大时间量，以及检查条件的频率。
-
-用户可以配置等待来忽略等待时出现的特定类型的异常，例如在页面上搜索元素时出现的`NoSuchElementException`。
-
-{{< tabpane langEqualsHeader=true >}}
-  {{< tab header="Java" >}}
-// Waiting 30 seconds for an element to be present on the page, checking
-// for its presence once every 5 seconds.
-Wait<WebDriver> wait = new FluentWait<WebDriver>(driver)
-  .withTimeout(Duration.ofSeconds(30))
-  .pollingEvery(Duration.ofSeconds(5))
-  .ignoring(NoSuchElementException.class);
-
-WebElement foo = wait.until(driver -> {
-  return driver.findElement(By.id("foo"));
-});
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-driver = Firefox()
-driver.get("http://somedomain/url_that_delays_loading")
-wait = WebDriverWait(driver, timeout=10, poll_frequency=1, ignored_exceptions=[ElementNotVisibleException, ElementNotSelectableException])
-element = wait.until(EC.element_to_be_clickable((By.XPATH, "//div")))
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-using (var driver = new FirefoxDriver())
-{
-  WebDriverWait wait = new WebDriverWait(driver, timeout: TimeSpan.FromSeconds(30))
-  {
-      PollingInterval = TimeSpan.FromSeconds(5),
-  };
-  wait.IgnoreExceptionTypes(typeof(NoSuchElementException));
-
-  var foo = wait.Until(drv => drv.FindElement(By.Id("foo")));
-}  {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :firefox
-exception = Selenium::WebDriver::Error::NoSuchElementError
-
-begin
-  driver.get 'http://somedomain/url_that_delays_loading'
-  wait = Selenium::WebDriver::Wait.new(timeout: 30, interval: 5, message: 'Timed out after 30 sec', ignore: exception)
-  foo = wait.until { driver.find_element(id: 'foo')}
-ensure
-  driver.quit
-end
-  {{< /tab >}}
-  {{< tab header="JavaScript" >}}
-const {Builder, until} = require('selenium-webdriver');
-
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    await driver.get('http://somedomain/url_that_delays_loading');
-    // Waiting 30 seconds for an element to be present on the page, checking
-    // for its presence once every 5 seconds.
-    let foo = await driver.wait(until.elementLocated(By.id('foo')), 30000, 'Timed out after 30 seconds', 5000);
-})();
-  {{< /tab >}}
-  {{< tab header="Kotlin" >}}
-val wait = FluentWait<WebDriver>(driver)
-        .withTimeout(Duration.ofSeconds(30))
-        .pollingEvery(Duration.ofSeconds(3))
-        .ignoring(NoSuchElementException::class.java)
-
-val foo = wait.until {it.findElement(By.id("foo")) }
-  {{< /tab >}}
-{{< /tabpane >}}
-


### PR DESCRIPTION
### Description
* Removed the static code examples and replaced with references code in the examples directory
* Added a section on hard coded sleeps; not technically a Selenium "feature," so maybe we don't want this?
* Removed Java-specific comments
* Removed the "Fluent Wait" section because that term only applies to Java (the example for customizing the explicit wait for Java uses the `FluentWait` class)
* Moved Expected Conditions out of the Wait page and into the Support Features page
* All explicit wait examples use lambdas not conditions classes
* Hopefully the explanations are more clear and focuses on the important bits

### Motivation and Context
* Code examples were not working
* Descriptions were repetitive and overly technical

