### PR TITLE
Update style.en.md for Default Code Tabs

### DIFF
--- a/website_and_docs/content/documentation/about/style.en.md
+++ b/website_and_docs/content/documentation/about/style.en.md
@@ -132,26 +132,6 @@ This auto-formats the code in each tab to match the header name,
 but more importantly it ensures that all tabs on the page with a language
 are set to the same thing, so we always want to include it.
 
-    {{</* tabpane langEqualsHeader=true */>}}
-      {{</* tab header="Java" */>}}
-        WebDriver driver = new ChromeDriver();
-      {{</* /tab */>}}
-      {{</* tab header="Python" */>}}
-        driver = webdriver.Chrome()
-      {{</* /tab */>}}
-      {{</* tab header="CSharp" */>}}
-        var driver = new ChromeDriver();
-      {{</* /tab */>}}
-      {{</* tab header="Ruby" */>}}
-        driver = Selenium::WebDriver.for :chrome
-      {{</* /tab */>}}
-      {{</* tab header="JavaScript" */>}}
-        let driver = await new Builder().forBrowser('chrome').build();
-      {{</* /tab */>}}
-      {{</* tab header="Kotlin" */>}}
-        val driver = ChromeDriver()
-      {{</* /tab */>}}
-    {{</* /tabpane */>}}
 
 #### Reference Github Examples
 


### PR DESCRIPTION
### Description
Update style.en.md for Default Code Tabs as the code below the description of **Default Code Tabs** is not getting translated.
![image](https://github.com/SeleniumHQ/seleniumhq.github.io/assets/17446771/ea5de60e-4385-4690-9dde-dcd89a185329)


### Motivation and Context
After removing those lines of code, **Default Code Tabs** description will become more readable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improved translation

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
