### PR TITLE
Remove SE_CACHE_PATH from Selenium Manager page

### DIFF
--- a/website_and_docs/content/documentation/selenium_manager.en.md
+++ b/website_and_docs/content/documentation/selenium_manager.en.md
@@ -70,7 +70,6 @@ located by default at `~/.cache/selenium/selenium-manager-config.toml`.
 | --driver-ttl 86400               | SE_DRIVER_TTL=86400                                | driver-ttl = 86400                                  |
 | --clear-cache                    |                                                    |                                                     |
 | --clear-metadata                 |                                                    |                                                     |
-|                                  | SE_CACHE_PATH=/my/custom/cache                     | cache-path = "/my/custom/cache"                     |
 | --debug                          | SE_DEBUG=true                                      | debug true                                          |
 | --trace                          | SE_TRACE=true                                      |                                                     |
 

--- a/website_and_docs/content/documentation/selenium_manager.ja.md
+++ b/website_and_docs/content/documentation/selenium_manager.ja.md
@@ -70,7 +70,6 @@ located by default at `~/.cache/selenium/selenium-manager-config.toml`.
 | --driver-ttl 86400               | SE_DRIVER_TTL=86400                                | driver-ttl = 86400                                  |
 | --clear-cache                    |                                                    |                                                     |
 | --clear-metadata                 |                                                    |                                                     |
-|                                  | SE_CACHE_PATH=/my/custom/cache                     | cache-path = "/my/custom/cache"                     |
 | --debug                          | SE_DEBUG=true                                      | debug true                                          |
 | --trace                          | SE_TRACE=true                                      |                                                     |
 

--- a/website_and_docs/content/documentation/selenium_manager.pt-br.md
+++ b/website_and_docs/content/documentation/selenium_manager.pt-br.md
@@ -70,7 +70,6 @@ located by default at `~/.cache/selenium/selenium-manager-config.toml`.
 | --driver-ttl 86400               | SE_DRIVER_TTL=86400                                | driver-ttl = 86400                                  |
 | --clear-cache                    |                                                    |                                                     |
 | --clear-metadata                 |                                                    |                                                     |
-|                                  | SE_CACHE_PATH=/my/custom/cache                     | cache-path = "/my/custom/cache"                     |
 | --debug                          | SE_DEBUG=true                                      | debug true                                          |
 | --trace                          | SE_TRACE=true                                      |                                                     |
 

--- a/website_and_docs/content/documentation/selenium_manager.zh-cn.md
+++ b/website_and_docs/content/documentation/selenium_manager.zh-cn.md
@@ -70,7 +70,6 @@ located by default at `~/.cache/selenium/selenium-manager-config.toml`.
 | --driver-ttl 86400               | SE_DRIVER_TTL=86400                                | driver-ttl = 86400                                  |
 | --clear-cache                    |                                                    |                                                     |
 | --clear-metadata                 |                                                    |                                                     |
-|                                  | SE_CACHE_PATH=/my/custom/cache                     | cache-path = "/my/custom/cache"                     |
 | --debug                          | SE_DEBUG=true                                      | debug true                                          |
 | --trace                          | SE_TRACE=true                                      |                                                     |
 


### PR DESCRIPTION
### Description
The Selenium Manager page contains this configuration key (SE_CACHE_PATH) which is not still implemented.

### Motivation and Context
This has been reported in

https://github.com/SeleniumHQ/selenium/issues/12383

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
