### PR TITLE
add badge version tags for 4.8-4.10

### DIFF
--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/browsing_context.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/browsing_context.en.md
@@ -12,6 +12,7 @@ Creates a new browsing context in a new window.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L35" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -31,6 +32,7 @@ Creates a new browsing context in a new tab.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L49" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -50,6 +52,7 @@ Creates a browsing context for the existing tab/window to run commands.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L28-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -70,6 +73,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L41-L43" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -89,6 +93,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L55-L57" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -106,6 +111,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L63-L65" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -123,6 +129,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L74-L77" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -142,6 +149,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L86-L91" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -161,6 +169,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L102-L105" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -178,6 +187,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L117-L120" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -195,6 +205,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L127-L130" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/browsing_context.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/browsing_context.ja.md
@@ -21,6 +21,7 @@ Creates a new browsing context in a new window.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L35" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -40,6 +41,7 @@ Creates a new browsing context in a new tab.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L49" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -59,6 +61,7 @@ Creates a browsing context for the existing tab/window to run commands.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L28-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -79,6 +82,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L41-L43" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -98,6 +102,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L55-L57" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -115,6 +120,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L63-L65" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -132,6 +138,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L74-L77" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -151,6 +158,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L86-L91" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -170,6 +178,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L102-L105" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -187,6 +196,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L117-L120" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -204,6 +214,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L127-L130" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/browsing_context.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/browsing_context.pt-br.md
@@ -21,6 +21,7 @@ Creates a new browsing context in a new window.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L35" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -40,6 +41,7 @@ Creates a new browsing context in a new tab.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L49" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -59,6 +61,7 @@ Creates a browsing context for the existing tab/window to run commands.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L28-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -79,6 +82,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L41-L43" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -98,6 +102,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L55-L57" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -115,6 +120,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L63-L65" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -132,6 +138,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L74-L77" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -151,6 +158,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L86-L91" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -170,6 +178,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L102-L105" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -187,6 +196,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L117-L120" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -204,6 +214,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L127-L130" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/browsing_context.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/browsing_context.zh-cn.md
@@ -21,6 +21,7 @@ Creates a new browsing context in a new window.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L35" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -40,6 +41,7 @@ Creates a new browsing context in a new tab.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L49" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -59,6 +61,7 @@ Creates a browsing context for the existing tab/window to run commands.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L28-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -79,6 +82,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L41-L43" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -98,6 +102,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L55-L57" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -115,6 +120,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L63-L65" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -132,6 +138,7 @@ The API allows to pass the reference browsing context, which is used to create a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L74-L77" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -151,6 +158,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L86-L91" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -170,6 +178,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L102-L105" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -187,6 +196,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L117-L120" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -204,6 +214,7 @@ Provides a tree of all browsing contexts descending from the parent browsing con
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/browsingcontext/BrowsingContextTest.java#L127-L130" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/log.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/log.en.md
@@ -12,6 +12,7 @@ Listen to the `console.log` events and register callbacks to process the event.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/log/LogInspectorTest.java#L31-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -51,6 +52,7 @@ Listen to all JS logs at all levels and register callbacks to process the log.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/log/LogInspectorTest.java#L52-L59" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/log.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/log.ja.md
@@ -21,6 +21,7 @@ Listen to the `console.log` events and register callbacks to process the event.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/log/LogInspectorTest.java#L31-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -60,6 +61,7 @@ Listen to all JS logs at all levels and register callbacks to process the log.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/log/LogInspectorTest.java#L52-L59" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/log.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/log.pt-br.md
@@ -21,6 +21,7 @@ Listen to the `console.log` events and register callbacks to process the event.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/log/LogInspectorTest.java#L31-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
@@ -60,6 +61,7 @@ Listen to all JS logs at all levels and register callbacks to process the log.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/bidirectional/log/LogInspectorTest.java#L52-L59" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/log.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/bidirectional_w3c/log.zh-cn.md
@@ -28,6 +28,7 @@ Listen to the `console.log` events and register callbacks to process the event.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/javascript/test/bidirectional/logInspector.spec.js#L23-37" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
@@ -48,6 +49,7 @@ and register callbacks to process the exception details.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/javascript/test/bidirectional/logInspector.spec.js#L44-54" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
@@ -219,6 +219,7 @@ Property value: String representing path to log file
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L74" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L44" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -235,6 +236,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L74" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
@@ -248,6 +250,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< /tab >}}
 {{% tab header="Ruby" %}}
 `$stdout` and `$stderr` are both valid values
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L53" >}}
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -265,6 +268,7 @@ so this example is just setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L89" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -277,6 +281,7 @@ Property value: String representation of `ChromiumDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L63" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -297,6 +302,7 @@ The log output will be managed by the driver, not the process, so minor differen
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L106-L107" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `ChromeDriverService.CHROME_DRIVER_APPEND_LOG_PROPERTY` and `ChromeDriverService.CHROME_DRIVER_READABLE_TIMESTAMP`\
@@ -309,6 +315,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L74-L75" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -327,6 +334,7 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L125" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_DISABLE_BUILD_CHECK`\
@@ -339,6 +347,7 @@ Property value: `"true"` or `"false"`
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L144" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L85" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
@@ -223,6 +223,7 @@ Property value: String representing path to log file
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L74" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L44" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -239,6 +240,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L74" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
@@ -252,6 +254,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< /tab >}}
 {{% tab header="Ruby" %}}
 `$stdout` and `$stderr` are both valid values
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L53" >}}
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -269,6 +272,7 @@ so this example is just setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L89" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -281,6 +285,7 @@ Property value: String representation of `ChromiumDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L63" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -301,6 +306,7 @@ The log output will be managed by the driver, not the process, so minor differen
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L106-L107" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `ChromeDriverService.CHROME_DRIVER_APPEND_LOG_PROPERTY` and `ChromeDriverService.CHROME_DRIVER_READABLE_TIMESTAMP`\
@@ -313,6 +319,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L74-L75" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -331,6 +338,7 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L125" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_DISABLE_BUILD_CHECK`\
@@ -343,6 +351,7 @@ Property value: `"true"` or `"false"`
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L144" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L85" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
@@ -218,6 +218,7 @@ Property value: String representing path to log file
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L74" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L44" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -234,6 +235,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L74" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
@@ -247,6 +249,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< /tab >}}
 {{% tab header="Ruby" %}}
 `$stdout` and `$stderr` are both valid values
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L53" >}}
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -264,6 +267,7 @@ so this example is just setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L89" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -276,6 +280,7 @@ Property value: String representation of `ChromiumDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L63" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -296,6 +301,7 @@ The log output will be managed by the driver, not the process, so minor differen
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L106-L107" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `ChromeDriverService.CHROME_DRIVER_APPEND_LOG_PROPERTY` and `ChromeDriverService.CHROME_DRIVER_READABLE_TIMESTAMP`\
@@ -308,6 +314,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L74-L75" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -326,6 +333,7 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L125" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_DISABLE_BUILD_CHECK`\
@@ -338,6 +346,7 @@ Property value: `"true"` or `"false"`
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L144" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L85" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
@@ -217,6 +217,7 @@ Property value: String representing path to log file
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L74" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L44" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -233,6 +234,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L74" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
@@ -246,6 +248,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< /tab >}}
 {{% tab header="Ruby" %}}
 `$stdout` and `$stderr` are both valid values
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L53" >}}
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -263,6 +266,7 @@ so this example is just setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L89" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -275,6 +279,7 @@ Property value: String representation of `ChromiumDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L63" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -295,6 +300,7 @@ The log output will be managed by the driver, not the process, so minor differen
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L106-L107" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `ChromeDriverService.CHROME_DRIVER_APPEND_LOG_PROPERTY` and `ChromeDriverService.CHROME_DRIVER_READABLE_TIMESTAMP`\
@@ -307,6 +313,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L74-L75" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -325,6 +332,7 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L125" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_DISABLE_BUILD_CHECK`\
@@ -337,6 +345,7 @@ Property value: `"true"` or `"false"`
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L144" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/chrome_spec.rb#L85" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.en.md
@@ -185,6 +185,7 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L55" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
@@ -197,6 +198,7 @@ Property value: String representing path to log file
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L74" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L44" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -213,6 +215,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L69" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
@@ -226,6 +229,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< /tab >}}
 {{% tab header="Ruby" %}}
 `$stdout` and `$stderr` are both valid values
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L53" >}}
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -243,6 +247,7 @@ so this example is just setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L84" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -255,6 +260,7 @@ Property value: String representation of `ChromiumDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L63" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -275,6 +281,7 @@ The log output will be managed by the driver, not the process, so minor differen
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L101-L102" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `EdgeDriverService.EDGE_DRIVER_APPEND_LOG_PROPERTY` and `EdgeDriverService.EDGE_DRIVER_READABLE_TIMESTAMP`\
@@ -287,6 +294,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L74-L75" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -305,6 +313,7 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L120" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_DISABLE_BUILD_CHECK`\
@@ -317,6 +326,7 @@ Property value: `"true"` or `"false"`
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L144" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L85" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
@@ -187,6 +187,7 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L55" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
@@ -199,6 +200,7 @@ Property value: String representing path to log file
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L74" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L44" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -215,6 +217,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L69" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
@@ -228,6 +231,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< /tab >}}
 {{% tab header="Ruby" %}}
 `$stdout` and `$stderr` are both valid values
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L53" >}}
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -245,6 +249,7 @@ so this example is just setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L84" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -257,6 +262,7 @@ Property value: String representation of `ChromiumDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L63" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -277,6 +283,7 @@ The log output will be managed by the driver, not the process, so minor differen
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L101-L102" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `EdgeDriverService.EDGE_DRIVER_APPEND_LOG_PROPERTY` and `EdgeDriverService.EDGE_DRIVER_READABLE_TIMESTAMP`\
@@ -289,6 +296,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L74-L75" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -307,6 +315,7 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L120" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_DISABLE_BUILD_CHECK`\
@@ -319,6 +328,7 @@ Property value: `"true"` or `"false"`
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L144" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L85" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md
@@ -187,6 +187,7 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L55" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
@@ -199,6 +200,7 @@ Property value: String representing path to log file
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L74" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L44" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -215,6 +217,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L69" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
@@ -228,6 +231,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< /tab >}}
 {{% tab header="Ruby" %}}
 `$stdout` and `$stderr` are both valid values
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L53" >}}
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -245,6 +249,7 @@ so this example is just setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L84" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -257,6 +262,7 @@ Property value: String representation of `ChromiumDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L63" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -277,6 +283,7 @@ The log output will be managed by the driver, not the process, so minor differen
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L101-L102" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `EdgeDriverService.EDGE_DRIVER_APPEND_LOG_PROPERTY` and `EdgeDriverService.EDGE_DRIVER_READABLE_TIMESTAMP`\
@@ -289,6 +296,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L74-L75" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -307,6 +315,7 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L120" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_DISABLE_BUILD_CHECK`\
@@ -319,6 +328,7 @@ Property value: `"true"` or `"false"`
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L144" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L85" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md
@@ -187,6 +187,7 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L55" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
@@ -199,6 +200,7 @@ Property value: String representing path to log file
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L74" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L44" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -215,6 +217,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L69" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
@@ -228,6 +231,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< /tab >}}
 {{% tab header="Ruby" %}}
 `$stdout` and `$stderr` are both valid values
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L53" >}}
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -245,6 +249,7 @@ so this example is just setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L84" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -257,6 +262,7 @@ Property value: String representation of `ChromiumDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L63" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -277,6 +283,7 @@ The log output will be managed by the driver, not the process, so minor differen
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L101-L102" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `EdgeDriverService.EDGE_DRIVER_APPEND_LOG_PROPERTY` and `EdgeDriverService.EDGE_DRIVER_READABLE_TIMESTAMP`\
@@ -289,6 +296,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L74-L75" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -307,6 +315,7 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L120" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_DISABLE_BUILD_CHECK`\
@@ -319,6 +328,7 @@ Property value: `"true"` or `"false"`
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L144" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/edge_spec.rb#L85" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
@@ -158,6 +158,7 @@ Property value: String representing path to log file
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L31" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -174,6 +175,7 @@ To change the logging output to display in the console:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L65" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
@@ -186,6 +188,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L40" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -205,6 +208,7 @@ so this examples is just for setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L80" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -217,6 +221,7 @@ Property value: String representation of `FirefoxDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L50" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -234,6 +239,7 @@ Firefox truncates lines by default. To turn off truncation:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L97" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_NO_TRUNCATE`\
@@ -246,6 +252,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L60" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -263,6 +270,7 @@ or want profiles to be created some place specific, you can change the profile r
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L109" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_PROFILE_ROOT`\
@@ -275,6 +283,7 @@ Property value: String representing path to profile root directory
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L69" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
@@ -161,6 +161,7 @@ Property value: String representing path to log file
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L31" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -177,6 +178,7 @@ To change the logging output to display in the console:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L65" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
@@ -189,6 +191,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L40" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -208,6 +211,7 @@ so this examples is just for setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L80" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -220,6 +224,7 @@ Property value: String representation of `FirefoxDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L50" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -237,6 +242,7 @@ Firefox truncates lines by default. To turn off truncation:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L97" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_NO_TRUNCATE`\
@@ -249,6 +255,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L60" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -266,6 +273,7 @@ or want profiles to be created some place specific, you can change the profile r
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L109" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_PROFILE_ROOT`\
@@ -278,6 +286,7 @@ Property value: String representing path to profile root directory
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L69" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
@@ -160,6 +160,7 @@ Property value: String representing path to log file
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L31" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -176,6 +177,7 @@ To change the logging output to display in the console:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L65" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
@@ -188,6 +190,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L40" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -207,6 +210,7 @@ so this examples is just for setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L80" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -219,6 +223,7 @@ Property value: String representation of `FirefoxDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L50" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -236,6 +241,7 @@ Firefox truncates lines by default. To turn off truncation:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L97" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_NO_TRUNCATE`\
@@ -248,6 +254,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L60" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -265,6 +272,7 @@ or want profiles to be created some place specific, you can change the profile r
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L109" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_PROFILE_ROOT`\
@@ -277,6 +285,7 @@ Property value: String representing path to profile root directory
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L69" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
@@ -159,6 +159,7 @@ Property value: String representing path to log file
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L31" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -175,6 +176,7 @@ To change the logging output to display in the console:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L65" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
@@ -187,6 +189,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L40" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -206,6 +209,7 @@ so this examples is just for setting the log level generically:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L80" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY`\
@@ -218,6 +222,7 @@ Property value: String representation of `FirefoxDriverLogLevel` enum
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L50" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -235,6 +240,7 @@ Firefox truncates lines by default. To turn off truncation:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L97" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_NO_TRUNCATE`\
@@ -247,6 +253,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L60" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -264,6 +271,7 @@ or want profiles to be created some place specific, you can change the profile r
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L109" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_PROFILE_ROOT`\
@@ -276,6 +284,7 @@ Property value: String representing path to profile root directory
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/firefox_spec.rb#L69" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.en.md
@@ -613,6 +613,7 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#L53" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
@@ -625,6 +626,7 @@ Property value: String representing path to log file
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L32" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -641,6 +643,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#L67" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
@@ -653,6 +656,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L41" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -681,6 +685,7 @@ Property value: String representation of `InternetExplorerDriverLogLevel.DEBUG.t
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L85" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L52" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -707,6 +712,7 @@ Property value: String representing path to supporting files directory
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L98" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L62" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.ja.md
@@ -586,6 +586,7 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#L53" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
@@ -598,6 +599,7 @@ Property value: String representing path to log file
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L32" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -614,6 +616,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#L67" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
@@ -626,6 +629,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L41" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -654,6 +658,7 @@ Property value: String representation of `InternetExplorerDriverLogLevel.DEBUG.t
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L85" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L52" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -680,6 +685,7 @@ Property value: String representing path to supporting files directory
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L98" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L62" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.pt-br.md
@@ -603,6 +603,7 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#L53" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
@@ -615,6 +616,7 @@ Property value: String representing path to log file
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L32" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -631,6 +633,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#L67" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
@@ -643,6 +646,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L41" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -671,6 +675,7 @@ Property value: String representation of `InternetExplorerDriverLogLevel.DEBUG.t
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L85" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L52" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -697,6 +702,7 @@ Property value: String representing path to supporting files directory
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L98" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L62" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.zh-cn.md
@@ -596,6 +596,7 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#L53" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
@@ -608,6 +609,7 @@ Property value: String representing path to log file
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L32" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -624,6 +626,7 @@ To change the logging output to display in the console as STDOUT:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#L67" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
@@ -636,6 +639,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L41" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -664,6 +668,7 @@ Property value: String representation of `InternetExplorerDriverLogLevel.DEBUG.t
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L85" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L52" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -690,6 +695,7 @@ Property value: String representing path to supporting files directory
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L98" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/internet_explorer_spec.rb#L62" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
@@ -61,6 +61,7 @@ available is to turn logs off or on. If logs are toggled on, they can be found a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/SafariTest.java#L31" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `SafariDriverService.SAFARI_DRIVER_LOGGING`\
@@ -73,6 +74,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L20" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
@@ -61,6 +61,7 @@ available is to turn logs off or on. If logs are toggled on, they can be found a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/SafariTest.java#L31" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `SafariDriverService.SAFARI_DRIVER_LOGGING`\
@@ -73,6 +74,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L20" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
@@ -61,6 +61,7 @@ available is to turn logs off or on. If logs are toggled on, they can be found a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/SafariTest.java#L31" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `SafariDriverService.SAFARI_DRIVER_LOGGING`\
@@ -73,6 +74,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L20" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
@@ -61,6 +61,7 @@ available is to turn logs off or on. If logs are toggled on, they can be found a
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
+{{< badge-version version="4.10" >}}
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/SafariTest.java#L31" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `SafariDriverService.SAFARI_DRIVER_LOGGING`\
@@ -73,6 +74,7 @@ Property value: `"true"` or `"false"`
 {{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L20" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/service.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/service.en.md
@@ -54,9 +54,11 @@ If you cannot update Selenium or have an advanced use case, here is how to speci
 {{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L12" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
+{{< badge-version version="4.9" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L27" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L18" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -82,6 +84,7 @@ If you want the driver to run on a specific port, you may specify it as follows:
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L36" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L25" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/service.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/service.ja.md
@@ -50,9 +50,11 @@ If you can not update Selenium or have an advanced use case here is how to speci
 {{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L12" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
+{{< badge-version version="4.9" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L27" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L18" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -78,6 +80,7 @@ If you want the driver to run on a specific port, you may specify it as follows:
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L36" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L25" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/service.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/service.pt-br.md
@@ -50,9 +50,11 @@ If you can not update Selenium or have an advanced use case here is how to speci
 {{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L12" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
+{{< badge-version version="4.9" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L27" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L18" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -78,6 +80,7 @@ If you want the driver to run on a specific port, you may specify it as follows:
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L36" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L25" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/service.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/service.zh-cn.md
@@ -50,9 +50,11 @@ If you can not update Selenium or have an advanced use case here is how to speci
 {{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L12" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
+{{< badge-version version="4.9" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L27" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L18" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
@@ -78,6 +80,7 @@ If you want the driver to run on a specific port, you may specify it as follows:
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L36" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
+{{< badge-version version="4.8" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L25" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}


### PR DESCRIPTION
### Description
Annotates what version of Selenium is required to successfully execute the code in the example documentation

### Motivation and Context
Trying to keep on top of what is new
