### PR TITLE
Add build and release info to selenium-manager docs

### DIFF
--- a/website_and_docs/content/documentation/selenium_manager.en.md
+++ b/website_and_docs/content/documentation/selenium_manager.en.md
@@ -77,4 +77,10 @@ located by default at `~/.cache/selenium/selenium-manager-config.toml`.
 
 ## Development
 
-Selenium Manager is written in Rust and compiled into binaries using GitHub Actions.
+Selenium Manager is written in Rust. Find the source code for it in the [Selenium GitHub repository](https://github.com/SeleniumHQ/selenium/tree/trunk/rust).
+
+## Build and Release
+
+Selenium Manager is compiled using GitHub Actions workflows. The workflows create binaries for Windows, Linux, and MacOS. These binaries work in both x86 and ARM architectures, so these 3 binaries should be enough for almost all use cases. You can find the build job definitions [here](https://github.com/SeleniumHQ/selenium/actions/workflows/build-selenium-manager.yml).
+
+The build artifacts are manually checked into the selenium repo and stored under the [common folder](https://github.com/SeleniumHQ/selenium/tree/trunk/common/manager). The [bazel build tasks](https://github.com/SeleniumHQ/selenium/blob/trunk/README.md#bazel) then copy these pre-built binaries for testing and packaging the binary within Selenium releases.

--- a/website_and_docs/content/documentation/selenium_manager.en.md
+++ b/website_and_docs/content/documentation/selenium_manager.en.md
@@ -83,4 +83,4 @@ Selenium Manager is written in Rust. Find the source code for it in the [Seleniu
 
 Selenium Manager is compiled using GitHub Actions workflows. The workflows create binaries for Windows, Linux, and MacOS. These binaries work in both x86 and ARM architectures, so these 3 binaries should be enough for almost all use cases. You can find the build job definitions [here](https://github.com/SeleniumHQ/selenium/actions/workflows/build-selenium-manager.yml).
 
-The build artifacts are manually checked into the selenium repo and stored under the [common folder](https://github.com/SeleniumHQ/selenium/tree/trunk/common/manager). The [bazel build tasks](https://github.com/SeleniumHQ/selenium/blob/trunk/README.md#bazel) then copy these pre-built binaries for testing and packaging the binary within Selenium releases.
+The build artifacts are manually checked into the selenium repo and stored under the [common folder](https://github.com/SeleniumHQ/selenium/tree/trunk/common/manager). The [bazel build tasks](https://github.com/SeleniumHQ/selenium/blob/trunk/README.md#bazel) then copy these pre-built binaries for packaging the binary within Selenium releases.

--- a/website_and_docs/content/documentation/selenium_manager.ja.md
+++ b/website_and_docs/content/documentation/selenium_manager.ja.md
@@ -77,4 +77,10 @@ located by default at `~/.cache/selenium/selenium-manager-config.toml`.
 
 ## Development
 
-Selenium Manager is written in Rust and compiled into binaries using GitHub Actions.
+Selenium Manager is written in Rust. Find the source code for it in the [Selenium GitHub repository](https://github.com/SeleniumHQ/selenium/tree/trunk/rust).
+
+## Build and Release
+
+Selenium Manager is compiled using GitHub Actions workflows. The workflows create binaries for Windows, Linux, and MacOS. These binaries work in both x86 and ARM architectures, so these 3 binaries should be enough for almost all use cases. You can find the build job definitions [here](https://github.com/SeleniumHQ/selenium/actions/workflows/build-selenium-manager.yml).
+
+The build artifacts are manually checked into the selenium repo and stored under the [common folder](https://github.com/SeleniumHQ/selenium/tree/trunk/common/manager). The [bazel build tasks](https://github.com/SeleniumHQ/selenium/blob/trunk/README.md#bazel) then copy these pre-built binaries for packaging the binary within Selenium releases.

--- a/website_and_docs/content/documentation/selenium_manager.pt-br.md
+++ b/website_and_docs/content/documentation/selenium_manager.pt-br.md
@@ -77,4 +77,10 @@ located by default at `~/.cache/selenium/selenium-manager-config.toml`.
 
 ## Development
 
-Selenium Manager is written in Rust and compiled into binaries using GitHub Actions.
+Selenium Manager is written in Rust. Find the source code for it in the [Selenium GitHub repository](https://github.com/SeleniumHQ/selenium/tree/trunk/rust).
+
+## Build and Release
+
+Selenium Manager is compiled using GitHub Actions workflows. The workflows create binaries for Windows, Linux, and MacOS. These binaries work in both x86 and ARM architectures, so these 3 binaries should be enough for almost all use cases. You can find the build job definitions [here](https://github.com/SeleniumHQ/selenium/actions/workflows/build-selenium-manager.yml).
+
+The build artifacts are manually checked into the selenium repo and stored under the [common folder](https://github.com/SeleniumHQ/selenium/tree/trunk/common/manager). The [bazel build tasks](https://github.com/SeleniumHQ/selenium/blob/trunk/README.md#bazel) then copy these pre-built binaries for packaging the binary within Selenium releases.

--- a/website_and_docs/content/documentation/selenium_manager.zh-cn.md
+++ b/website_and_docs/content/documentation/selenium_manager.zh-cn.md
@@ -77,4 +77,10 @@ located by default at `~/.cache/selenium/selenium-manager-config.toml`.
 
 ## Development
 
-Selenium Manager is written in Rust and compiled into binaries using GitHub Actions.
+Selenium Manager is written in Rust. Find the source code for it in the [Selenium GitHub repository](https://github.com/SeleniumHQ/selenium/tree/trunk/rust).
+
+## Build and Release
+
+Selenium Manager is compiled using GitHub Actions workflows. The workflows create binaries for Windows, Linux, and MacOS. These binaries work in both x86 and ARM architectures, so these 3 binaries should be enough for almost all use cases. You can find the build job definitions [here](https://github.com/SeleniumHQ/selenium/actions/workflows/build-selenium-manager.yml).
+
+The build artifacts are manually checked into the selenium repo and stored under the [common folder](https://github.com/SeleniumHQ/selenium/tree/trunk/common/manager). The [bazel build tasks](https://github.com/SeleniumHQ/selenium/blob/trunk/README.md#bazel) then copy these pre-built binaries for packaging the binary within Selenium releases.


### PR DESCRIPTION
### Description
Provides more information about where the selenium-manager source code is located, how the binary is built, and how the pre-compiled binary gets included in releases via bazel build steps.

### Motivation and Context
Clearer understanding of the details of the build and release process.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
