### PR TITLE
Aligning and fixing overflowing elements 

### DIFF
--- a/website_and_docs/assets/scss/_backgrounds.scss
+++ b/website_and_docs/assets/scss/_backgrounds.scss
@@ -1,3 +1,9 @@
+@media (min-width: 991px) { 
+html, body {
+  max-width: 100%;
+  overflow-x: hidden;
+}}
+
 .-bg-selenium-green {
   // https://www.svgbackgrounds.com/#liquid-cheese
   // https://cssgenerator.org/rgba-and-hex-color-generator.html used to get the values

--- a/website_and_docs/layouts/partials/announcement-banner.html
+++ b/website_and_docs/layouts/partials/announcement-banner.html
@@ -1,9 +1,9 @@
 {{ $color := "selenium-blue" }}
 {{ $p1 := .p1 }}
 
-<section id="announcement-banner" class="alert-static row -bg-{{ $color }}">
-  <div class="container" style="padding: 10px;">
-    <div class="row justify-content-center">
+<section id="announcement-banner" class="alert-static g-0 row -bg-{{ $color }}">
+  <div class="container g-0" style="padding: 10px;">
+    <div class="row g-0 justify-content-center">
       <div class="alert alert-{{ $color }} col-12 fade show mb-0 p-0 -bg-{{ $color }}" role="alert">
         <h4 class="alert-heading text-center m-0">
           SeleniumConf Chicago 2023 is a wrap! 

--- a/website_and_docs/layouts/partials/footer.html
+++ b/website_and_docs/layouts/partials/footer.html
@@ -21,7 +21,7 @@
         {{ template "footer-links-block"  . }}
         {{ end }}
         {{ end }}
-        <a href="https://www.netlify.com"> <img src="https://www.netlify.com/v3/img/components/netlify-light.svg" alt="Deploys by Netlify" /> </a>
+        <a href="https://www.netlify.com"> <img style="margin-right: 50px;" src="https://www.netlify.com/v3/img/components/netlify-light.svg" alt="Deploys by Netlify" /> </a>
       </div>
       <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
         {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ .}} {{ T "footer_all_rights_reserved" }}</small>{{ end }}

--- a/website_and_docs/layouts/partials/news-feed.html
+++ b/website_and_docs/layouts/partials/news-feed.html
@@ -1,5 +1,7 @@
+<div class="row">
 <div class="d-flex justify-content-center p-5 td-box--100">
   <h2 class="selenium">News</h2>
+  </div>
 </div>
 {{ $regular_pages := .regular_pages }}
 {{ range first 3 (where $regular_pages "Type" "blog") }}

--- a/website_and_docs/layouts/shortcodes/getting-started.html
+++ b/website_and_docs/layouts/shortcodes/getting-started.html
@@ -4,8 +4,10 @@
 {{ $type   := .Get "type" | default "" }} 
 <a id="td-block-{{ .Ordinal }}" class="td-offset-anchor"></a>
 {{ with .Get "title" }}
+<div class="row">
 <div class="d-flex justify-content-center td-box--{{ $col_id }} pt-5">
   <h2>{{ . }}</h2>
+</div>
 </div>
 {{ end }}
 <section class="row td-box td-box--{{ $col_id }} td-box--gradient td-box--height-{{ $height }} pt-3">


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This PR addresses the overflow and alignment issues observed on the Selenium website. Certain elements were not aligned properly with the screen viewport, causing them to bleed outside of the viewport. This set a general width for the page that's wider than the viewport, leading to horizontal scrolling. The changes made in this PR ensure that all elements adjust and align properly according to the size of the screen viewport.

Fixes: #1482  

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Issue: Usability and accessibility of the webpage
Impact: Users had to horizontally scroll to view content, which is not ideal for usability and accessibility.

### Screenshots:

<img width="1440" alt="image" src="https://github.com/SeleniumHQ/seleniumhq.github.io/assets/39815871/0a217bb9-3215-4d47-bed6-36cf68db08e0">

<img width="1440" alt="image" src="https://github.com/SeleniumHQ/seleniumhq.github.io/assets/39815871/998d5c77-fa44-4630-b295-038002d5caa4">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
