### PR TITLE
[Docs] Added instructions for Java in the 'Test Runners' section

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
@@ -258,8 +258,41 @@ Many of the code examples in this documentation can be found in our example repo
 There are multiple options in each language, but here is what we are using in our examples:
 
 {{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-// Add instructions
+{{% tab header="Java" text=true %}}
+Install JUnit 5 test runner using a build tool.
+
+### Maven
+
+In the project’s `pom.xml` file, specify the dependency: 
+
+{{< gh-codeblock path="examples/java/pom.xml#L53-L58" >}}
+
+and configure the build plugin:
+
+{{< gh-codeblock path="examples/java/pom.xml#L63-L73" >}}
+
+Now, run your tests using:
+
+```shell
+mvn clean test
+```
+
+### Gradle
+
+In the project's `build.gradle` file,  specify the dependency: 
+
+{{< gh-codeblock path="examples/java/build.gradle#L15" >}}
+
+and add the following in the `test` task:
+
+{{< gh-codeblock path="examples/java/build.gradle#L19" >}}
+
+Now, run your tests using:
+
+```shell
+gradle clean test
+```
+
 {{< /tab >}}
 {{< tab header="Python" >}}
 // Add instructions

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
@@ -260,8 +260,41 @@ Many of the code examples in this documentation can be found in our example repo
 There are multiple options in each language, but here is what we are using in our examples:
 
 {{< tabpane text=true langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-// Add instructions
+{{% tab header="Java" text=true %}}
+Install JUnit 5 test runner using a build tool.
+
+### Maven
+
+In the project’s `pom.xml` file, specify the dependency: 
+
+{{< gh-codeblock path="examples/java/pom.xml#L53-L58" >}}
+
+and configure the build plugin:
+
+{{< gh-codeblock path="examples/java/pom.xml#L63-L73" >}}
+
+Now, run your tests using:
+
+```shell
+mvn clean test
+```
+
+### Gradle
+
+In the project's `build.gradle` file,  specify the dependency: 
+
+{{< gh-codeblock path="examples/java/build.gradle#L15" >}}
+
+and add the following in the `test` task:
+
+{{< gh-codeblock path="examples/java/build.gradle#L19" >}}
+
+Now, run your tests using:
+
+```shell
+gradle clean test
+```
+
 {{< /tab >}}
 {{< tab header="Python" >}}
 // Add instructions

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
@@ -259,8 +259,41 @@ Existem múltiplas opções em cada linguagem, mas esta será qual usaremos em n
 
 
 {{< tabpane text=true langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-// Add instructions
+{{% tab header="Java" text=true %}}
+Install JUnit 5 test runner using a build tool.
+
+### Maven
+
+In the project’s `pom.xml` file, specify the dependency: 
+
+{{< gh-codeblock path="examples/java/pom.xml#L53-L58" >}}
+
+and configure the build plugin:
+
+{{< gh-codeblock path="examples/java/pom.xml#L63-L73" >}}
+
+Now, run your tests using:
+
+```shell
+mvn clean test
+```
+
+### Gradle
+
+In the project's `build.gradle` file,  specify the dependency: 
+
+{{< gh-codeblock path="examples/java/build.gradle#L15" >}}
+
+and add the following in the `test` task:
+
+{{< gh-codeblock path="examples/java/build.gradle#L19" >}}
+
+Now, run your tests using:
+
+```shell
+gradle clean test
+```
+
 {{< /tab >}}
 {{< tab header="Python" >}}
 // Add instructions

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
@@ -276,8 +276,41 @@ Many of the code examples in this documentation can be found in our example repo
 There are multiple options in each language, but here is what we are using in our examples:
 
 {{< tabpane text=true langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-// Add instructions
+{{% tab header="Java" text=true %}}
+Install JUnit 5 test runner using a build tool.
+
+### Maven
+
+In the project’s `pom.xml` file, specify the dependency: 
+
+{{< gh-codeblock path="examples/java/pom.xml#L53-L58" >}}
+
+and configure the build plugin:
+
+{{< gh-codeblock path="examples/java/pom.xml#L63-L73" >}}
+
+Now, run your tests using:
+
+```shell
+mvn clean test
+```
+
+### Gradle
+
+In the project's `build.gradle` file,  specify the dependency: 
+
+{{< gh-codeblock path="examples/java/build.gradle#L15" >}}
+
+and add the following in the `test` task:
+
+{{< gh-codeblock path="examples/java/build.gradle#L19" >}}
+
+Now, run your tests using:
+
+```shell
+gradle clean test
+```
+
 {{< /tab >}}
 {{< tab header="Python" >}}
 // Add instructions


### PR DESCRIPTION
Fixes #1457

### Description
This PR adds instructions to setup JUnit 5 as a test runner for Java. 

### Motivation and Context
There are currently no instructions for Java. So, I've included it.

### Types of changes

- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
