### PR TITLE
Update Logging Documentation

### DIFF
--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.en.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.en.md
@@ -6,101 +6,158 @@ description: >
   Getting information about Selenium execution.
 ---
 
-Each language adopts a distinctly different approach to logging information about the activity
-of the program.
+Turning on logging is a valuable way to get extra information that might help you determine
+why you might be having a problem.
 
-### 1. Getting a logger
+## Getting a logger
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs are typically created per class. You can work with the default logger to 
+work with all loggers. To filter out specific classes, see [Filtering](#logger-filtering)
+
+Get the root logger:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L20" >}}
+
+Java Logging is not exactly straightforward, and if you are just looking for an easy way 
+to look at the important Selenium logs, 
+take a look at the [Selenium Logger project](https://github.com/titusfortner/selenium-logger#selenium-logger)
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs are typically created per module. You can match all submodules by referencing the top
+level module. So to work with all loggers in selenium module, you can do this:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L8" >}}
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Ruby uses a custom implementation of the default `Logger` class with some interesting additional features.
-    
-    logger = Selenium::WebDriver.logger
+If you want to see as much debugging as possible in all the classes,
+  you can turn on debugging globally in Ruby by setting `$DEBUG = true`.
+
+For more fine-tuned control, Ruby Selenium created its own Logger class to wrap the default `Logger` class.
+This implementation provides some interesting additional features. 
+Obtain the logger directly from the `#logger`class method on the `Selenium::WebDriver` module:
+
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L11" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-    const logging = require('selenium-webdriver/lib/logging')
-    logger = logging.getLogger('webdriver')
+```javascript
+const logging = require('selenium-webdriver/lib/logging')
+logger = logging.getLogger('webdriver')
+```
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-### 2. Logger Level
+## Logger level
 Logger level helps to filter out logs based on their severity.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+  Java has 7 logger levels: `SEVERE`, `WARNING`, `INFO`, `CONFIG`, `FINE`, `FINER`, and `FINEST`.
+The default is `INFO`. 
+
+You have to change both the level of the logger and the level of the handlers on the root logger:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L22-L25" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+  Python has 6 logger levels: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `NOTSET`. 
+  The default is `WARNING`
+ 
+To change the level of the logger:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L10" >}}
+Things get complicated when you use PyTest, though. By default, PyTest hides logging unless the test
+fails. You need to set 3 things to get PyTest to display logs on passing tests.
+
+To always output logs with PyTest you need to run with additional arguments.
+First, `-s` to prevent PyTest from capturing the console.
+Second, `-p no:logging`, which allows you to override the default PyTest logging settings so logs can
+be displayed regardless of errors.
+
+So you need to set these flags in your IDE, or run PyTest on command line like:
+```bash
+pytest -s -p no:logging
+```
+
+Finally, since you turned off logging in the arguments above, you now need to add configuration to
+turn it back on:
+
+```py
+logging.basicConfig(level=logging.WARN)
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Levels are: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. Default is `:warn`.  
-  To change the level of the logger:
+  Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
+  As of Selenium v4.9.1, The default is `:info`.  
   
-    Selenium::WebDriver.logger.level = :info
+To change the level of the logger:
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L13" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-  Levels are: `OFF`, `SEVERE`, `WARNING`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`, `ALL`. Default is `OFF`.  
+  JavaScript has 9 logger levels: `OFF`, `SEVERE`, `WARNING`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`, `ALL`. 
+  The default is `OFF`.
+
   To change the level of the logger:
-  
-    logger.setLevel(logging.Level.INFO)
+
+```javascript
+logger.setLevel(logging.Level.INFO)
+```  
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Actionable Items**
+### Actionable items
 
 Things are logged as warnings if they are something the user needs to take action on. This is often used
 for deprecations. For various reasons, Selenium project does not follow standard Semantic Versioning practices.
-Our policy is to mark things as deprecated for 3 releases and then remove them.
+Our policy is to mark things as deprecated for 3 releases and then remove them, so deprecations
+may be logged as warnings.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs actionable content at logger level `WARN`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+WARNING: this is a warning
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs actionable content at logger level — `WARNING`
+Details about deprecations are logged at this level.
+
+Example:
+```text
+WARNING  selenium:test_logging.py:23 this is a warning
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Ruby logs deprecations as warnings, specifying what is changing, what needs to be
-  used instead. It may include additional messages, and always includes an ID.
+Ruby logs actionable content at logger level — `:warn`.
+Details about deprecations are logged at this level.
 
-  For example:
-  > 2022-12-24 16:07:09 WARN Selenium [DEPRECATION] [:jwp_caps] \`Capabilities#version=\` is deprecated. Use \`Capabilities#browser_version=\` instead.
-
-  Because these items can get annoying, we've provided an easy way to turn them off.  
-  
-  To turn off a specific warning, set the ID to ignore:
-  
-    Selenium::WebDriver.logger.ignore(:jwp_caps)
-  
-  It accepts an `Array` to turn off multiple IDs:
-  
-    Selenium::WebDriver.logger.ignore(%i[jwp_caps pause pauses])
-  
-  To turn off all *deprecation* notices:
-  
-    Selenium::WebDriver.logger.ignore(:deprecations)
+For example:
+```text
+2023-05-08 20:53:13 WARN Selenium [:example_id] this is a warning 
+```
+  Because these items can get annoying, we've provided an easy way to turn them off, see [filtering section](#logger-filtering) below.
   {{% /tab %}}
   {{< tab header="JavaScript" >}}
   {{< alert-content />}}
@@ -110,27 +167,42 @@ Our policy is to mark things as deprecated for 3 releases and then remove them.
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Useful Information**
+### Useful information
 
 This is the default level where Selenium logs things that users should be aware of but do not need to take actions on.
-It presents information such as requests and responses between driver and server, payload, etc.
-
-Different languages have different level to log information.
+This might reference a new method or direct users to more information about something
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+  Java logs useful information at logger level `INFO`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+INFO: this is useful information
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs useful information at logger level — `INFO`
+
+Example:
+```text
+INFO     selenium:test_logging.py:22 this is useful information
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Because the Ruby `Logger` class only has one "debug" level, Selenium is currently using the `:info` level as a general debug mode, and `:debug` as a lower level debug mode.
-  To bring things in line with other languages, we are considering <a href="https://github.com/SeleniumHQ/selenium/issues/11797">changing this behavior</a>.
-  For now, both info and warnings are handled at the default `:warn` level.
+Ruby logs useful information at logger level — `:info`.
+
+Example:
+```text
+2023-05-08 20:53:13 INFO Selenium [:example_id] this is useful information 
+```
+
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
   Logs useful information at level: `INFO`
@@ -140,22 +212,40 @@ Different languages have different level to log information.
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Debugging Details**
+### Debugging Details
 
 The debug log level is used for information that may be needed for diagnosing issues and troubleshooting problems.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs most debug content at logger level `FINE`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+FINE: this is detailed debug information
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs debugging details at logger level — `DEBUG`
+
+Example:
+```text
+DEBUG    selenium:test_logging.py:24 this is detailed debug information
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Logs debugging details at level: `:info` and `:debug`
+Ruby only provides one level for debugging, so all details are at logger level — `:debug`.
+
+Example:
+```text
+2023-05-08 20:53:13 DEBUG Selenium [:example_id] this is detailed debug information 
+```
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
   Logs debugging details at level: `FINER` and `FINEST`
@@ -165,52 +255,77 @@ The debug log level is used for information that may be needed for diagnosing is
   {{< /tab >}}
 {{< /tabpane >}}
 
-### 3. Log Output:
-Logs can be displayed on `stdout` or stored in a file.
+## Logger output
+
+Logs can be displayed in the console or stored in a file. Different languages have different defaults.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+By default all logs are sent to `System.err`. To direct output to a file, you need to add a handler:
+
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L27-L28" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+  By default all logs are sent to `sys.stderr`. To direct output somewhere else, you need to add a
+handler with either a `StreamHandler` or a `FileHandler`:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L12-L14" >}}
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
   By default, logs are sent to the console in `stdout`.  
   To store the logs in a file:
-  
-    Selenium::WebDriver.logger.output = '/path/to/selenium.log'
-  
-  Sample Output:
-  
-    2023-02-08 12:31:23 INFO Selenium -> POST session/8b83ff54712d0a247937d045f8c8e171/url
-    2023-02-08 12:31:23 INFO Selenium    >>> http://127.0.0.1:9515/session/8b83ff54712d0a247937d045f8c8e171/url | {"url":"https://www.selenium.dev/selenium/web/web-form.html"}
-    2023-02-08 12:31:23 INFO Selenium <- {"value":null}
+
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L15" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-  Send logs to console output:
+JavaScript does not currently support sending output to a file.  
 
-    logging.installConsoleHandler()
-  
-  Sample Output:
-  
-    [2023-03-21T22:28:20Z] [FINER] [webdriver.http.Executor] >>> POST /session/0208994573cca3250a1066424c1b915c/url
-    [2023-03-21T22:28:22Z] [FINER] [webdriver.http.Executor] >>>
-    POST /session/0208994573cca3250a1066424c1b915c/url HTTP/1.1
-    accept: application/json; charset=utf-8
-
-    {"url":"https://www.selenium.dev/selenium/web/web-form.html"}
-    <<<
-    HTTP/1.1 200
-    content-length: 14
-    content-type: application/json; charset=utf-8
-    cache-control: no-cache
-
-    {"value":null}
+To send logs to console output:
+```javascript
+logging.installConsoleHandler()
+```
   {{% /tab %}}
+  {{< tab header="Kotlin" >}}
+  {{< alert-content >}}{{< /alert-content >}}
+  {{< /tab >}}
+{{< /tabpane >}}
+
+## Logger filtering
+
+{{< tabpane langEqualsHeader=true text=true >}}
+{{% tab header="Java" %}}
+Java logging is managed on a per class level, so 
+instead of using the root logger (`Logger.getLogger("")`), set the level you want to use on a per-class
+basis:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L30-L31" >}}
+  {{% /tab %}}
+  {{< tab header="Python" >}}
+Because logging is managed by module, instead of working with just "selenium", you can specify
+different levels for different modules:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L16-L17" >}}
+  {{< /tab >}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
+  {{% tab header="Ruby" %}}
+Ruby's logger allows you to opt in ("allow") or opt out ("ignore") of log messages based on their IDs.
+Everything that Selenium logs includes an ID. You can also turn on or off all deprecation notices by
+using `:deprecations`.
+
+These methods accept one or more symbols or an array of symbols:
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#17" >}}
+or
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L18" >}}
+  {{% /tab %}}
+  {{< tab header="JavaScript" >}}
+  {{< alert-content >}}{{< /alert-content >}}
+  {{< /tab >}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.ja.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.ja.md
@@ -6,101 +6,158 @@ description: >
   Getting information about Selenium execution.
 ---
 
-Each language adopts a distinctly different approach to logging information about the activity
-of the program.
+Turning on logging is a valuable way to get extra information that might help you determine
+why you might be having a problem.
 
-### 1. Getting a logger
+## Getting a logger
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs are typically created per class. You can work with the default logger to 
+work with all loggers. To filter out specific classes, see [Filtering](#logger-filtering)
+
+Get the root logger:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L20" >}}
+
+Java Logging is not exactly straightforward, and if you are just looking for an easy way 
+to look at the important Selenium logs, 
+take a look at the [Selenium Logger project](https://github.com/titusfortner/selenium-logger#selenium-logger)
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs are typically created per module. You can match all submodules by referencing the top
+level module. So to work with all loggers in selenium module, you can do this:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L8" >}}
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Ruby uses a custom implementation of the default `Logger` class with some interesting additional features.
-    
-    logger = Selenium::WebDriver.logger
+If you want to see as much debugging as possible in all the classes,
+  you can turn on debugging globally in Ruby by setting `$DEBUG = true`.
+
+For more fine-tuned control, Ruby Selenium created its own Logger class to wrap the default `Logger` class.
+This implementation provides some interesting additional features. 
+Obtain the logger directly from the `#logger`class method on the `Selenium::WebDriver` module:
+
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L11" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-    const logging = require('selenium-webdriver/lib/logging')
-    logger = logging.getLogger('webdriver')
+```javascript
+const logging = require('selenium-webdriver/lib/logging')
+logger = logging.getLogger('webdriver')
+```
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-### 2. Logger Level
+## Logger level
 Logger level helps to filter out logs based on their severity.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+  Java has 7 logger levels: `SEVERE`, `WARNING`, `INFO`, `CONFIG`, `FINE`, `FINER`, and `FINEST`.
+The default is `INFO`. 
+
+You have to change both the level of the logger and the level of the handlers on the root logger:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L22-L25" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+  Python has 6 logger levels: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `NOTSET`. 
+  The default is `WARNING`
+ 
+To change the level of the logger:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L10" >}}
+Things get complicated when you use PyTest, though. By default, PyTest hides logging unless the test
+fails. You need to set 3 things to get PyTest to display logs on passing tests.
+
+To always output logs with PyTest you need to run with additional arguments.
+First, `-s` to prevent PyTest from capturing the console.
+Second, `-p no:logging`, which allows you to override the default PyTest logging settings so logs can
+be displayed regardless of errors.
+
+So you need to set these flags in your IDE, or run PyTest on command line like:
+```bash
+pytest -s -p no:logging
+```
+
+Finally, since you turned off logging in the arguments above, you now need to add configuration to
+turn it back on:
+
+```py
+logging.basicConfig(level=logging.WARN)
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Levels are: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. Default is `:warn`.  
-  To change the level of the logger:
+  Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
+  As of Selenium v4.9.1, The default is `:info`.  
   
-    Selenium::WebDriver.logger.level = :info
+To change the level of the logger:
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L13" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-  Levels are: `OFF`, `SEVERE`, `WARNING`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`, `ALL`. Default is `OFF`.  
+  JavaScript has 9 logger levels: `OFF`, `SEVERE`, `WARNING`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`, `ALL`. 
+  The default is `OFF`.
+
   To change the level of the logger:
-  
-    logger.setLevel(logging.Level.INFO)
+
+```javascript
+logger.setLevel(logging.Level.INFO)
+```  
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Actionable Items**
+### Actionable items
 
 Things are logged as warnings if they are something the user needs to take action on. This is often used
 for deprecations. For various reasons, Selenium project does not follow standard Semantic Versioning practices.
-Our policy is to mark things as deprecated for 3 releases and then remove them.
+Our policy is to mark things as deprecated for 3 releases and then remove them, so deprecations
+may be logged as warnings.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs actionable content at logger level `WARN`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+WARNING: this is a warning
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs actionable content at logger level — `WARNING`
+Details about deprecations are logged at this level.
+
+Example:
+```text
+WARNING  selenium:test_logging.py:23 this is a warning
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Ruby logs deprecations as warnings, specifying what is changing, what needs to be
-  used instead. It may include additional messages, and always includes an ID.
+Ruby logs actionable content at logger level — `:warn`.
+Details about deprecations are logged at this level.
 
-  For example:
-  > 2022-12-24 16:07:09 WARN Selenium [DEPRECATION] [:jwp_caps] \`Capabilities#version=\` is deprecated. Use \`Capabilities#browser_version=\` instead.
-
-  Because these items can get annoying, we've provided an easy way to turn them off.  
-  
-  To turn off a specific warning, set the ID to ignore:
-  
-    Selenium::WebDriver.logger.ignore(:jwp_caps)
-  
-  It accepts an `Array` to turn off multiple IDs:
-  
-    Selenium::WebDriver.logger.ignore(%i[jwp_caps pause pauses])
-  
-  To turn off all *deprecation* notices:
-  
-    Selenium::WebDriver.logger.ignore(:deprecations)
+For example:
+```text
+2023-05-08 20:53:13 WARN Selenium [:example_id] this is a warning 
+```
+  Because these items can get annoying, we've provided an easy way to turn them off, see [filtering section](#logger-filtering) below.
   {{% /tab %}}
   {{< tab header="JavaScript" >}}
   {{< alert-content />}}
@@ -110,27 +167,42 @@ Our policy is to mark things as deprecated for 3 releases and then remove them.
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Useful Information**
+### Useful information
 
 This is the default level where Selenium logs things that users should be aware of but do not need to take actions on.
-It presents information such as requests and responses between driver and server, payload, etc.
-
-Different languages have different level to log information.
+This might reference a new method or direct users to more information about something
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+  Java logs useful information at logger level `INFO`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+INFO: this is useful information
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs useful information at logger level — `INFO`
+
+Example:
+```text
+INFO     selenium:test_logging.py:22 this is useful information
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Because the Ruby `Logger` class only has one "debug" level, Selenium is currently using the `:info` level as a general debug mode, and `:debug` as a lower level debug mode.
-  To bring things in line with other languages, we are considering <a href="https://github.com/SeleniumHQ/selenium/issues/11797">changing this behavior</a>.
-  For now, both info and warnings are handled at the default `:warn` level.
+Ruby logs useful information at logger level — `:info`.
+
+Example:
+```text
+2023-05-08 20:53:13 INFO Selenium [:example_id] this is useful information 
+```
+
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
   Logs useful information at level: `INFO`
@@ -140,22 +212,40 @@ Different languages have different level to log information.
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Debugging Details**
+### Debugging Details
 
 The debug log level is used for information that may be needed for diagnosing issues and troubleshooting problems.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs most debug content at logger level `FINE`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+FINE: this is detailed debug information
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs debugging details at logger level — `DEBUG`
+
+Example:
+```text
+DEBUG    selenium:test_logging.py:24 this is detailed debug information
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Logs debugging details at level: `:info` and `:debug`
+Ruby only provides one level for debugging, so all details are at logger level — `:debug`.
+
+Example:
+```text
+2023-05-08 20:53:13 DEBUG Selenium [:example_id] this is detailed debug information 
+```
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
   Logs debugging details at level: `FINER` and `FINEST`
@@ -165,52 +255,77 @@ The debug log level is used for information that may be needed for diagnosing is
   {{< /tab >}}
 {{< /tabpane >}}
 
-### 3. Log Output:
-Logs can be displayed on `stdout` or stored in a file.
+## Logger output
+
+Logs can be displayed in the console or stored in a file. Different languages have different defaults.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+By default all logs are sent to `System.err`. To direct output to a file, you need to add a handler:
+
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L27-L28" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+  By default all logs are sent to `sys.stderr`. To direct output somewhere else, you need to add a
+handler with either a `StreamHandler` or a `FileHandler`:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L12-L14" >}}
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
   By default, logs are sent to the console in `stdout`.  
   To store the logs in a file:
-  
-    Selenium::WebDriver.logger.output = '/path/to/selenium.log'
-  
-  Sample Output:
-  
-    2023-02-08 12:31:23 INFO Selenium -> POST session/8b83ff54712d0a247937d045f8c8e171/url
-    2023-02-08 12:31:23 INFO Selenium    >>> http://127.0.0.1:9515/session/8b83ff54712d0a247937d045f8c8e171/url | {"url":"https://www.selenium.dev/selenium/web/web-form.html"}
-    2023-02-08 12:31:23 INFO Selenium <- {"value":null}
+
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L15" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-  Send logs to console output:
+JavaScript does not currently support sending output to a file.  
 
-    logging.installConsoleHandler()
-  
-  Sample Output:
-  
-    [2023-03-21T22:28:20Z] [FINER] [webdriver.http.Executor] >>> POST /session/0208994573cca3250a1066424c1b915c/url
-    [2023-03-21T22:28:22Z] [FINER] [webdriver.http.Executor] >>>
-    POST /session/0208994573cca3250a1066424c1b915c/url HTTP/1.1
-    accept: application/json; charset=utf-8
-
-    {"url":"https://www.selenium.dev/selenium/web/web-form.html"}
-    <<<
-    HTTP/1.1 200
-    content-length: 14
-    content-type: application/json; charset=utf-8
-    cache-control: no-cache
-
-    {"value":null}
+To send logs to console output:
+```javascript
+logging.installConsoleHandler()
+```
   {{% /tab %}}
+  {{< tab header="Kotlin" >}}
+  {{< alert-content >}}{{< /alert-content >}}
+  {{< /tab >}}
+{{< /tabpane >}}
+
+## Logger filtering
+
+{{< tabpane langEqualsHeader=true text=true >}}
+{{% tab header="Java" %}}
+Java logging is managed on a per class level, so 
+instead of using the root logger (`Logger.getLogger("")`), set the level you want to use on a per-class
+basis:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L30-L31" >}}
+  {{% /tab %}}
+  {{< tab header="Python" >}}
+Because logging is managed by module, instead of working with just "selenium", you can specify
+different levels for different modules:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L16-L17" >}}
+  {{< /tab >}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
+  {{% tab header="Ruby" %}}
+Ruby's logger allows you to opt in ("allow") or opt out ("ignore") of log messages based on their IDs.
+Everything that Selenium logs includes an ID. You can also turn on or off all deprecation notices by
+using `:deprecations`.
+
+These methods accept one or more symbols or an array of symbols:
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#17" >}}
+or
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L18" >}}
+  {{% /tab %}}
+  {{< tab header="JavaScript" >}}
+  {{< alert-content >}}{{< /alert-content >}}
+  {{< /tab >}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.pt-br.md
@@ -6,101 +6,158 @@ description: >
   Getting information about Selenium execution.
 ---
 
-Each language adopts a distinctly different approach to logging information about the activity
-of the program.
+Turning on logging is a valuable way to get extra information that might help you determine
+why you might be having a problem.
 
-### 1. Getting a logger
+## Getting a logger
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs are typically created per class. You can work with the default logger to 
+work with all loggers. To filter out specific classes, see [Filtering](#logger-filtering)
+
+Get the root logger:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L20" >}}
+
+Java Logging is not exactly straightforward, and if you are just looking for an easy way 
+to look at the important Selenium logs, 
+take a look at the [Selenium Logger project](https://github.com/titusfortner/selenium-logger#selenium-logger)
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs are typically created per module. You can match all submodules by referencing the top
+level module. So to work with all loggers in selenium module, you can do this:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L8" >}}
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Ruby uses a custom implementation of the default `Logger` class with some interesting additional features.
-    
-    logger = Selenium::WebDriver.logger
+If you want to see as much debugging as possible in all the classes,
+  you can turn on debugging globally in Ruby by setting `$DEBUG = true`.
+
+For more fine-tuned control, Ruby Selenium created its own Logger class to wrap the default `Logger` class.
+This implementation provides some interesting additional features. 
+Obtain the logger directly from the `#logger`class method on the `Selenium::WebDriver` module:
+
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L11" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-    const logging = require('selenium-webdriver/lib/logging')
-    logger = logging.getLogger('webdriver')
+```javascript
+const logging = require('selenium-webdriver/lib/logging')
+logger = logging.getLogger('webdriver')
+```
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-### 2. Logger Level
+## Logger level
 Logger level helps to filter out logs based on their severity.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+  Java has 7 logger levels: `SEVERE`, `WARNING`, `INFO`, `CONFIG`, `FINE`, `FINER`, and `FINEST`.
+The default is `INFO`. 
+
+You have to change both the level of the logger and the level of the handlers on the root logger:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L22-L25" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+  Python has 6 logger levels: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `NOTSET`. 
+  The default is `WARNING`
+ 
+To change the level of the logger:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L10" >}}
+Things get complicated when you use PyTest, though. By default, PyTest hides logging unless the test
+fails. You need to set 3 things to get PyTest to display logs on passing tests.
+
+To always output logs with PyTest you need to run with additional arguments.
+First, `-s` to prevent PyTest from capturing the console.
+Second, `-p no:logging`, which allows you to override the default PyTest logging settings so logs can
+be displayed regardless of errors.
+
+So you need to set these flags in your IDE, or run PyTest on command line like:
+```bash
+pytest -s -p no:logging
+```
+
+Finally, since you turned off logging in the arguments above, you now need to add configuration to
+turn it back on:
+
+```py
+logging.basicConfig(level=logging.WARN)
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Levels are: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. Default is `:warn`.  
-  To change the level of the logger:
+  Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
+  As of Selenium v4.9.1, The default is `:info`.  
   
-    Selenium::WebDriver.logger.level = :info
+To change the level of the logger:
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L13" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-  Levels are: `OFF`, `SEVERE`, `WARNING`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`, `ALL`. Default is `OFF`.  
+  JavaScript has 9 logger levels: `OFF`, `SEVERE`, `WARNING`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`, `ALL`. 
+  The default is `OFF`.
+
   To change the level of the logger:
-  
-    logger.setLevel(logging.Level.INFO)
+
+```javascript
+logger.setLevel(logging.Level.INFO)
+```  
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Actionable Items**
+### Actionable items
 
 Things are logged as warnings if they are something the user needs to take action on. This is often used
 for deprecations. For various reasons, Selenium project does not follow standard Semantic Versioning practices.
-Our policy is to mark things as deprecated for 3 releases and then remove them.
+Our policy is to mark things as deprecated for 3 releases and then remove them, so deprecations
+may be logged as warnings.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs actionable content at logger level `WARN`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+WARNING: this is a warning
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs actionable content at logger level — `WARNING`
+Details about deprecations are logged at this level.
+
+Example:
+```text
+WARNING  selenium:test_logging.py:23 this is a warning
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Ruby logs deprecations as warnings, specifying what is changing, what needs to be
-  used instead. It may include additional messages, and always includes an ID.
+Ruby logs actionable content at logger level — `:warn`.
+Details about deprecations are logged at this level.
 
-  For example:
-  > 2022-12-24 16:07:09 WARN Selenium [DEPRECATION] [:jwp_caps] \`Capabilities#version=\` is deprecated. Use \`Capabilities#browser_version=\` instead.
-
-  Because these items can get annoying, we've provided an easy way to turn them off.  
-  
-  To turn off a specific warning, set the ID to ignore:
-  
-    Selenium::WebDriver.logger.ignore(:jwp_caps)
-  
-  It accepts an `Array` to turn off multiple IDs:
-  
-    Selenium::WebDriver.logger.ignore(%i[jwp_caps pause pauses])
-  
-  To turn off all *deprecation* notices:
-  
-    Selenium::WebDriver.logger.ignore(:deprecations)
+For example:
+```text
+2023-05-08 20:53:13 WARN Selenium [:example_id] this is a warning 
+```
+  Because these items can get annoying, we've provided an easy way to turn them off, see [filtering section](#logger-filtering) below.
   {{% /tab %}}
   {{< tab header="JavaScript" >}}
   {{< alert-content />}}
@@ -110,27 +167,42 @@ Our policy is to mark things as deprecated for 3 releases and then remove them.
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Useful Information**
+### Useful information
 
 This is the default level where Selenium logs things that users should be aware of but do not need to take actions on.
-It presents information such as requests and responses between driver and server, payload, etc.
-
-Different languages have different level to log information.
+This might reference a new method or direct users to more information about something
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+  Java logs useful information at logger level `INFO`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+INFO: this is useful information
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs useful information at logger level — `INFO`
+
+Example:
+```text
+INFO     selenium:test_logging.py:22 this is useful information
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Because the Ruby `Logger` class only has one "debug" level, Selenium is currently using the `:info` level as a general debug mode, and `:debug` as a lower level debug mode.
-  To bring things in line with other languages, we are considering <a href="https://github.com/SeleniumHQ/selenium/issues/11797">changing this behavior</a>.
-  For now, both info and warnings are handled at the default `:warn` level.
+Ruby logs useful information at logger level — `:info`.
+
+Example:
+```text
+2023-05-08 20:53:13 INFO Selenium [:example_id] this is useful information 
+```
+
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
   Logs useful information at level: `INFO`
@@ -140,22 +212,40 @@ Different languages have different level to log information.
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Debugging Details**
+### Debugging Details
 
 The debug log level is used for information that may be needed for diagnosing issues and troubleshooting problems.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs most debug content at logger level `FINE`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+FINE: this is detailed debug information
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs debugging details at logger level — `DEBUG`
+
+Example:
+```text
+DEBUG    selenium:test_logging.py:24 this is detailed debug information
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Logs debugging details at level: `:info` and `:debug`
+Ruby only provides one level for debugging, so all details are at logger level — `:debug`.
+
+Example:
+```text
+2023-05-08 20:53:13 DEBUG Selenium [:example_id] this is detailed debug information 
+```
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
   Logs debugging details at level: `FINER` and `FINEST`
@@ -165,52 +255,77 @@ The debug log level is used for information that may be needed for diagnosing is
   {{< /tab >}}
 {{< /tabpane >}}
 
-### 3. Log Output:
-Logs can be displayed on `stdout` or stored in a file.
+## Logger output
+
+Logs can be displayed in the console or stored in a file. Different languages have different defaults.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+By default all logs are sent to `System.err`. To direct output to a file, you need to add a handler:
+
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L27-L28" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+  By default all logs are sent to `sys.stderr`. To direct output somewhere else, you need to add a
+handler with either a `StreamHandler` or a `FileHandler`:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L12-L14" >}}
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
   By default, logs are sent to the console in `stdout`.  
   To store the logs in a file:
-  
-    Selenium::WebDriver.logger.output = '/path/to/selenium.log'
-  
-  Sample Output:
-  
-    2023-02-08 12:31:23 INFO Selenium -> POST session/8b83ff54712d0a247937d045f8c8e171/url
-    2023-02-08 12:31:23 INFO Selenium    >>> http://127.0.0.1:9515/session/8b83ff54712d0a247937d045f8c8e171/url | {"url":"https://www.selenium.dev/selenium/web/web-form.html"}
-    2023-02-08 12:31:23 INFO Selenium <- {"value":null}
+
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L15" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-  Send logs to console output:
+JavaScript does not currently support sending output to a file.  
 
-    logging.installConsoleHandler()
-  
-  Sample Output:
-  
-    [2023-03-21T22:28:20Z] [FINER] [webdriver.http.Executor] >>> POST /session/0208994573cca3250a1066424c1b915c/url
-    [2023-03-21T22:28:22Z] [FINER] [webdriver.http.Executor] >>>
-    POST /session/0208994573cca3250a1066424c1b915c/url HTTP/1.1
-    accept: application/json; charset=utf-8
-
-    {"url":"https://www.selenium.dev/selenium/web/web-form.html"}
-    <<<
-    HTTP/1.1 200
-    content-length: 14
-    content-type: application/json; charset=utf-8
-    cache-control: no-cache
-
-    {"value":null}
+To send logs to console output:
+```javascript
+logging.installConsoleHandler()
+```
   {{% /tab %}}
+  {{< tab header="Kotlin" >}}
+  {{< alert-content >}}{{< /alert-content >}}
+  {{< /tab >}}
+{{< /tabpane >}}
+
+## Logger filtering
+
+{{< tabpane langEqualsHeader=true text=true >}}
+{{% tab header="Java" %}}
+Java logging is managed on a per class level, so 
+instead of using the root logger (`Logger.getLogger("")`), set the level you want to use on a per-class
+basis:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L30-L31" >}}
+  {{% /tab %}}
+  {{< tab header="Python" >}}
+Because logging is managed by module, instead of working with just "selenium", you can specify
+different levels for different modules:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L16-L17" >}}
+  {{< /tab >}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
+  {{% tab header="Ruby" %}}
+Ruby's logger allows you to opt in ("allow") or opt out ("ignore") of log messages based on their IDs.
+Everything that Selenium logs includes an ID. You can also turn on or off all deprecation notices by
+using `:deprecations`.
+
+These methods accept one or more symbols or an array of symbols:
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#17" >}}
+or
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L18" >}}
+  {{% /tab %}}
+  {{< tab header="JavaScript" >}}
+  {{< alert-content >}}{{< /alert-content >}}
+  {{< /tab >}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.zh-cn.md
@@ -6,101 +6,158 @@ description: >
   Getting information about Selenium execution.
 ---
 
-Each language adopts a distinctly different approach to logging information about the activity
-of the program.
+Turning on logging is a valuable way to get extra information that might help you determine
+why you might be having a problem.
 
-### 1. Getting a logger
+## Getting a logger
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs are typically created per class. You can work with the default logger to 
+work with all loggers. To filter out specific classes, see [Filtering](#logger-filtering)
+
+Get the root logger:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L20" >}}
+
+Java Logging is not exactly straightforward, and if you are just looking for an easy way 
+to look at the important Selenium logs, 
+take a look at the [Selenium Logger project](https://github.com/titusfortner/selenium-logger#selenium-logger)
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs are typically created per module. You can match all submodules by referencing the top
+level module. So to work with all loggers in selenium module, you can do this:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L8" >}}
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Ruby uses a custom implementation of the default `Logger` class with some interesting additional features.
-    
-    logger = Selenium::WebDriver.logger
+If you want to see as much debugging as possible in all the classes,
+  you can turn on debugging globally in Ruby by setting `$DEBUG = true`.
+
+For more fine-tuned control, Ruby Selenium created its own Logger class to wrap the default `Logger` class.
+This implementation provides some interesting additional features. 
+Obtain the logger directly from the `#logger`class method on the `Selenium::WebDriver` module:
+
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L11" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-    const logging = require('selenium-webdriver/lib/logging')
-    logger = logging.getLogger('webdriver')
+```javascript
+const logging = require('selenium-webdriver/lib/logging')
+logger = logging.getLogger('webdriver')
+```
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-### 2. Logger Level
+## Logger level
 Logger level helps to filter out logs based on their severity.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+  Java has 7 logger levels: `SEVERE`, `WARNING`, `INFO`, `CONFIG`, `FINE`, `FINER`, and `FINEST`.
+The default is `INFO`. 
+
+You have to change both the level of the logger and the level of the handlers on the root logger:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L22-L25" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+  Python has 6 logger levels: `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG`, and `NOTSET`. 
+  The default is `WARNING`
+ 
+To change the level of the logger:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L10" >}}
+Things get complicated when you use PyTest, though. By default, PyTest hides logging unless the test
+fails. You need to set 3 things to get PyTest to display logs on passing tests.
+
+To always output logs with PyTest you need to run with additional arguments.
+First, `-s` to prevent PyTest from capturing the console.
+Second, `-p no:logging`, which allows you to override the default PyTest logging settings so logs can
+be displayed regardless of errors.
+
+So you need to set these flags in your IDE, or run PyTest on command line like:
+```bash
+pytest -s -p no:logging
+```
+
+Finally, since you turned off logging in the arguments above, you now need to add configuration to
+turn it back on:
+
+```py
+logging.basicConfig(level=logging.WARN)
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Levels are: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. Default is `:warn`.  
-  To change the level of the logger:
+  Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
+  As of Selenium v4.9.1, The default is `:info`.  
   
-    Selenium::WebDriver.logger.level = :info
+To change the level of the logger:
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L13" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-  Levels are: `OFF`, `SEVERE`, `WARNING`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`, `ALL`. Default is `OFF`.  
+  JavaScript has 9 logger levels: `OFF`, `SEVERE`, `WARNING`, `INFO`, `DEBUG`, `FINE`, `FINER`, `FINEST`, `ALL`. 
+  The default is `OFF`.
+
   To change the level of the logger:
-  
-    logger.setLevel(logging.Level.INFO)
+
+```javascript
+logger.setLevel(logging.Level.INFO)
+```  
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Actionable Items**
+### Actionable items
 
 Things are logged as warnings if they are something the user needs to take action on. This is often used
 for deprecations. For various reasons, Selenium project does not follow standard Semantic Versioning practices.
-Our policy is to mark things as deprecated for 3 releases and then remove them.
+Our policy is to mark things as deprecated for 3 releases and then remove them, so deprecations
+may be logged as warnings.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs actionable content at logger level `WARN`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+WARNING: this is a warning
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs actionable content at logger level — `WARNING`
+Details about deprecations are logged at this level.
+
+Example:
+```text
+WARNING  selenium:test_logging.py:23 this is a warning
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Ruby logs deprecations as warnings, specifying what is changing, what needs to be
-  used instead. It may include additional messages, and always includes an ID.
+Ruby logs actionable content at logger level — `:warn`.
+Details about deprecations are logged at this level.
 
-  For example:
-  > 2022-12-24 16:07:09 WARN Selenium [DEPRECATION] [:jwp_caps] \`Capabilities#version=\` is deprecated. Use \`Capabilities#browser_version=\` instead.
-
-  Because these items can get annoying, we've provided an easy way to turn them off.  
-  
-  To turn off a specific warning, set the ID to ignore:
-  
-    Selenium::WebDriver.logger.ignore(:jwp_caps)
-  
-  It accepts an `Array` to turn off multiple IDs:
-  
-    Selenium::WebDriver.logger.ignore(%i[jwp_caps pause pauses])
-  
-  To turn off all *deprecation* notices:
-  
-    Selenium::WebDriver.logger.ignore(:deprecations)
+For example:
+```text
+2023-05-08 20:53:13 WARN Selenium [:example_id] this is a warning 
+```
+  Because these items can get annoying, we've provided an easy way to turn them off, see [filtering section](#logger-filtering) below.
   {{% /tab %}}
   {{< tab header="JavaScript" >}}
   {{< alert-content />}}
@@ -110,27 +167,42 @@ Our policy is to mark things as deprecated for 3 releases and then remove them.
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Useful Information**
+### Useful information
 
 This is the default level where Selenium logs things that users should be aware of but do not need to take actions on.
-It presents information such as requests and responses between driver and server, payload, etc.
-
-Different languages have different level to log information.
+This might reference a new method or direct users to more information about something
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+  Java logs useful information at logger level `INFO`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+INFO: this is useful information
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs useful information at logger level — `INFO`
+
+Example:
+```text
+INFO     selenium:test_logging.py:22 this is useful information
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Because the Ruby `Logger` class only has one "debug" level, Selenium is currently using the `:info` level as a general debug mode, and `:debug` as a lower level debug mode.
-  To bring things in line with other languages, we are considering <a href="https://github.com/SeleniumHQ/selenium/issues/11797">changing this behavior</a>.
-  For now, both info and warnings are handled at the default `:warn` level.
+Ruby logs useful information at logger level — `:info`.
+
+Example:
+```text
+2023-05-08 20:53:13 INFO Selenium [:example_id] this is useful information 
+```
+
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
   Logs useful information at level: `INFO`
@@ -140,22 +212,40 @@ Different languages have different level to log information.
   {{< /tab >}}
 {{< /tabpane >}}
 
-**Debugging Details**
+### Debugging Details
 
 The debug log level is used for information that may be needed for diagnosing issues and troubleshooting problems.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+Java logs most debug content at logger level `FINE`
+
+Example:
+```text
+May 08, 2023 9:23:38 PM dev.selenium.troubleshooting.LoggingTest logging
+FINE: this is detailed debug information
+```
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+Python logs debugging details at logger level — `DEBUG`
+
+Example:
+```text
+DEBUG    selenium:test_logging.py:24 this is detailed debug information
+```
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
-  Logs debugging details at level: `:info` and `:debug`
+Ruby only provides one level for debugging, so all details are at logger level — `:debug`.
+
+Example:
+```text
+2023-05-08 20:53:13 DEBUG Selenium [:example_id] this is detailed debug information 
+```
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
   Logs debugging details at level: `FINER` and `FINEST`
@@ -165,52 +255,77 @@ The debug log level is used for information that may be needed for diagnosing is
   {{< /tab >}}
 {{< /tabpane >}}
 
-### 3. Log Output:
-Logs can be displayed on `stdout` or stored in a file.
+## Logger output
+
+Logs can be displayed in the console or stored in a file. Different languages have different defaults.
 
 {{< tabpane langEqualsHeader=true text=true >}}
-  {{< tab header="Java" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="Python" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-  {{< alert-content >}}{{< /alert-content >}}
-  {{< /tab >}}
+  {{% tab header="Java" %}}
+By default all logs are sent to `System.err`. To direct output to a file, you need to add a handler:
+
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L27-L28" >}}
+  {{% /tab %}}
+  {{% tab header="Python" %}}
+  By default all logs are sent to `sys.stderr`. To direct output somewhere else, you need to add a
+handler with either a `StreamHandler` or a `FileHandler`:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L12-L14" >}}
+  {{% /tab %}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
   {{% tab header="Ruby" %}}
   By default, logs are sent to the console in `stdout`.  
   To store the logs in a file:
-  
-    Selenium::WebDriver.logger.output = '/path/to/selenium.log'
-  
-  Sample Output:
-  
-    2023-02-08 12:31:23 INFO Selenium -> POST session/8b83ff54712d0a247937d045f8c8e171/url
-    2023-02-08 12:31:23 INFO Selenium    >>> http://127.0.0.1:9515/session/8b83ff54712d0a247937d045f8c8e171/url | {"url":"https://www.selenium.dev/selenium/web/web-form.html"}
-    2023-02-08 12:31:23 INFO Selenium <- {"value":null}
+
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L15" >}}
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-  Send logs to console output:
+JavaScript does not currently support sending output to a file.  
 
-    logging.installConsoleHandler()
-  
-  Sample Output:
-  
-    [2023-03-21T22:28:20Z] [FINER] [webdriver.http.Executor] >>> POST /session/0208994573cca3250a1066424c1b915c/url
-    [2023-03-21T22:28:22Z] [FINER] [webdriver.http.Executor] >>>
-    POST /session/0208994573cca3250a1066424c1b915c/url HTTP/1.1
-    accept: application/json; charset=utf-8
-
-    {"url":"https://www.selenium.dev/selenium/web/web-form.html"}
-    <<<
-    HTTP/1.1 200
-    content-length: 14
-    content-type: application/json; charset=utf-8
-    cache-control: no-cache
-
-    {"value":null}
+To send logs to console output:
+```javascript
+logging.installConsoleHandler()
+```
   {{% /tab %}}
+  {{< tab header="Kotlin" >}}
+  {{< alert-content >}}{{< /alert-content >}}
+  {{< /tab >}}
+{{< /tabpane >}}
+
+## Logger filtering
+
+{{< tabpane langEqualsHeader=true text=true >}}
+{{% tab header="Java" %}}
+Java logging is managed on a per class level, so 
+instead of using the root logger (`Logger.getLogger("")`), set the level you want to use on a per-class
+basis:
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/troubleshooting/LoggingTest.java#L30-L31" >}}
+  {{% /tab %}}
+  {{< tab header="Python" >}}
+Because logging is managed by module, instead of working with just "selenium", you can specify
+different levels for different modules:
+{{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L16-L17" >}}
+  {{< /tab >}}
+  {{% tab header="CSharp" %}}
+```text
+.NET does not currently have a Logging implementation
+```
+  {{% /tab %}}
+  {{% tab header="Ruby" %}}
+Ruby's logger allows you to opt in ("allow") or opt out ("ignore") of log messages based on their IDs.
+Everything that Selenium logs includes an ID. You can also turn on or off all deprecation notices by
+using `:deprecations`.
+
+These methods accept one or more symbols or an array of symbols:
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#17" >}}
+or
+{{< gh-codeblock path="/examples/ruby/spec/troubleshooting/logging_spec.rb#L18" >}}
+  {{% /tab %}}
+  {{< tab header="JavaScript" >}}
+  {{< alert-content >}}{{< /alert-content >}}
+  {{< /tab >}}
   {{< tab header="Kotlin" >}}
   {{< alert-content >}}{{< /alert-content >}}
   {{< /tab >}}


### PR DESCRIPTION
### Description
Reformatted/reorganized the page a bit to fit markdown structure better
Added details about how to do logging in Ruby, Python & Java referencing example code

### Motivation and Context
I want a place to point to when someone has a failure and I want more information about what might be going on. Should be especially useful in latest versions of Selenium with Selenium Manager logging added.

I... was going to add assertions by parsing the log file, but I ran out of energy. Also, we can't run the PyTest example because the easiest way to get the logs is actually to make the test fail. ☹️ 


@TamsilAmani would also appreciate if you have a chance to look at this.
@mdmintz let me know if there's a better way to show people what to do with the Python stuff. 
