### PR TITLE
Selenium 4.14 release blog and version bump

### DIFF
--- a/website_and_docs/content/blog/2023/selenium-4-14-released.md
+++ b/website_and_docs/content/blog/2023/selenium-4-14-released.md
@@ -1,0 +1,128 @@
+---
+title: "Selenium 4.14 Released!"
+linkTitle: "Selenium 4.14 Released!"
+date: 2023-09-25
+tags: ["selenium"]
+categories: ["releases"]
+author: Titus Fortner [@titusfortner](https://titusfortner.com)
+description: >
+  Today we're happy to announce that Selenium 4.14 has been released!
+---
+
+We're very happy to announce the release of Selenium 4.14.0 for Java, 
+Python, Javascript, Ruby, .NET and the Grid.
+Links to everything can be found on our [downloads page][downloads].
+
+### Highlights
+
+  * Chrome DevTools support is now: v116, v117, and v118 (Firefox still uses v85 for all versions)
+  * If you are using Java, this release requires Java 11! (see post on [Java 8 support](/blog/2023/java-8-support/))
+  * Selenium supports automatic downloading and management of the Microsoft Edge browser
+
+#### Relevant improvements per language
+
+  * Java 
+    * Removed support for Async HTTP Client, the default is now the default Java library
+    * Allow setting SSL context in client config for HttpClient
+    * Several logging message improvements
+    * [See all changes](https://github.com/SeleniumHQ/selenium/blob/trunk/java/CHANGELOG)
+
+  <br>
+  
+  * JavaScript
+    * [See all changes](https://github.com/SeleniumHQ/selenium/blob/trunk/javascript/node/selenium-webdriver/CHANGES.md)
+  
+  <br>
+  
+  * .NET
+    * Saving screenshots with different image formats is deprecated
+    * Removed IdentityModel dependency
+    * [See all changes](https://github.com/SeleniumHQ/selenium/blob/trunk/dotnet/CHANGELOG)
+  
+  <br>
+  
+  * Python
+    * Fix bug that didn't close log_output in Service classes
+    * [See all changes](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES)
+
+<br>
+  
+  * Ruby
+    * Provide public access to atom scripts
+    * [See all changes](https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES)
+
+<br>
+
+  * Rust
+    * Automated Edge management
+    * Recognizes and handles webview2 
+    * Locates existing Chromium browsers when specifying Chrome
+    * [See all changes](https://github.com/SeleniumHQ/selenium/blob/trunk/rust/CHANGELOG.md)
+
+
+### Contributors
+
+**Special shout-out to everyone who helped the Selenium Team get this release out!**
+
+#### [Selenium](https://github.com/SeleniumHQ/selenium)
+
+<div class="d-flex justify-content-center">
+  <div class="col-11 p-4 bg-transparent">
+    <div class="row justify-content-center">
+{{< gh-user "https://api.github.com/users/alexey-pelykh" >}} 
+{{< gh-user "https://api.github.com/users/manuelsblanco" >}}
+{{< gh-user "https://api.github.com/users/sbabcoc" >}}
+    </div>
+  </div>
+</div>
+
+#### [Selenium Docs & Website](https://github.com/SeleniumHQ/seleniumhq.github.io)
+
+<div class="row justify-content-center">
+  <div class="col-11 p-4 bg-transparent">
+    <div class="row justify-content-center">
+{{< gh-user "https://api.github.com/users/alaahong" >}}
+    </div>
+  </div>
+</div>
+
+#### [Docker Selenium](https://github.com/SeleniumHQ/docker-selenium)
+
+<div class="row justify-content-center">
+  <div class="col-11 p-4 bg-transparent">
+    <div class="row justify-content-center">
+{{< gh-user "https://api.github.com/users/amardeep2006" >}}
+{{< gh-user "https://api.github.com/users/imtheish97" >}}
+{{< gh-user "https://api.github.com/users/IronMage" >}}
+{{< gh-user "https://api.github.com/users/williamlac" >}}
+    </div>
+  </div>
+</div>
+
+**Thanks as well to all the [Selenium Team Members][team] who contributed to this release:**
+
+<div class="row justify-content-center">
+  <div class="col-11 p-4 bg-transparent">
+    <div class="row justify-content-center">
+{{< gh-user "https://api.github.com/users/bonigarcia" >}}
+{{< gh-user "https://api.github.com/users/harsha509" >}}
+{{< gh-user "https://api.github.com/users/jimevans" >}}
+{{< gh-user "https://api.github.com/users/joerg1985" >}}
+{{< gh-user "https://api.github.com/users/nvborisenko" >}}
+{{< gh-user "https://api.github.com/users/pujagani" >}}
+{{< gh-user "https://api.github.com/users/shs96c" >}} 
+{{< gh-user "https://api.github.com/users/symonk" >}} 
+{{< gh-user "https://api.github.com/users/titusfortner" >}}
+    </div>
+  </div>
+</div>
+
+Stay tuned for updates by following [SeleniumHQ](https://twitter.com/seleniumhq)!
+
+Happy testing!
+
+[downloads]: /downloads
+[bindings]: /downloads#bindings
+[team]: /project/structure
+[BiDi]: https://github.com/w3c/webdriver-bidi
+

--- a/website_and_docs/layouts/downloads/list.html
+++ b/website_and_docs/layouts/downloads/list.html
@@ -25,7 +25,7 @@
       <div class="card-body">
         <p class="card-text">
           Latest stable version
-          <a href="https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.13.0/selenium-server-4.13.0.jar">4.13.0</a>
+          <a href="https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.14.0/selenium-server-4.14.0.jar">4.14.0</a>
         </p>
         <p class="card-text">
           To use the Selenium Server in a Grid configuration see the
@@ -107,7 +107,7 @@
     <div class="card-body">
       <h2 class="card-title">C# NuGet</h2>
       <p class="card-text w-lg-75">
-        Nuget latest release is 4.13.1 Released on September 25, 2023.
+        Nuget latest release is 4.14.0 Released on October 9, 2023.
       </p>
       <ul>
         <li>

--- a/website_and_docs/layouts/partials/selenium-clients-and-webdriver-bindings.html
+++ b/website_and_docs/layouts/partials/selenium-clients-and-webdriver-bindings.html
@@ -27,7 +27,7 @@
         <p class="card-text m-0 pb-1">
           Stable:
           <a href="https://www.nuget.org/packages/Selenium.WebDriver" class="card-link">
-              4.13.1 (September 25, 2023)
+              4.14.0 (October 9, 2023)
           </a>
         </p>
         <p class="card-text m-0 pb-1">
@@ -54,8 +54,8 @@
         </p>
         <p class="card-text m-0 pb-1">
           Stable:
-          <a href="https://rubygems.org/gems/selenium-webdriver/versions/4.13.0" class="card-link">
-            4.13.1 (September 25, 2023)
+          <a href="https://rubygems.org/gems/selenium-webdriver/versions/4.14.0" class="card-link">
+            4.14.0 (October 9, 2023)
           </a>
         </p>
         <p class="card-text m-0 pb-1">
@@ -82,8 +82,8 @@
         </p>
         <p class="card-text m-0 pb-1">
           Stable:
-          <a href="https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.13.0/selenium-java-4.13.0.zip" class="card-link">
-            4.13.0 (September 25, 2023)
+          <a href="https://github.com/SeleniumHQ/selenium/releases/download/selenium-4.14.0/selenium-java-4.14.0.zip" class="card-link">
+            4.14.0 (October 9, 2023)
           </a>
         </p>
         <p class="card-text m-0 pb-1">
@@ -111,7 +111,7 @@
         <p class="card-text m-0 pb-1">
           Stable:
           <a href="https://pypi.python.org/pypi/selenium" class="card-link">
-            4.13.0 (September 25, 2023)
+            4.14.0 (October 9, 2023)
           </a>
         </p>
         <p class="card-text m-0 pb-1">
@@ -139,7 +139,7 @@
         <p class="card-text m-0 pb-1">
           Stable:
           <a href="https://npmjs.org/package/selenium-webdriver" class="card-link">
-            4.13.0 (September 25, 2023)
+            4.14.0 (October 9, 2023)
           </a>
         </p>
         <p class="card-text m-0 pb-1">


### PR DESCRIPTION
We can't publish this until the Java jar is actually accessible on Sonatype, and I messed up the deploy (thankfully not in a bad way, just in a Titus has to wait longer to redeploy before he can go to sleep kind of way)

So please run the Java tests on trunk - https://github.com/SeleniumHQ/seleniumhq.github.io/actions/workflows/java-examples.yml to make sure 4.14 is loaded and working.

Then Merge

Then Social Media all the things

Then 🍻 


Ok it's getting pulled in. once these pass -- https://github.com/SeleniumHQ/seleniumhq.github.io/actions/runs/6465275856
if they don't pass, we'll figure out what we broke.