### PR TITLE
Add Vaadin TestBench to frameworks list

### DIFF
--- a/website_and_docs/content/ecosystem/_index.html
+++ b/website_and_docs/content/ecosystem/_index.html
@@ -454,6 +454,17 @@ aliases:
           <td>Java</td>
           <td>Mohab Mohie</td>
         </tr>
+        <tr>
+          <th scope="row">
+            <p>
+              <a href="https://github.com/vaadin/testbench">
+                TestBench
+              </a>
+            </p>
+          </th>
+          <td>Java</td>
+          <td>Vaadin</td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
### Description
Add Vaadin TestBench to frameworks list.

### Motivation and Context
Vaadin is a popular framework for creating UIs in pure Java (without writing HTML or JS). And Vaadin TestBench is a good Selenium-based tool for testing Vaadin UIs (as well as non-Vaadin UIs).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
