### PR TITLE
use driver finder for all binary location

### DIFF
--- a/.github/workflows/dotnet-examples.yml
+++ b/.github/workflows/dotnet-examples.yml
@@ -30,41 +30,14 @@ jobs:
     steps:
     - name: Checkout GitHub repo
       uses: actions/checkout@v3
-    - name: Install Chrome for set binary test
-      uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: stable
-      id: setup-chrome
-    - name: Install Edge for set binary test
-      uses: browser-actions/setup-edge@v1
-      with:
-        edge-version: stable
-      id: setup-edge
-    - name: Install Firefox for set binary test
-      if: matrix.os != 'windows-latest'
-      uses: browser-actions/setup-firefox@v1
-      with:
-        firefox-version: latest
-      id: setup-firefox
-    - name: Set ENV Windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $env:GITHUB_ENV
-        echo "EDGE_BIN=${{ steps.setup-edge.outputs.edge-path }}" >> $env:GITHUB_ENV
-    - name: Set ENV Other
-      if: matrix.os != 'windows-latest'
-      run: |
-        echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-        echo "EDGE_BIN=${{ steps.setup-edge.outputs.edge-path }}" >> "$GITHUB_ENV"
-        echo "FF_BIN=${{ steps.setup-firefox.outputs.firefox-path }}" >> "$GITHUB_ENV"
     - name: Remove driver directories Windows
-      if: matrix.os == 'windows'
+      if: matrix.os == 'windows-latest'
       run: |
         rm "$env:ChromeWebDriver" -r -v
         rm "$env:EdgeWebDriver" -r -v
         rm "$env:GeckoWebDriver" -r -v
     - name: Remove driver directories Non-Windows
-      if: matrix.os != 'windows'
+      if: matrix.os != 'windows-latest'
       run: |
         sudo rm -rf $CHROMEWEBDRIVER $EDGEWEBDRIVER $GECKOWEBDRIVER
     - name: Start Xvfb

--- a/.github/workflows/java-examples.yml
+++ b/.github/workflows/java-examples.yml
@@ -30,48 +30,14 @@ jobs:
     steps:
     - name: Checkout GitHub repo
       uses: actions/checkout@v3
-    - name: Install Chrome for set binary test
-      uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: stable
-      id: setup-chrome
-    - name: Install Edge for set binary test
-      uses: browser-actions/setup-edge@v1
-      with:
-        edge-version: stable
-      id: setup-edge
-    - name: Install Firefox for set binary test
-      if: matrix.os != 'windows-latest'
-      uses: browser-actions/setup-firefox@v1
-      with:
-        firefox-version: latest
-      id: setup-firefox
-    - name: Set ENV Windows
-      if: matrix.os == 'windows-latest'
-      run: |
-        echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $env:GITHUB_ENV
-        echo "EDGE_BIN=C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" >> $env:GITHUB_ENV
-        echo "FF_BIN=C:\Program Files (x86)\Mozilla Firefox\firefox-browser.exe" >> $env:GITHUB_ENV
-    - name: Set ENV Mac
-      if: matrix.os == 'macos-latest'
-      run: |
-        echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-        echo "EDGE_BIN=/Users/runner/hostedtoolcache/msedge/stable/x64/Contents/MacOS/Microsoft Edge" >> "$GITHUB_ENV"
-        echo "FF_BIN=/Users/runner/hostedtoolcache/firefox/latest/x64/Contents/MacOS/firefox" >> "$GITHUB_ENV"
-    - name: Set ENV Linux
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-        echo "EDGE_BIN=/opt/hostedtoolcache/msedge/stable/x64/msedge" >> "$GITHUB_ENV"
-        echo "FF_BIN=/opt/hostedtoolcache/firefox/latest/x64/firefox" >> "$GITHUB_ENV"
     - name: Remove driver directories Windows
-      if: matrix.os == 'windows'
+      if: matrix.os == 'windows-latest'
       run: |
         rm "$env:ChromeWebDriver" -r -v
         rm "$env:EdgeWebDriver" -r -v
         rm "$env:GeckoWebDriver" -r -v
     - name: Remove driver directories Non-Windows
-      if: matrix.os != 'windows'
+      if: matrix.os != 'windows-latest'
       run: |
         sudo rm -rf $CHROMEWEBDRIVER $EDGEWEBDRIVER $GECKOWEBDRIVER
     - name: Start Xvfb

--- a/.github/workflows/js-examples.yml
+++ b/.github/workflows/js-examples.yml
@@ -65,13 +65,13 @@ jobs:
         echo "EDGE_BIN=/opt/hostedtoolcache/msedge/stable/x64/msedge" >> "$GITHUB_ENV"
         echo "FF_BIN=/opt/hostedtoolcache/firefox/latest/x64/firefox" >> "$GITHUB_ENV"
     - name: Remove driver directories Windows
-      if: matrix.os == 'windows'
+      if: matrix.os == 'windows-latest'
       run: |
         rm "$env:ChromeWebDriver" -r -v
         rm "$env:EdgeWebDriver" -r -v
         rm "$env:GeckoWebDriver" -r -v
     - name: Remove driver directories Non-Windows
-      if: matrix.os != 'windows'
+      if: matrix.os != 'windows-latest'
       run: |
             sudo rm -rf $CHROMEWEBDRIVER $EDGEWEBDRIVER $GECKOWEBDRIVER
     - name: Start Xvfb

--- a/.github/workflows/kotlin-examples.yml
+++ b/.github/workflows/kotlin-examples.yml
@@ -65,13 +65,13 @@ jobs:
         echo "EDGE_BIN=/opt/hostedtoolcache/msedge/stable/x64/msedge" >> "$GITHUB_ENV"
         echo "FF_BIN=/opt/hostedtoolcache/firefox/latest/x64/firefox" >> "$GITHUB_ENV"
     - name: Remove driver directories Windows
-      if: matrix.os == 'windows'
+      if: matrix.os == 'windows-latest'
       run: |
         rm "$env:ChromeWebDriver" -r -v
         rm "$env:EdgeWebDriver" -r -v
         rm "$env:GeckoWebDriver" -r -v
     - name: Remove driver directories Non-Windows
-      if: matrix.os != 'windows'
+      if: matrix.os != 'windows-latest'
       run: |
         sudo rm -rf $CHROMEWEBDRIVER $EDGEWEBDRIVER $GECKOWEBDRIVER
     - name: Start Xvfb

--- a/.github/workflows/python-examples.yml
+++ b/.github/workflows/python-examples.yml
@@ -30,50 +30,16 @@ jobs:
     steps:
     - name: Checkout GitHub repo
       uses: actions/checkout@v3
-    - name: Install Chrome for set binary test
-      uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: stable
-      id: setup-chrome
-    - name: Install Edge for set binary test
-      uses: browser-actions/setup-edge@v1
-      with:
-        edge-version: stable
-      id: setup-edge
-    - name: Install Firefox for set binary test
-      if: matrix.os != 'windows-latest'
-      uses: browser-actions/setup-firefox@v1
-      with:
-        firefox-version: latest
-      id: setup-firefox
-    - name: Set ENV Windows
+    - name: Remove driver directories Windows
       if: matrix.os == 'windows-latest'
       run: |
-        echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $env:GITHUB_ENV
-        echo "EDGE_BIN=C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" >> $env:GITHUB_ENV
-        echo "FF_BIN=C:\Program Files (x86)\Mozilla Firefox\firefox-browser.exe" >> $env:GITHUB_ENV
-    - name: Set ENV Mac
-      if: matrix.os == 'macos-latest'
+        rm "$env:ChromeWebDriver" -r -v
+        rm "$env:EdgeWebDriver" -r -v
+        rm "$env:GeckoWebDriver" -r -v
+    - name: Remove driver directories Non-Windows
+      if: matrix.os != 'windows-latest'
       run: |
-        echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-        echo "EDGE_BIN=/Users/runner/hostedtoolcache/msedge/stable/x64/Contents/MacOS/Microsoft Edge" >> "$GITHUB_ENV"
-        echo "FF_BIN=/Users/runner/hostedtoolcache/firefox/latest/x64/Contents/MacOS/firefox" >> "$GITHUB_ENV"
-    - name: Set ENV Linux
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-        echo "EDGE_BIN=/opt/hostedtoolcache/msedge/stable/x64/msedge" >> "$GITHUB_ENV"
-        echo "FF_BIN=/opt/hostedtoolcache/firefox/latest/x64/firefox" >> "$GITHUB_ENV"
-        - name: Remove driver directories Windows
-          if: matrix.os == 'windows'
-          run: |
-            rm "$env:ChromeWebDriver" -r -v
-            rm "$env:EdgeWebDriver" -r -v
-            rm "$env:GeckoWebDriver" -r -v
-        - name: Remove driver directories Non-Windows
-          if: matrix.os != 'windows'
-          run: |
-            sudo rm -rf $CHROMEWEBDRIVER $EDGEWEBDRIVER $GECKOWEBDRIVER
+        sudo rm -rf $CHROMEWEBDRIVER $EDGEWEBDRIVER $GECKOWEBDRIVER
     - name: Start Xvfb
       if: matrix.os == 'ubuntu-latest'
       run: Xvfb :99 &

--- a/.github/workflows/ruby-examples.yml
+++ b/.github/workflows/ruby-examples.yml
@@ -30,48 +30,14 @@ jobs:
     steps:
       - name: Checkout GitHub repo
         uses: actions/checkout@v3
-      - name: Install Chrome for set binary test
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: stable
-        id: setup-chrome
-      - name: Install Edge for set binary test
-        uses: browser-actions/setup-edge@v1
-        with:
-          edge-version: stable
-        id: setup-edge
-      - name: Install Firefox for set binary test
-        if: matrix.os != 'windows-latest'
-        uses: browser-actions/setup-firefox@v1
-        with:
-          firefox-version: latest
-        id: setup-firefox
-      - name: Set ENV Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $env:GITHUB_ENV
-          echo "EDGE_BIN=C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" >> $env:GITHUB_ENV
-          echo "FF_BIN=C:\Program Files (x86)\Mozilla Firefox\firefox-browser.exe" >> $env:GITHUB_ENV
-      - name: Set ENV Mac
-        if: matrix.os == 'macos-latest'
-        run: |
-          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-          echo "EDGE_BIN=/Users/runner/hostedtoolcache/msedge/stable/x64/Contents/MacOS/Microsoft Edge" >> "$GITHUB_ENV"
-          echo "FF_BIN=/Users/runner/hostedtoolcache/firefox/latest/x64/Contents/MacOS/firefox" >> "$GITHUB_ENV"
-      - name: Set ENV Linux
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
-          echo "EDGE_BIN=/opt/hostedtoolcache/msedge/stable/x64/msedge" >> "$GITHUB_ENV"
-          echo "FF_BIN=/opt/hostedtoolcache/firefox/latest/x64/firefox" >> "$GITHUB_ENV"
       - name: Remove driver directories Windows
-        if: matrix.os == 'windows'
+        if: matrix.os == 'windows-latest'
         run: |
           rm "$env:ChromeWebDriver" -r -v
           rm "$env:EdgeWebDriver" -r -v
           rm "$env:GeckoWebDriver" -r -v
       - name: Remove driver directories Non-Windows
-        if: matrix.os != 'windows'
+        if: matrix.os != 'windows-latest'
         run: |
           sudo rm -rf $CHROMEWEBDRIVER $EDGEWEBDRIVER $GECKOWEBDRIVER
       - name: Start Xvfb

--- a/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs
@@ -171,9 +171,14 @@ namespace SeleniumDocs.Browsers
             return _logLocation;
         }
 
-        private string GetChromeLocation()
+        private static string GetChromeLocation()
         {
-            return Environment.GetEnvironmentVariable("CHROME_BIN");
+            var options = new ChromeOptions
+            {
+                BrowserVersion = "stable"
+            };
+            DriverFinder.FullPath(options);
+            return options.BinaryLocation;
         }
     }
 }

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -171,9 +171,14 @@ namespace SeleniumDocs.Browsers
             return _logLocation;
         }
 
-        private string GetEdgeLocation()
+        private static string GetEdgeLocation()
         {
-            return Environment.GetEnvironmentVariable("EDGE_BIN");
+            var options = new EdgeOptions
+            {
+                BrowserVersion = "stable"
+            };
+            DriverFinder.FullPath(options);
+            return options.BinaryLocation;
         }
     }
 }

--- a/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs
@@ -195,9 +195,14 @@ namespace SeleniumDocs.Browsers
             driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(2);
         }
 
-        private string GetFirefoxLocation()
+        private static string GetFirefoxLocation()
         {
-            return Environment.GetEnvironmentVariable("FF_BIN");
+            var options = new FirefoxOptions()
+            {
+                BrowserVersion = "stable"
+            };
+            DriverFinder.FullPath(options);
+            return options.BinaryLocation;
         }
     }
 }

--- a/examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs
+++ b/examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs
@@ -21,9 +21,10 @@ namespace SeleniumDocs.Drivers
         [TestMethod]
         public void DriverLocation()
         {
-            var service = ChromeDriverService.CreateDefaultService(GetDriverLocation());
+            var options = GetLatestChromeOptions();
+            var service = ChromeDriverService.CreateDefaultService(GetDriverLocation(options));
 
-            driver = new ChromeDriver(service);
+            driver = new ChromeDriver(service, options);
         }
 
         [TestMethod]
@@ -35,9 +36,17 @@ namespace SeleniumDocs.Drivers
             driver = new ChromeDriver(service);
         }
         
-        private string GetDriverLocation()
+        private static string GetDriverLocation(ChromeOptions options)
         {
-            return DriverFinder.FullPath(new ChromeOptions());
+            return DriverFinder.FullPath(options);
+        }
+
+        private static ChromeOptions GetLatestChromeOptions()
+        {
+            return new ChromeOptions
+            {
+                BrowserVersion = "stable"
+            };
         }
     }
 }

--- a/examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs
+++ b/examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs
@@ -51,9 +51,9 @@ namespace SeleniumDocs.Waits
         {
             driver.Url = "https://www.selenium.dev/selenium/web/dynamic.html";
             IWebElement revealed = driver.FindElement(By.Id("revealed"));
-            WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(2));
-
             driver.FindElement(By.Id("reveal")).Click();
+
+            WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(2));
             wait.Until(d => revealed.Displayed);
 
             revealed.SendKeys("Displayed");
@@ -65,13 +65,14 @@ namespace SeleniumDocs.Waits
         {
             driver.Url = "https://www.selenium.dev/selenium/web/dynamic.html";
             IWebElement revealed = driver.FindElement(By.Id("revealed"));
+            driver.FindElement(By.Id("reveal")).Click();
+
             WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(2))
             {
                 PollingInterval = TimeSpan.FromMilliseconds(300),
             };
             wait.IgnoreExceptionTypes(typeof(ElementNotInteractableException));
 
-            driver.FindElement(By.Id("reveal")).Click();
             wait.Until(d => {
                 revealed.SendKeys("Displayed");
                 return true;

--- a/examples/java/src/test/java/dev/selenium/BaseChromeTest.java
+++ b/examples/java/src/test/java/dev/selenium/BaseChromeTest.java
@@ -1,15 +1,11 @@
 package dev.selenium;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.openqa.selenium.chrome.ChromeDriver;
 
 public class BaseChromeTest extends BaseTest {
 
-    @BeforeEach
-    public void setup() {
-        System.setProperty("webdriver.chrome.logfile", "chromedriver.log");
-        System.setProperty("webdriver.chrome.verboseLogging", "true");
-        driver = new ChromeDriver();
-    }
-
+  @BeforeEach
+  public void setup() {
+    startChromeDriver();
+  }
 }

--- a/examples/java/src/test/java/dev/selenium/BaseFirefoxTest.java
+++ b/examples/java/src/test/java/dev/selenium/BaseFirefoxTest.java
@@ -1,13 +1,11 @@
 package dev.selenium;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.openqa.selenium.firefox.FirefoxDriver;
 
 public class BaseFirefoxTest extends BaseTest {
 
-    @BeforeEach
-    public void setup() {
-        driver = new FirefoxDriver();
-    }
-
+  @BeforeEach
+  public void setup() {
+    startFirefoxDriver();
+  }
 }

--- a/examples/java/src/test/java/dev/selenium/BaseTest.java
+++ b/examples/java/src/test/java/dev/selenium/BaseTest.java
@@ -1,28 +1,79 @@
 package dev.selenium;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.time.Duration;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.GeckoDriverService;
-import org.openqa.selenium.remote.service.DriverService;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class BaseTest {
-    protected WebDriver driver;
-    protected WebDriverWait wait;
+  protected WebDriver driver;
+  protected WebDriverWait wait;
+  protected File driverPath;
+  protected File browserPath;
 
-    public WebElement getLocatedElement(WebDriver driver, By by) {
-        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(5));
-        return wait.until(d -> driver.findElement(by));
-    }
+  public WebElement getLocatedElement(WebDriver driver, By by) {
+    WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(5));
+    return wait.until(d -> driver.findElement(by));
+  }
 
-    @AfterEach
-    public void quit() {
-        if (driver != null) {
-            driver.quit();
-        }
+  protected FirefoxDriver startFirefoxDriver() {
+    return startFirefoxDriver(new FirefoxOptions());
+  }
+
+  protected FirefoxDriver startFirefoxDriver(FirefoxOptions options) {
+    options.setImplicitWaitTimeout(Duration.ofSeconds(1));
+    driver = new FirefoxDriver(options);
+    return (FirefoxDriver) driver;
+  }
+
+  protected ChromeDriver startChromeDriver() {
+    ChromeOptions options = new ChromeOptions();
+    options.setImplicitWaitTimeout(Duration.ofSeconds(1));
+    return startChromeDriver(options);
+  }
+
+  protected ChromeDriver startChromeDriver(ChromeOptions options) {
+    driver = new ChromeDriver(options);
+    return (ChromeDriver) driver;
+  }
+
+  protected File getTempDirectory(String prefix)  {
+    File tempDirectory = null;
+    try {
+      tempDirectory = Files.createTempDirectory(prefix).toFile();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
+    tempDirectory.deleteOnExit();
+
+    return tempDirectory;
+  }
+
+  protected File getTempFile(String prefix, String suffix) {
+    File logLocation = null;
+    try {
+      logLocation = File.createTempFile(prefix, suffix);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    logLocation.deleteOnExit();
+
+    return logLocation;
+  }
+
+  @AfterEach
+  public void quit() {
+    if (driver != null) {
+      driver.quit();
+    }
+  }
 }

--- a/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java
+++ b/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java
@@ -3,14 +3,22 @@ package dev.selenium.bidirectional.chrome_devtools;
 import com.google.common.collect.ImmutableMap;
 import dev.selenium.BaseTest;
 import java.time.Duration;
-import java.util.*;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Cookie;
+import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.devtools.DevTools;
@@ -62,6 +70,7 @@ public class CdpApiTest extends BaseTest {
   }
 
   @Test
+  @Disabled("4.15 broke the casting")
   public void performanceMetrics() {
     driver.get("https://www.selenium.dev/selenium/web/frameset.html");
 
@@ -108,15 +117,14 @@ public class CdpApiTest extends BaseTest {
 
     CopyOnWriteArrayList<String> logs = new CopyOnWriteArrayList<>();
     devTools.addListener(
-            Runtime.consoleAPICalled(),
-            event -> logs.add((String) event.getArgs().get(0).getValue().orElse("")));
+        Runtime.consoleAPICalled(),
+        event -> logs.add((String) event.getArgs().get(0).getValue().orElse("")));
 
     driver.findElement(By.id("consoleLog")).click();
 
     wait.until(_d -> !logs.isEmpty());
     Assertions.assertEquals("Hello, world!", logs.get(0));
   }
-
 
   @Test
   public void jsErrors() {

--- a/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
@@ -1,11 +1,19 @@
 package dev.selenium.browsers;
 
-import com.google.common.collect.ImmutableList;
+import dev.selenium.BaseTest;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Pdf;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
@@ -14,192 +22,163 @@ import org.openqa.selenium.chromium.ChromiumDriverLogLevel;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogType;
 import org.openqa.selenium.logging.LoggingPreferences;
-import org.openqa.selenium.print.PrintOptions;
+import org.openqa.selenium.manager.SeleniumManagerOutput;
+import org.openqa.selenium.remote.service.DriverFinder;
 
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Base64;
-import java.util.logging.Level;
-import java.util.regex.Pattern;
+public class ChromeTest extends BaseTest {
+  @AfterEach
+  public void clearProperties() {
+    System.clearProperty(ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY);
+    System.clearProperty(ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY);
+  }
 
-public class ChromeTest {
-    private ChromeDriver driver;
-    private File logLocation;
+  @Test
+  public void basicOptions() {
+    ChromeOptions options = new ChromeOptions();
+    driver = new ChromeDriver(options);
+  }
 
-    @AfterEach
-    public void quit() {
-        if (logLocation != null && logLocation.exists()) {
-            logLocation.delete();
-        }
-        System.clearProperty(ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY);
-        System.clearProperty(ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY);
+  @Test
+  public void arguments() {
+    ChromeOptions options = new ChromeOptions();
 
-        driver.quit();
-    }
+    options.addArguments("--start-maximized");
 
-    @Test
-    public void basicOptions() throws IOException {
-        ChromeOptions options = new ChromeOptions();
-//        options.setExperimentalOption("perfLoggingPrefs", ImmutableMap.of("enableNetwork", true));
-        LoggingPreferences logPrefs = new LoggingPreferences();
-        logPrefs.enable(LogType.BROWSER, Level.ALL);
-        logPrefs.enable(LogType.PERFORMANCE, Level.ALL);
-        options.setCapability(ChromeOptions.LOGGING_PREFS, logPrefs);
+    driver = new ChromeDriver(options);
+  }
 
-        driver = new ChromeDriver(options);
-        driver.get("https://www.selenium.dev");
-        driver.manage().logs().get(LogType.PERFORMANCE).forEach(System.out::println);
+  @Test
+  public void setBrowserLocation() {
+    ChromeOptions options = new ChromeOptions();
 
-        String content = driver.print(new PrintOptions()).getContent();
-        byte[] bytes = Base64.getDecoder().decode(content);
-        Files.write(Paths.get("printed.pdf"), bytes);
-    }
+    options.setBinary(getChromeLocation());
 
-    @Test
-    public void arguments() {
-        ChromeOptions options = new ChromeOptions();
+    driver = new ChromeDriver(options);
+  }
 
-        options.addArguments("--start-maximized");
+  @Test
+  public void extensionOptions() {
+    ChromeOptions options = new ChromeOptions();
+    Path path = Paths.get("src/test/resources/extensions/webextensions-selenium-example.crx");
+    File extensionFilePath = new File(path.toUri());
 
-        driver = new ChromeDriver(options);
-    }
+    options.addExtensions(extensionFilePath);
 
-    @Test
-    public void setBrowserLocation() {
-        ChromeOptions options = new ChromeOptions();
+    driver = new ChromeDriver(options);
+    driver.get("https://www.selenium.dev/selenium/web/blank.html");
+    WebElement injected = driver.findElement(By.id("webextensions-selenium-example"));
+    Assertions.assertEquals(
+        "Content injected by webextensions-selenium-example", injected.getText());
+  }
 
-        options.setBinary(getChromeLocation());
+  @Test
+  public void excludeSwitches() {
+    ChromeOptions options = new ChromeOptions();
 
-        driver = new ChromeDriver(options);
-    }
+    options.setExperimentalOption("excludeSwitches", List.of("disable-popup-blocking"));
 
-    @Test
-    public void extensionOptions() {
-        ChromeOptions options = new ChromeOptions();
-        Path path = Paths.get("src/test/resources/extensions/webextensions-selenium-example.crx");
-        File extensionPath = new File(path.toUri());
+    driver = new ChromeDriver(options);
+  }
 
-        options.addExtensions(extensionPath);
+  @Test
+  public void loggingPreferences() {
+    ChromeOptions options = new ChromeOptions();
+    LoggingPreferences logPrefs = new LoggingPreferences();
+    logPrefs.enable(LogType.PERFORMANCE, Level.ALL);
+    options.setCapability(ChromeOptions.LOGGING_PREFS, logPrefs);
 
-        driver = new ChromeDriver(options);
-        driver.get("https://www.selenium.dev/selenium/web/blank.html");
-        WebElement injected = driver.findElement(By.id("webextensions-selenium-example"));
-        Assertions.assertEquals("Content injected by webextensions-selenium-example", injected.getText());
-    }
+    driver = new ChromeDriver(options);
+    driver.get("https://www.selenium.dev");
 
-    @Test
-    public void excludeSwitches() {
-        ChromeOptions options = new ChromeOptions();
+    LogEntries logEntries = driver.manage().logs().get(LogType.PERFORMANCE);
+    Assertions.assertFalse(logEntries.getAll().isEmpty());
+  }
 
-        options.setExperimentalOption("excludeSwitches", ImmutableList.of("disable-popup-blocking"));
+  @Test
+  public void logsToFile() throws IOException {
+    File logLocation = getTempFile("logsToFile", ".log");
+    ChromeDriverService service =
+        new ChromeDriverService.Builder().withLogFile(logLocation).build();
 
-        driver = new ChromeDriver(options);
-    }
+    driver = new ChromeDriver(service);
 
-    @Test
-    public void loggingPreferences() {
-        ChromeOptions options = new ChromeOptions();
-        LoggingPreferences logPrefs = new LoggingPreferences();
-        logPrefs.enable(LogType.PERFORMANCE, Level.ALL);
-        options.setCapability(ChromeOptions.LOGGING_PREFS, logPrefs);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    Assertions.assertTrue(fileContent.contains("Starting ChromeDriver"));
+  }
 
-        driver = new ChromeDriver(options);
-        driver.get("https://www.selenium.dev");
+  @Test
+  public void logsToConsole() throws IOException {
+    File logLocation = getTempFile("logsToConsole", ".log");
+    System.setOut(new PrintStream(logLocation));
 
-        LogEntries logEntries = driver.manage().logs().get(LogType.PERFORMANCE);
-        Assertions.assertFalse(logEntries.getAll().isEmpty());
-    }
+    ChromeDriverService service =
+        new ChromeDriverService.Builder().withLogOutput(System.out).build();
 
-    @Test
-    public void logsToFile() throws IOException {
-        ChromeDriverService service = new ChromeDriverService.Builder()
-                .withLogFile(getLogLocation())
-                .build();
+    driver = new ChromeDriver(service);
 
-        driver = new ChromeDriver(service);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    Assertions.assertTrue(fileContent.contains("Starting ChromeDriver"));
+  }
 
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        Assertions.assertTrue(fileContent.contains("Starting ChromeDriver"));
-    }
+  @Test
+  public void logsWithLevel() throws IOException {
+    File logLocation = getTempFile("logsWithLevel", ".log");
+    System.setProperty(
+        ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY, logLocation.getAbsolutePath());
 
-    @Test
-    public void logsToConsole() throws IOException {
-        System.setOut(new PrintStream(getLogLocation()));
+    ChromeDriverService service =
+        new ChromeDriverService.Builder().withLogLevel(ChromiumDriverLogLevel.DEBUG).build();
 
-        ChromeDriverService service = new ChromeDriverService.Builder()
-                .withLogOutput(System.out)
-                .build();
+    driver = new ChromeDriver(service);
 
-        driver = new ChromeDriver(service);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    Assertions.assertTrue(fileContent.contains("[DEBUG]:"));
+  }
 
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        Assertions.assertTrue(fileContent.contains("Starting ChromeDriver"));
-    }
+  @Test
+  public void configureDriverLogs() throws IOException {
+    File logLocation = getTempFile("configureDriverLogs", ".log");
+    System.setProperty(
+        ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY, logLocation.getAbsolutePath());
+    System.setProperty(
+        ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY,
+        ChromiumDriverLogLevel.DEBUG.toString());
 
-    @Test
-    public void logsWithLevel() throws IOException {
-        System.setProperty(ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY,
-                getLogLocation().getAbsolutePath());
+    ChromeDriverService service =
+        new ChromeDriverService.Builder().withAppendLog(true).withReadableTimestamp(true).build();
 
-        ChromeDriverService service = new ChromeDriverService.Builder()
-            .withLogLevel(ChromiumDriverLogLevel.DEBUG)
-            .build();
+    driver = new ChromeDriver(service);
 
-        driver = new ChromeDriver(service);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    Pattern pattern = Pattern.compile("\\[\\d\\d-\\d\\d-\\d\\d\\d\\d", Pattern.CASE_INSENSITIVE);
+    Assertions.assertTrue(pattern.matcher(fileContent).find());
+  }
 
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        Assertions.assertTrue(fileContent.contains("[DEBUG]:"));
-    }
+  @Test
+  public void disableBuildChecks() throws IOException {
+    File logLocation = getTempFile("disableBuildChecks", ".log");
+    System.setProperty(
+        ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY, logLocation.getAbsolutePath());
+    System.setProperty(
+        ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY,
+        ChromiumDriverLogLevel.WARNING.toString());
 
-    @Test
-    public void configureDriverLogs() throws IOException {
-        System.setProperty(ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY,
-                getLogLocation().getAbsolutePath());
-        System.setProperty(ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY,
-                ChromiumDriverLogLevel.DEBUG.toString());
+    ChromeDriverService service =
+        new ChromeDriverService.Builder().withBuildCheckDisabled(true).build();
 
-        ChromeDriverService service = new ChromeDriverService.Builder()
-            .withAppendLog(true)
-            .withReadableTimestamp(true)
-            .build();
+    driver = new ChromeDriver(service);
 
-        driver = new ChromeDriver(service);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    String expected =
+        "[WARNING]: You are using an unsupported command-line switch: --disable-build-check";
+    Assertions.assertTrue(fileContent.contains(expected));
+  }
 
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        Pattern pattern = Pattern.compile("\\[\\d\\d-\\d\\d-\\d\\d\\d\\d", Pattern.CASE_INSENSITIVE);
-        Assertions.assertTrue(pattern.matcher(fileContent).find());
-    }
-
-    @Test
-    public void disableBuildChecks() throws IOException {
-        System.setProperty(ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY,
-                getLogLocation().getAbsolutePath());
-        System.setProperty(ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY,
-                ChromiumDriverLogLevel.WARNING.toString());
-
-        ChromeDriverService service = new ChromeDriverService.Builder()
-                .withBuildCheckDisabled(true)
-                .build();
-
-        driver = new ChromeDriver(service);
-
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        String expected = "[WARNING]: You are using an unsupported command-line switch: --disable-build-check";
-        Assertions.assertTrue(fileContent.contains(expected));
-    }
-
-    private File getLogLocation() throws IOException {
-        if (logLocation == null || !logLocation.exists()) {
-            logLocation = File.createTempFile("chromedriver-", ".log");
-        }
-
-        return logLocation;
-    }
-
-    private File getChromeLocation() {
-        File location = new File(System.getenv("CHROME_BIN"));
-        return location.exists() ? location : null;
-    }
+  private File getChromeLocation() {
+    ChromeOptions options = new ChromeOptions();
+    options.setBrowserVersion("stable");
+    SeleniumManagerOutput.Result output =
+        DriverFinder.getPath(ChromeDriverService.createDefaultService(), options);
+    return new File(output.getBrowserPath());
+  }
 }

--- a/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java
@@ -1,6 +1,12 @@
 package dev.selenium.browsers;
 
 import dev.selenium.BaseTest;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -8,189 +14,159 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.*;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Duration;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
+import org.openqa.selenium.firefox.FirefoxDriverService;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.firefox.GeckoDriverService;
+import org.openqa.selenium.manager.SeleniumManagerOutput;
+import org.openqa.selenium.remote.service.DriverFinder;
 
 public class FirefoxTest extends BaseTest {
-    private FirefoxDriver driver;
-    private File logLocation;
-    private File tempDirectory;
+  private FirefoxDriver driver;
 
-    @AfterEach
-    public void quit() {
-        if (logLocation != null && logLocation.exists()) {
-            logLocation.delete();
-        }
-        if (tempDirectory  != null && tempDirectory.exists()) {
-            tempDirectory.delete();
-        }
-        System.clearProperty(GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY);
-        System.clearProperty(GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY);
+  @AfterEach
+  public void clearProperties() {
+    System.clearProperty(GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY);
+    System.clearProperty(GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY);
+  }
 
-        driver.quit();
-    }
+  @Test
+  public void basicOptions() {
+    FirefoxOptions options = new FirefoxOptions();
+    driver = new FirefoxDriver(options);
+  }
 
-    @Test
-    public void basicOptions() {
-        FirefoxOptions options = new FirefoxOptions();
-        driver = new FirefoxDriver(options);
-    }
+  @Test
+  public void arguments() {
+    FirefoxOptions options = new FirefoxOptions();
 
-    @Test
-    public void arguments() {
-        FirefoxOptions options = new FirefoxOptions();
+    options.addArguments("-headless");
 
-        options.addArguments("-headless");
+    driver = new FirefoxDriver(options);
+  }
 
-        driver = new FirefoxDriver(options);
-    }
+  @Test
+  @DisabledOnOs(OS.WINDOWS)
+  public void setBrowserLocation() {
+    FirefoxOptions options = new FirefoxOptions();
 
-    @Test
-    @DisabledOnOs(OS.WINDOWS)
-    public void setBrowserLocation() {
-        FirefoxOptions options = new FirefoxOptions();
+    options.setBinary(getFirefoxLocation());
 
-        options.setBinary(getFirefoxLocation());
+    driver = new FirefoxDriver(options);
+  }
 
-        driver = new FirefoxDriver(options);
-    }
+  @Test
+  public void logsToFile() throws IOException {
+    File logLocation = getTempFile("logsToFile", ".log");
+    FirefoxDriverService service =
+        new GeckoDriverService.Builder().withLogFile(logLocation).build();
 
-    @Test
-    public void logsToFile() throws IOException {
-        FirefoxDriverService service = new GeckoDriverService.Builder()
-                .withLogFile(getLogLocation())
-                .build();
+    driver = new FirefoxDriver(service);
 
-        driver = new FirefoxDriver(service);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    Assertions.assertTrue(fileContent.contains("geckodriver	INFO	Listening on"));
+  }
 
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        Assertions.assertTrue(fileContent.contains("geckodriver	INFO	Listening on"));
-    }
+  @Test
+  public void logsToConsole() throws IOException {
+    File logLocation = getTempFile("logsToConsole", ".log");
+    System.setOut(new PrintStream(logLocation));
 
-    @Test
-    public void logsToConsole() throws IOException {
-        System.setOut(new PrintStream(getLogLocation()));
+    FirefoxDriverService service =
+        new GeckoDriverService.Builder().withLogOutput(System.out).build();
 
-        FirefoxDriverService service = new GeckoDriverService.Builder()
-                .withLogOutput(System.out)
-                .build();
+    driver = new FirefoxDriver(service);
 
-        driver = new FirefoxDriver(service);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    Assertions.assertTrue(fileContent.contains("geckodriver	INFO	Listening on"));
+  }
 
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        Assertions.assertTrue(fileContent.contains("geckodriver	INFO	Listening on"));
-    }
+  @Test
+  public void logsWithLevel() throws IOException {
+    File logLocation = getTempFile("logsWithLevel", ".log");
+    System.setProperty(GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY, logLocation.getAbsolutePath());
 
-    @Test
-    public void logsWithLevel() throws IOException {
-        System.setProperty(GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY,
-                getLogLocation().getAbsolutePath());
+    FirefoxDriverService service =
+        new GeckoDriverService.Builder().withLogLevel(FirefoxDriverLogLevel.DEBUG).build();
 
-        FirefoxDriverService service = new GeckoDriverService.Builder()
-                .withLogLevel(FirefoxDriverLogLevel.DEBUG)
-                .build();
+    driver = new FirefoxDriver(service);
 
-        driver = new FirefoxDriver(service);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    Assertions.assertTrue(fileContent.contains("Marionette\tDEBUG"));
+  }
 
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        Assertions.assertTrue(fileContent.contains("Marionette\tDEBUG"));
-    }
+  @Test
+  public void stopsTruncatingLogs() throws IOException {
+    File logLocation = getTempFile("geckodriver-", "log");
+    System.setProperty(GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY, logLocation.getAbsolutePath());
+    System.setProperty(
+        GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY, FirefoxDriverLogLevel.DEBUG.toString());
 
-    @Test
-    public void stopsTruncatingLogs() throws IOException {
-        System.setProperty(GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY,
-                getLogLocation().getAbsolutePath());
-        System.setProperty(GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY,
-                FirefoxDriverLogLevel.DEBUG.toString());
+    FirefoxDriverService service =
+        new GeckoDriverService.Builder().withTruncatedLogs(false).build();
 
-        FirefoxDriverService service = new GeckoDriverService.Builder()
-                .withTruncatedLogs(false)
-                .build();
+    driver = new FirefoxDriver(service);
 
-        driver = new FirefoxDriver(service);
+    String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
+    Assertions.assertFalse(fileContent.contains(" ... "));
+  }
 
-        String fileContent = new String(Files.readAllBytes(getLogLocation().toPath()));
-        Assertions.assertFalse(fileContent.contains(" ... "));
-    }
+  @Test
+  public void setProfileLocation() {
+    File profileDirectory = getTempDirectory("profile-");
+    FirefoxDriverService service =
+        new GeckoDriverService.Builder().withProfileRoot(profileDirectory).build();
 
-    @Test
-    public void setProfileLocation() throws IOException {
-        FirefoxDriverService service = new GeckoDriverService.Builder()
-                .withProfileRoot(getTempDirectory())
-                .build();
+    driver = new FirefoxDriver(service);
 
-        driver = new FirefoxDriver(service);
+    String location = (String) driver.getCapabilities().getCapability("moz:profile");
+    Assertions.assertTrue(location.contains(profileDirectory.getAbsolutePath()));
+  }
 
-        String location = (String) driver.getCapabilities().getCapability("moz:profile");
-        Assertions.assertTrue(location.contains(getTempDirectory().getAbsolutePath()));
-    }
+  @Test
+  public void installAddon() {
+    driver = startFirefoxDriver();
+    Path xpiPath = Paths.get("src/test/resources/extensions/selenium-example.xpi");
 
-    @Test
-    public void installAddon() {
-        driver = startDriver();
-        Path xpiPath = Paths.get("src/test/resources/extensions/selenium-example.xpi");
+    driver.installExtension(xpiPath);
 
-        driver.installExtension(xpiPath);
+    driver.get("https://www.selenium.dev/selenium/web/blank.html");
+    WebElement injected = driver.findElement(By.id("webextensions-selenium-example"));
+    Assertions.assertEquals(
+        "Content injected by webextensions-selenium-example", injected.getText());
+  }
 
-        driver.get("https://www.selenium.dev/selenium/web/blank.html");
-        WebElement injected = driver.findElement(By.id("webextensions-selenium-example"));
-        Assertions.assertEquals("Content injected by webextensions-selenium-example", injected.getText());
-    }
+  @Test
+  public void uninstallAddon() {
+    driver = startFirefoxDriver();
+    Path xpiPath = Paths.get("src/test/resources/extensions/selenium-example.xpi");
+    String id = driver.installExtension(xpiPath);
 
-    @Test
-    public void uninstallAddon() {
-        driver = startDriver();
-        Path xpiPath = Paths.get("src/test/resources/extensions/selenium-example.xpi");
-        String id = driver.installExtension(xpiPath);
+    driver.uninstallExtension(id);
 
-        driver.uninstallExtension(id);
+    driver.get("https://www.selenium.dev/selenium/web/blank.html");
+    Assertions.assertEquals(driver.findElements(By.id("webextensions-selenium-example")).size(), 0);
+  }
 
-        driver.get("https://www.selenium.dev/selenium/web/blank.html");
-        Assertions.assertEquals(driver.findElements(By.id("webextensions-selenium-example")).size(), 0);
-    }
+  @Test
+  public void installUnsignedAddonPath() {
+    driver = startFirefoxDriver();
+    Path path = Paths.get("src/test/resources/extensions/selenium-example");
 
-    @Test
-    public void installUnsignedAddonPath() {
-        driver = startDriver();
-        Path path = Paths.get("src/test/resources/extensions/selenium-example");
+    driver.installExtension(path, true);
 
-        driver.installExtension(path, true);
+    driver.get("https://www.selenium.dev/selenium/web/blank.html");
+    WebElement injected = getLocatedElement(driver, By.id("webextensions-selenium-example"));
+    Assertions.assertEquals(
+        "Content injected by webextensions-selenium-example", injected.getText());
+  }
 
-        driver.get("https://www.selenium.dev/selenium/web/blank.html");
-        WebElement injected = getLocatedElement(driver, By.id("webextensions-selenium-example"));
-        Assertions.assertEquals("Content injected by webextensions-selenium-example", injected.getText());
-    }
-
-    private File getLogLocation() throws IOException {
-        if (logLocation == null || !logLocation.exists()) {
-            logLocation = File.createTempFile("geckodriver-", ".log");
-        }
-
-        return logLocation;
-    }
-
-    private File getTempDirectory() throws IOException {
-        if (tempDirectory == null || !tempDirectory.exists()) {
-            tempDirectory = Files.createTempDirectory("profile-").toFile();
-        }
-        
-        return tempDirectory;
-    }
-
-    private FirefoxDriver startDriver() {
-        FirefoxOptions options = new FirefoxOptions();
-        options.setImplicitWaitTimeout(Duration.ofSeconds(1));
-        return new FirefoxDriver(options);
-    }
-
-    private String getFirefoxLocation() {
-        return System.getenv("FF_BIN");
-    }
+  private Path getFirefoxLocation() {
+    FirefoxOptions options = new FirefoxOptions();
+    options.setBrowserVersion("stable");
+    SeleniumManagerOutput.Result output =
+        DriverFinder.getPath(GeckoDriverService.createDefaultService(), options);
+    return Path.of(output.getBrowserPath());
+  }
 }

--- a/examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java
+++ b/examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java
@@ -1,7 +1,7 @@
 package dev.selenium.drivers;
 
 import dev.selenium.BaseTest;
-import org.junit.jupiter.api.AfterEach;
+import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
@@ -9,41 +9,38 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.manager.SeleniumManagerOutput;
 import org.openqa.selenium.remote.service.DriverFinder;
 
-import java.io.File;
-
 public class ServiceTest extends BaseTest {
-    public File getDriverLocation() {
-        SeleniumManagerOutput.Result location = DriverFinder.getPath(ChromeDriverService.createDefaultService(), new ChromeOptions());
-        return new File(location.getDriverPath());
-    }
+  @Test
+  public void defaultService() {
+    ChromeDriverService service = new ChromeDriverService.Builder().build();
+    driver = new ChromeDriver(service);
+  }
 
-    @AfterEach
-    public void quit() {
-        driver.quit();
-    }
+  @Test
+  public void setDriverLocation() {
+    setBinaryPaths();
+    ChromeOptions options = new ChromeOptions();
+    options.setBinary(browserPath);
 
-    @Test
-    public void defaultService() {
-        ChromeDriverService service = new ChromeDriverService.Builder()
-                .build();
-        driver = new ChromeDriver(service);
-    }
+    ChromeDriverService service =
+        new ChromeDriverService.Builder().usingDriverExecutable(driverPath).build();
 
-    @Test
-    public void setDriverLocation() {
-        ChromeDriverService service = new ChromeDriverService.Builder()
-                .usingDriverExecutable(getDriverLocation())
-                .build();
+    driver = new ChromeDriver(service, options);
+  }
 
-        driver = new ChromeDriver(service);
-    }
+  @Test
+  public void setPort() {
+    ChromeDriverService service = new ChromeDriverService.Builder().usingPort(1234).build();
 
-    @Test
-    public void setPort() {
-        ChromeDriverService service = new ChromeDriverService.Builder()
-                .usingPort(1234)
-                .build();
+    driver = new ChromeDriver(service);
+  }
 
-        driver = new ChromeDriver(service);
-    }
+  private void setBinaryPaths() {
+    ChromeOptions options = new ChromeOptions();
+    options.setBrowserVersion("stable");
+    SeleniumManagerOutput.Result location =
+        DriverFinder.getPath(ChromeDriverService.createDefaultService(), options);
+    driverPath = new File(location.getDriverPath());
+    browserPath = new File(location.getBrowserPath());
+  }
 }

--- a/examples/java/src/test/java/dev/selenium/waits/WaitsTest.java
+++ b/examples/java/src/test/java/dev/selenium/waits/WaitsTest.java
@@ -1,84 +1,96 @@
 package dev.selenium.waits;
 
-import dev.selenium.BaseChromeTest;
+import dev.selenium.BaseTest;
+import java.time.Duration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementNotInteractableException;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.Wait;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.time.Duration;
+public class WaitsTest extends BaseTest {
+  @Test
+  public void fails() {
+    startChromeDriver(new ChromeOptions());
 
-public class WaitsTest extends BaseChromeTest {
-    @Test
-    public void fails() {
-        driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
-        driver.findElement(By.id("adder")).click();
+    driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
+    driver.findElement(By.id("adder")).click();
 
-        Assertions.assertThrows(NoSuchElementException.class, () -> {
-            driver.findElement(By.id("box0"));
+    Assertions.assertThrows(
+        NoSuchElementException.class,
+        () -> {
+          driver.findElement(By.id("box0"));
         });
-    }
+  }
 
-    @Test
-    public void sleep() throws InterruptedException {
-        driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
-        driver.findElement(By.id("adder")).click();
+  @Test
+  public void sleep() throws InterruptedException {
+    startChromeDriver(new ChromeOptions());
 
-        Thread.sleep(1000);
+    driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
+    driver.findElement(By.id("adder")).click();
 
-        WebElement added = driver.findElement(By.id("box0"));
+    Thread.sleep(1000);
 
-        Assertions.assertEquals("redbox", added.getDomAttribute("class"));
-    }
+    WebElement added = driver.findElement(By.id("box0"));
 
-    @Test
-    public void implicit() {
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(2));
-        driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
-        driver.findElement(By.id("adder")).click();
+    Assertions.assertEquals("redbox", added.getDomAttribute("class"));
+  }
 
-        WebElement added = driver.findElement(By.id("box0"));
+  @Test
+  public void implicit() {
+    startChromeDriver(new ChromeOptions());
 
-        Assertions.assertEquals("redbox", added.getDomAttribute("class"));
-    }
+    driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(2));
+    driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
+    driver.findElement(By.id("adder")).click();
 
-    @Test
-    public void explicit() {
-        driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
-        WebElement revealed = driver.findElement(By.id("revealed"));
-        Wait<WebDriver> wait = new WebDriverWait(driver, Duration.ofSeconds(2));
+    WebElement added = driver.findElement(By.id("box0"));
 
-        driver.findElement(By.id("reveal")).click();
-        wait.until(d -> revealed.isDisplayed());
+    Assertions.assertEquals("redbox", added.getDomAttribute("class"));
+  }
 
-        revealed.sendKeys("Displayed");
-        Assertions.assertEquals("Displayed", revealed.getDomProperty("value"));
-    }
+  @Test
+  public void explicit() {
+    startChromeDriver(new ChromeOptions());
 
-    @Test
-    public void explicitWithOptions() {
-        driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
-        WebElement revealed = driver.findElement(By.id("revealed"));
-        Wait<WebDriver> wait = new FluentWait<>(driver)
-                .withTimeout(Duration.ofSeconds(2))
-                .pollingEvery(Duration.ofMillis(300))
-                .ignoring(ElementNotInteractableException.class);
+    driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
+    WebElement revealed = driver.findElement(By.id("revealed"));
+    driver.findElement(By.id("reveal")).click();
 
-        driver.findElement(By.id("reveal")).click();
-        wait.until(d -> {
-            revealed.sendKeys("Displayed");
-            return true;
+    Wait<WebDriver> wait = new WebDriverWait(driver, Duration.ofSeconds(2));
+    wait.until(d -> revealed.isDisplayed());
+
+    revealed.sendKeys("Displayed");
+    Assertions.assertEquals("Displayed", revealed.getDomProperty("value"));
+  }
+
+  @Test
+  public void explicitWithOptions() {
+    startChromeDriver(new ChromeOptions());
+
+    driver.get("https://www.selenium.dev/selenium/web/dynamic.html");
+    WebElement revealed = driver.findElement(By.id("revealed"));
+    driver.findElement(By.id("reveal")).click();
+
+    Wait<WebDriver> wait =
+        new FluentWait<>(driver)
+            .withTimeout(Duration.ofSeconds(2))
+            .pollingEvery(Duration.ofMillis(300))
+            .ignoring(ElementNotInteractableException.class);
+
+    wait.until(
+        d -> {
+          revealed.sendKeys("Displayed");
+          return true;
         });
 
-        Assertions.assertEquals("Displayed", revealed.getDomProperty("value"));
-    }
+    Assertions.assertEquals("Displayed", revealed.getDomProperty("value"));
+  }
 }

--- a/examples/python/tests/browsers/test_chrome.py
+++ b/examples/python/tests/browsers/test_chrome.py
@@ -4,8 +4,6 @@ import subprocess
 
 from selenium import webdriver
 
-CHROME_LOCATION = os.getenv("CHROME_BIN")
-
 
 def test_basic_options():
     options = webdriver.ChromeOptions()
@@ -25,10 +23,10 @@ def test_args():
     driver.quit()
 
 
-def test_set_browser_location():
+def test_set_browser_location(chrome_bin):
     options = webdriver.ChromeOptions()
 
-    options.binary_location = CHROME_LOCATION
+    options.binary_location = chrome_bin
 
     driver = webdriver.Chrome(options=options)
 
@@ -37,9 +35,9 @@ def test_set_browser_location():
 
 def test_add_extension():
     options = webdriver.ChromeOptions()
-    path = os.path.abspath("tests/extensions/webextensions-selenium-example.crx")
+    extension_file_path = os.path.abspath("tests/extensions/webextensions-selenium-example.crx")
 
-    options.add_extension(path)
+    options.add_extension(extension_file_path)
 
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/selenium/web/blank.html")

--- a/examples/python/tests/browsers/test_edge.py
+++ b/examples/python/tests/browsers/test_edge.py
@@ -2,10 +2,7 @@ import os
 import re
 import subprocess
 
-import pytest
 from selenium import webdriver
-
-EDGE_LOCATION = os.getenv("EDGE_BIN")
 
 
 def test_basic_options():
@@ -26,10 +23,10 @@ def test_args():
     driver.quit()
 
 
-def test_set_browser_location():
+def test_set_browser_location(edge_bin):
     options = webdriver.EdgeOptions()
 
-    options.binary_location = EDGE_LOCATION
+    options.binary_location = edge_bin
 
     driver = webdriver.Edge(options=options)
 
@@ -38,9 +35,9 @@ def test_set_browser_location():
 
 def test_add_extension():
     options = webdriver.EdgeOptions()
-    path = os.path.abspath("tests/extensions/webextensions-selenium-example.crx")
+    extension_file_path = os.path.abspath("tests/extensions/webextensions-selenium-example.crx")
 
-    options.add_extension(path)
+    options.add_extension(extension_file_path)
 
     driver = webdriver.Edge(options=options)
     driver.get("https://www.selenium.dev/selenium/web/blank.html")
@@ -50,6 +47,7 @@ def test_add_extension():
 
 def test_keep_browser_open():
     options = webdriver.EdgeOptions()
+
     options.add_experimental_option("detach", True)
 
     driver = webdriver.Edge(options=options)
@@ -60,6 +58,7 @@ def test_keep_browser_open():
 
 def test_exclude_switches():
     options = webdriver.EdgeOptions()
+
     options.add_experimental_option('excludeSwitches', ['disable-popup-blocking'])
 
     driver = webdriver.Edge(options=options)
@@ -79,7 +78,6 @@ def test_log_to_file(log_path):
     driver.quit()
 
 
-@pytest.mark.skip(reason="this is not supported, yet")
 def test_log_to_stdout(capfd):
     service = webdriver.EdgeService(log_output=subprocess.STDOUT)
 
@@ -108,7 +106,7 @@ def test_log_features(log_path):
     driver = webdriver.Edge(service=service)
 
     with open(log_path, 'r') as f:
-        assert re.match("\[\d\d-\d\d-\d\d\d\d", f.read())
+        assert re.match(r"\[\d\d-\d\d-\d\d\d\d", f.read())
 
     driver.quit()
 

--- a/examples/python/tests/browsers/test_firefox.py
+++ b/examples/python/tests/browsers/test_firefox.py
@@ -5,8 +5,6 @@ import sys
 import pytest
 from selenium import webdriver
 
-FIREFOX_LOCATION = os.getenv("FF_BIN")
-
 
 def test_basic_options():
     options = webdriver.FirefoxOptions()
@@ -24,10 +22,10 @@ def test_arguments():
     driver.quit()
 
 
-def test_set_browser_location():
+def test_set_browser_location(firefox_bin):
     options = webdriver.FirefoxOptions()
 
-    options.binary_location = FIREFOX_LOCATION
+    options.binary_location = firefox_bin
 
     driver = webdriver.Firefox(options=options)
 

--- a/examples/python/tests/browsers/test_internet_explorer.py
+++ b/examples/python/tests/browsers/test_internet_explorer.py
@@ -5,14 +5,12 @@ import sys
 import pytest
 from selenium import webdriver
 
-EDGE_LOCATION = os.getenv("EDGE_BIN")
-
 
 @pytest.mark.skipif(sys.platform != "win32", reason="requires Windows")
-def test_basic_options_win10():
+def test_basic_options_win10(edge_bin):
     options = webdriver.IeOptions()
     options.attach_to_edge_chrome = True
-    options.edge_executable_path = EDGE_LOCATION
+    options.edge_executable_path = edge_bin
     driver = webdriver.Ie(options=options)
 
     driver.quit()

--- a/examples/python/tests/conftest.py
+++ b/examples/python/tests/conftest.py
@@ -17,10 +17,38 @@ def driver():
 
 
 @pytest.fixture(scope='function')
-def chromedriver_path():
+def chromedriver_bin():
     service = webdriver.chrome.service.Service()
     options = webdriver.ChromeOptions()
-    return webdriver.common.driver_finder.DriverFinder().get_path(service=service, options=options)
+    options.browser_version = 'stable'
+    yield webdriver.common.driver_finder.DriverFinder().get_path(service=service, options=options)
+
+
+@pytest.fixture(scope='function')
+def chrome_bin():
+    service = webdriver.chrome.service.Service()
+    options = webdriver.ChromeOptions()
+    options.browser_version = 'stable'
+    webdriver.common.driver_finder.DriverFinder().get_path(service=service, options=options)
+    yield options.binary_location
+
+
+@pytest.fixture(scope='function')
+def edge_bin():
+    service = webdriver.edge.service.Service()
+    options = webdriver.EdgeOptions()
+    options.browser_version = 'stable'
+    webdriver.common.driver_finder.DriverFinder().get_path(service=service, options=options)
+    yield options.binary_location
+
+
+@pytest.fixture(scope='function')
+def firefox_bin():
+    service = webdriver.firefox.service.Service()
+    options = webdriver.FirefoxOptions()
+    options.browser_version = 'stable'
+    webdriver.common.driver_finder.DriverFinder().get_path(service=service, options=options)
+    yield options.binary_location
 
 
 @pytest.fixture(scope='function')

--- a/examples/python/tests/drivers/test_service.py
+++ b/examples/python/tests/drivers/test_service.py
@@ -8,10 +8,13 @@ def test_basic_service():
     driver.quit()
 
 
-def test_driver_location(chromedriver_path):
-    service = webdriver.ChromeService(executable_path=chromedriver_path)
+def test_driver_location(chromedriver_bin, chrome_bin):
+    options = webdriver.ChromeOptions()
+    options.binary_location = chrome_bin
 
-    driver = webdriver.Chrome(service=service)
+    service = webdriver.ChromeService(executable_path=chromedriver_bin)
+
+    driver = webdriver.Chrome(service=service, options=options)
 
     driver.quit()
 

--- a/examples/python/tests/waits/test_waits.py
+++ b/examples/python/tests/waits/test_waits.py
@@ -36,9 +36,9 @@ def test_implicit(driver):
 def test_explicit(driver):
     driver.get('https://www.selenium.dev/selenium/web/dynamic.html')
     revealed = driver.find_element(By.ID, "revealed")
-    wait = WebDriverWait(driver, timeout=2)
-
     driver.find_element(By.ID, "reveal").click()
+
+    wait = WebDriverWait(driver, timeout=2)
     wait.until(lambda d : revealed.is_displayed())
 
     revealed.send_keys("Displayed")
@@ -48,10 +48,10 @@ def test_explicit(driver):
 def test_explicit_options(driver):
     driver.get('https://www.selenium.dev/selenium/web/dynamic.html')
     revealed = driver.find_element(By.ID, "revealed")
+    driver.find_element(By.ID, "reveal").click()
+
     errors = [NoSuchElementException, ElementNotInteractableException]
     wait = WebDriverWait(driver, timeout=2, poll_frequency=.2, ignored_exceptions=errors)
-
-    driver.find_element(By.ID, "reveal").click()
     wait.until(lambda d : revealed.send_keys("Displayed") or True)
 
     assert revealed.get_property("value") == "Displayed"

--- a/examples/ruby/spec/browsers/chrome_spec.rb
+++ b/examples/ruby/spec/browsers/chrome_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'Chrome' do
   describe 'Options' do
-    let(:chrome_location) { ENV.fetch('CHROME_BIN', nil) }
+    let(:chrome_location) { driver_finder && ENV.fetch('CHROME_BIN', nil) }
 
     it 'basic options' do
       options = Selenium::WebDriver::Options.chrome
@@ -14,7 +14,7 @@ RSpec.describe 'Chrome' do
     it 'add arguments' do
       options = Selenium::WebDriver::Options.chrome
 
-      options.args << '--maximize'
+      options.args << '--start-maximized'
 
       @driver = Selenium::WebDriver.for :chrome, options: options
     end
@@ -50,7 +50,7 @@ RSpec.describe 'Chrome' do
     it 'excludes switches' do
       options = Selenium::WebDriver::Options.chrome
 
-      options.exclude_switches << 'enable-automation'
+      options.exclude_switches << 'disable-popup-blocking'
 
       @driver = Selenium::WebDriver.for :chrome, options: options
     end
@@ -111,5 +111,11 @@ RSpec.describe 'Chrome' do
       warning = /\[WARNING\]: You are using an unsupported command-line switch: --disable-build-check/
       expect(File.readlines(file_name).grep(warning).any?).to eq true
     end
+  end
+
+  def driver_finder
+    options = Selenium::WebDriver::Options.chrome(browser_version: 'stable')
+    ENV['CHROMEDRIVER_BIN'] = Selenium::WebDriver::DriverFinder.path(options, Selenium::WebDriver::Chrome::Service)
+    ENV['CHROME_BIN'] = options.binary
   end
 end

--- a/examples/ruby/spec/browsers/edge_spec.rb
+++ b/examples/ruby/spec/browsers/edge_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'Edge' do
   describe 'Options' do
-    let(:edge_location) { ENV.fetch('EDGE_BIN', nil) }
+    let(:edge_location) { driver_finder && ENV.fetch('EDGE_BIN', nil) }
 
     it 'basic options' do
       options = Selenium::WebDriver::Options.edge
@@ -14,7 +14,7 @@ RSpec.describe 'Edge' do
     it 'add arguments' do
       options = Selenium::WebDriver::Options.edge
 
-      options.args << '--maximize'
+      options.args << '--start-maximized'
 
       @driver = Selenium::WebDriver.for :edge, options: options
     end
@@ -50,7 +50,7 @@ RSpec.describe 'Edge' do
     it 'excludes switches' do
       options = Selenium::WebDriver::Options.edge
 
-      options.exclude_switches << 'enable-automation'
+      options.exclude_switches << 'disable-popup-blocking'
 
       @driver = Selenium::WebDriver.for :edge, options: options
     end
@@ -111,5 +111,11 @@ RSpec.describe 'Edge' do
       warning = /\[WARNING\]: You are using an unsupported command-line switch: --disable-build-check/
       expect(File.readlines(file_name).grep(warning).any?).to eq true
     end
+  end
+
+  def driver_finder
+    options = Selenium::WebDriver::Options.edge(browser_version: 'stable')
+    ENV['EDGEDRIVER_BIN'] = Selenium::WebDriver::DriverFinder.path(options, Selenium::WebDriver::Edge::Service)
+    ENV['EDGE_BIN'] = options.binary
   end
 end

--- a/examples/ruby/spec/browsers/firefox_spec.rb
+++ b/examples/ruby/spec/browsers/firefox_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'Firefox' do
   describe 'Options' do
-    let(:firefox_location) { ENV.fetch('FF_BIN', nil) }
+    let(:firefox_location) { driver_finder && ENV.fetch('FIREFOX_BIN', nil) }
 
     it 'basic options' do
       options = Selenium::WebDriver::Options.firefox
@@ -118,5 +118,11 @@ RSpec.describe 'Firefox' do
       injected = driver.find_element(id: 'webextensions-selenium-example')
       expect(injected.text).to eq 'Content injected by webextensions-selenium-example'
     end
+  end
+
+  def driver_finder
+    options = Selenium::WebDriver::Options.firefox(browser_version: 'stable')
+    ENV['GECKODRIVER_BIN'] = Selenium::WebDriver::DriverFinder.path(options, Selenium::WebDriver::Firefox::Service)
+    ENV['FIREFOX_BIN'] = options.binary
   end
 end

--- a/examples/ruby/spec/drivers/service_spec.rb
+++ b/examples/ruby/spec/drivers/service_spec.rb
@@ -4,8 +4,10 @@ require 'spec_helper'
 
 RSpec.describe 'Service' do
   let(:file_name) { File.expand_path('driver.log') }
-  let(:driver_path) { "#{ENV.fetch('CHROMEWEBDRIVER', nil)}/chromedriver" }
+  let(:driver_path) { ENV.fetch('CHROMEDRIVER_BIN', nil) }
+  let(:browser_path) { ENV.fetch('CHROME_BIN', nil) }
 
+  before { driver_finder }
   after { FileUtils.rm_f(file_name) }
 
   it 'has default service' do
@@ -14,10 +16,12 @@ RSpec.describe 'Service' do
   end
 
   it 'specifies driver location' do
+    options = Selenium::WebDriver::Options.chrome(binary: browser_path)
     service = Selenium::WebDriver::Service.chrome
+
     service.executable_path = driver_path
 
-    @driver = Selenium::WebDriver.for :chrome, service: service
+    @driver = Selenium::WebDriver.for :chrome, service: service, options: options
   end
 
   it 'specifies driver port' do
@@ -25,5 +29,11 @@ RSpec.describe 'Service' do
     service.port = 1234
 
     @driver = Selenium::WebDriver.for :chrome, service: service
+  end
+
+  def driver_finder
+    options = Selenium::WebDriver::Options.chrome(browser_version: 'stable')
+    ENV['CHROMEDRIVER_BIN'] = Selenium::WebDriver::DriverFinder.path(options, Selenium::WebDriver::Chrome::Service)
+    ENV['CHROME_BIN'] = options.binary
   end
 end

--- a/examples/ruby/spec/spec_helper.rb
+++ b/examples/ruby/spec/spec_helper.rb
@@ -15,12 +15,6 @@ RSpec.configure do |config|
   end
 
   config.before do |example|
-    unless ENV.fetch('CHROMEWEBDRIVER', nil)
-      chromedriver = Selenium::WebDriver::DriverFinder.path(Selenium::WebDriver::Options.chrome,
-                                                            Selenium::WebDriver::Chrome::Service)
-      ENV['CHROMEWEBDRIVER'] = File.dirname chromedriver
-    end
-
     bug_tracker = 'https://gigithub.com/SeleniumHQ/seleniumhq.github.io/issues'
     guards = Selenium::WebDriver::Support::Guards.new(example,
                                                       bug_tracker: bug_tracker)

--- a/examples/ruby/spec/waits/waits_spec.rb
+++ b/examples/ruby/spec/waits/waits_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe 'Waits' do
   it 'explicit' do
     driver.get 'https://www.selenium.dev/selenium/web/dynamic.html'
     revealed = driver.find_element(id: 'revealed')
-    wait = Selenium::WebDriver::Wait.new
-
     driver.find_element(id: 'reveal').click
+
+    wait = Selenium::WebDriver::Wait.new
     wait.until { revealed.displayed? }
 
     revealed.send_keys('Displayed')
@@ -49,13 +49,14 @@ RSpec.describe 'Waits' do
   it 'options with explicit' do
     driver.get 'https://www.selenium.dev/selenium/web/dynamic.html'
     revealed = driver.find_element(id: 'revealed')
+    driver.find_element(id: 'reveal').click
+
     errors = [Selenium::WebDriver::Error::NoSuchElementError,
               Selenium::WebDriver::Error::ElementNotInteractableError]
     wait = Selenium::WebDriver::Wait.new(timeout: 2,
                                          interval: 0.3,
                                          ignore: errors)
 
-    driver.find_element(id: 'reveal').click
     wait.until { revealed.send_keys('Displayed') || true }
 
     expect(revealed.property(:value)).to eq('Displayed')

--- a/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools/cdp_api.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools/cdp_api.en.md
@@ -31,7 +31,7 @@ An alternate implementation can be found at [CDP Endpoint Set Cookie]({{< ref "c
 {{% tab header="Java" %}}
 Because Java requires using all the parameters example, the Map approach used in
 [CDP Endpoint Set Cookie]({{< ref "cdp_endpoint#set-cookie" >}}) might be more simple.
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L39-L57" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L47-L65" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -60,7 +60,7 @@ An alternate implementation can be found at [CDP Endpoint Performance Metrics]({
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L68-L72" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L77-L81" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -92,7 +92,7 @@ and [BiDi API Basic Authentication]({{< ref "bidi_api#basic-authentication" >}})
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 The [BiDi API Basic Authentication]({{< ref "bidi_api#basic-authentication" >}}) implementation should be preferred
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L85-L92" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L94-L101" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -127,7 +127,7 @@ and [WebDriver BiDi Console logs]({{< ref "../webdriver_bidi/log#console-logs" >
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 Use the [WebDriver BiDi Console logs]({{< ref "../webdriver_bidi/log#console-logs" >}}) implementation
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L105-L112" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L114-L121" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Use the [BiDi API Console logs and errors]({{< ref "bidi_api#console-logs-and-errors" >}}) implementation
@@ -159,7 +159,7 @@ and [WebDriver BiDi JavaScript exceptions]({{< ref "../webdriver_bidi/log#javasc
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 Use the [WebDriver BiDi JavaScript exceptions]({{< ref "../webdriver_bidi/log#javascript-exceptions" >}}) implementation
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L125-L130" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L133-L138" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Use the [BiDi API JavaScript exceptions]({{< ref "bidi_api#javascript-exceptions" >}}) implementation
@@ -188,7 +188,7 @@ Because getting download status requires setting a listener, this cannot be done
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L142-L154" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L150-L162" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools/cdp_api.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools/cdp_api.ja.md
@@ -31,7 +31,7 @@ An alternate implementation can be found at [CDP Endpoint Set Cookie]({{< ref "c
 {{% tab header="Java" %}}
 Because Java requires using all the parameters example, the Map approach used in
 [CDP Endpoint Set Cookie]({{< ref "cdp_endpoint#set-cookie" >}}) might be more simple.
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L39-L57" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L47-L65" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -60,7 +60,7 @@ An alternate implementation can be found at [CDP Endpoint Performance Metrics]({
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L68-L72" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L77-L81" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -92,7 +92,7 @@ and [BiDi API Basic Authentication]({{< ref "bidi_api#basic-authentication" >}})
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 The [BiDi API Basic Authentication]({{< ref "bidi_api#basic-authentication" >}}) implementation should be preferred
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L85-L92" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L94-L101" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -127,7 +127,7 @@ and [WebDriver BiDi Console logs]({{< ref "../webdriver_bidi/log#console-logs" >
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 Use the [WebDriver BiDi Console logs]({{< ref "../webdriver_bidi/log#console-logs" >}}) implementation
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L105-L112" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L114-L121" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Use the [BiDi API Console logs and errors]({{< ref "bidi_api#console-logs-and-errors" >}}) implementation
@@ -159,7 +159,7 @@ and [WebDriver BiDi JavaScript exceptions]({{< ref "../webdriver_bidi/log#javasc
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 Use the [WebDriver BiDi JavaScript exceptions]({{< ref "../webdriver_bidi/log#javascript-exceptions" >}}) implementation
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L125-L130" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L133-L138" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Use the [BiDi API JavaScript exceptions]({{< ref "bidi_api#javascript-exceptions" >}}) implementation
@@ -188,7 +188,7 @@ Because getting download status requires setting a listener, this cannot be done
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L142-L154" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L150-L162" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools/cdp_api.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools/cdp_api.pt-br.md
@@ -31,7 +31,7 @@ An alternate implementation can be found at [CDP Endpoint Set Cookie]({{< ref "c
 {{% tab header="Java" %}}
 Because Java requires using all the parameters example, the Map approach used in
 [CDP Endpoint Set Cookie]({{< ref "cdp_endpoint#set-cookie" >}}) might be more simple.
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L39-L57" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L47-L65" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -60,7 +60,7 @@ An alternate implementation can be found at [CDP Endpoint Performance Metrics]({
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L68-L72" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L77-L81" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -92,7 +92,7 @@ and [BiDi API Basic Authentication]({{< ref "bidi_api#basic-authentication" >}})
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 The [BiDi API Basic Authentication]({{< ref "bidi_api#basic-authentication" >}}) implementation should be preferred
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L85-L92" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L94-L101" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -127,7 +127,7 @@ and [WebDriver BiDi Console logs]({{< ref "../webdriver_bidi/log#console-logs" >
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 Use the [WebDriver BiDi Console logs]({{< ref "../webdriver_bidi/log#console-logs" >}}) implementation
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L105-L112" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L114-L121" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Use the [BiDi API Console logs and errors]({{< ref "bidi_api#console-logs-and-errors" >}}) implementation
@@ -159,7 +159,7 @@ and [WebDriver BiDi JavaScript exceptions]({{< ref "../webdriver_bidi/log#javasc
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 Use the [WebDriver BiDi JavaScript exceptions]({{< ref "../webdriver_bidi/log#javascript-exceptions" >}}) implementation
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L125-L130" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L133-L138" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Use the [BiDi API JavaScript exceptions]({{< ref "bidi_api#javascript-exceptions" >}}) implementation
@@ -188,7 +188,7 @@ Because getting download status requires setting a listener, this cannot be done
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L142-L154" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L150-L162" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools/cdp_api.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidirectional/chrome_devtools/cdp_api.zh-cn.md
@@ -31,7 +31,7 @@ An alternate implementation can be found at [CDP Endpoint Set Cookie]({{< ref "c
 {{% tab header="Java" %}}
 Because Java requires using all the parameters example, the Map approach used in
 [CDP Endpoint Set Cookie]({{< ref "cdp_endpoint#set-cookie" >}}) might be more simple.
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L39-L57" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L47-L65" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -60,7 +60,7 @@ An alternate implementation can be found at [CDP Endpoint Performance Metrics]({
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L68-L72" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L77-L81" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -92,7 +92,7 @@ and [BiDi API Basic Authentication]({{< ref "bidi_api#basic-authentication" >}})
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 The [BiDi API Basic Authentication]({{< ref "bidi_api#basic-authentication" >}}) implementation should be preferred
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L85-L92" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L94-L101" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Because Python requires using async methods for this example, the synchronous approach found in
@@ -127,7 +127,7 @@ and [WebDriver BiDi Console logs]({{< ref "../webdriver_bidi/log#console-logs" >
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 Use the [WebDriver BiDi Console logs]({{< ref "../webdriver_bidi/log#console-logs" >}}) implementation
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L105-L112" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L114-L121" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Use the [BiDi API Console logs and errors]({{< ref "bidi_api#console-logs-and-errors" >}}) implementation
@@ -159,7 +159,7 @@ and [WebDriver BiDi JavaScript exceptions]({{< ref "../webdriver_bidi/log#javasc
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 Use the [WebDriver BiDi JavaScript exceptions]({{< ref "../webdriver_bidi/log#javascript-exceptions" >}}) implementation
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L125-L130" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L133-L138" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 Use the [BiDi API JavaScript exceptions]({{< ref "bidi_api#javascript-exceptions" >}}) implementation
@@ -188,7 +188,7 @@ Because getting download status requires setting a listener, this cannot be done
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L142-L154" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/chrome_devtools/CdpApiTest.java#L150-L162" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
@@ -23,10 +23,10 @@ Starting a Chrome session with basic defined options looks like this:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L39-L40" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L37-L38" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L11-L12" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L9-L10" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L30-L31" >}}
@@ -55,10 +55,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L47" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L45" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L20" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L18" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L39" >}}
@@ -83,10 +83,10 @@ Add a browser location to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L56" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#31">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L29">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L49" >}}
@@ -112,10 +112,10 @@ Add an extension to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L67" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L65" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L42">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L40">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L61" >}}
@@ -141,7 +141,7 @@ so long as the quit command is not sent to the driver.
 **Note**: This is already the default behavior in Java. 
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L53" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L51" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 **Note**: This is already the default behavior in .NET.
@@ -169,10 +169,10 @@ Set excluded arguments on options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L79" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L78" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L64" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L62" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L76" >}}
@@ -205,14 +205,14 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L87" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L100-L101" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L73" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L71" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L86" >}}
@@ -236,14 +236,14 @@ To change the logging output to display in the console as STDOUT:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L101" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L114-L115" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L84" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L82" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -269,14 +269,14 @@ so this example is just setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L116" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L129-L130" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `ChromiumDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L95" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L93" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -304,13 +304,13 @@ The log output will be managed by the driver, not the process, so minor differen
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L133-L134" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L147-L148" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `ChromeDriverService.CHROME_DRIVER_APPEND_LOG_PROPERTY` and `ChromeDriverService.CHROME_DRIVER_READABLE_TIMESTAMP`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L106" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L104" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -336,14 +336,14 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L152" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L166-L167" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_DISABLE_BUILD_CHECK`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L117" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L155" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
@@ -22,10 +22,10 @@ Chrome に固有のCapabilityは、Google の[Capabilities & ChromeOptions](http
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L39-L40" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L37-L38" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L11-L12" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L9-L10" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L30-L31" >}}
@@ -56,10 +56,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L47" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L45" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L20" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L18" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L39" >}}
@@ -84,10 +84,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L56" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L31">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L29">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L49" >}}
@@ -115,10 +115,10 @@ please use the `load-extension` argument instead, as mentioned in
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L67" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L65" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L42">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L40">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L61" >}}
@@ -143,7 +143,7 @@ please use the `load-extension` argument instead, as mentioned in
 **Note**: This is already the default behavior in Java.
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L53" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L51" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 **Note**: This is already the default behavior in .NET.
@@ -173,10 +173,10 @@ can be parsed from the
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L79" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L78" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L64" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L62" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L76" >}}
@@ -209,14 +209,14 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L87" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L100-L101" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L73" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L71" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L86" >}}
@@ -240,14 +240,14 @@ To change the logging output to display in the console as STDOUT:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L101" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L114-L115" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L84" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L82" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -273,14 +273,14 @@ so this example is just setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L116" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L129-L130" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `ChromiumDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L95" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L93" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -308,13 +308,13 @@ The log output will be managed by the driver, not the process, so minor differen
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L133-L134" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L147-L148" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `ChromeDriverService.CHROME_DRIVER_APPEND_LOG_PROPERTY` and `ChromeDriverService.CHROME_DRIVER_READABLE_TIMESTAMP`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L106" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L104" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -340,14 +340,14 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L152" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L166-L167" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_DISABLE_BUILD_CHECK`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L117" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L155" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
@@ -21,10 +21,10 @@ Este é um exemplo de como iniciar uma sessão Chrome com um conjunto de opçõe
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L39-L40" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L37-L38" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L11-L12" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L9-L10" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L30-L31" >}}
@@ -55,10 +55,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L47" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L45" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L20" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L18" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L39" >}}
@@ -80,10 +80,10 @@ Adicionar uma localização:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L56" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L31">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L29">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L49" >}}
@@ -111,10 +111,10 @@ Adicionar uma extensão:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L67" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L65" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L42">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L40">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L61" >}}
@@ -141,7 +141,7 @@ Adicionar detach:
 **Note**: This is already the default behavior in Java.
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L53" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L51" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 **Note**: This is already the default behavior in .NET.
@@ -170,10 +170,10 @@ Exclua parametros:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L79" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L78" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L64" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L62" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L76" >}}
@@ -206,14 +206,14 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L87" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L100-L101" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L73" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L71" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L86" >}}
@@ -237,14 +237,14 @@ To change the logging output to display in the console as STDOUT:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L101" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L114-L115" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L84" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L82" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -270,14 +270,14 @@ so this example is just setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L116" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L129-L130" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `ChromiumDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L95" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L93" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -305,13 +305,13 @@ The log output will be managed by the driver, not the process, so minor differen
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L133-L134" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L147-L148" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `ChromeDriverService.CHROME_DRIVER_APPEND_LOG_PROPERTY` and `ChromeDriverService.CHROME_DRIVER_READABLE_TIMESTAMP`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L106" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L104" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -337,14 +337,14 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L152" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L166-L167" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_DISABLE_BUILD_CHECK`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L117" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L155" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
@@ -21,10 +21,10 @@ Chrome浏览器的特有功能可以在谷歌的页面找到: [Capabilities & Ch
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L39-L40" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L37-L38" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L11-L12" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L9-L10" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L30-L31" >}}
@@ -55,10 +55,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L47" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L45" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L20" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L18" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L39" >}}
@@ -82,10 +82,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L56" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L31">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L29">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L49" >}}
@@ -111,10 +111,10 @@ please use the `load-extension` argument instead, as mentioned in
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L67" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L65" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L42">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L40">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L61" >}}
@@ -141,7 +141,7 @@ please use the `load-extension` argument instead, as mentioned in
 **Note**: This is already the default behavior in Java.
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L53" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L51" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 **Note**: This is already the default behavior in .NET.
@@ -169,10 +169,10 @@ can be parsed from the
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L79" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L78" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L64" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L62" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L76" >}}
@@ -205,14 +205,14 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L87" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L100-L101" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L73" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L71" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L86" >}}
@@ -236,14 +236,14 @@ To change the logging output to display in the console as STDOUT:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L101" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L114-L115" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L84" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L82" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -269,14 +269,14 @@ so this example is just setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L116" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L129-L130" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `ChromiumDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L95" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L93" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -304,13 +304,13 @@ The log output will be managed by the driver, not the process, so minor differen
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L133-L134" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L147-L148" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `ChromeDriverService.CHROME_DRIVER_APPEND_LOG_PROPERTY` and `ChromeDriverService.CHROME_DRIVER_READABLE_TIMESTAMP`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L106" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L104" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -336,14 +336,14 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L152" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java#L166-L167" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `ChromeDriverService.CHROME_DRIVER_DISABLE_BUILD_CHECK`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L117" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_chrome.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs#L155" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.en.md
@@ -20,10 +20,10 @@ Starting an Edge session with basic defined options looks like this:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L39-L40" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L37-L38" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L12-L13" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L9-L10" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L30-L31" >}}
@@ -52,10 +52,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L47" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L45" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L21" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L18" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L39" >}}
@@ -80,10 +80,10 @@ Add a browser location to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L56" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#32">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L29">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L49" >}}
@@ -109,10 +109,10 @@ Add an extension to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L67" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L65" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L43" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L40" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L61" >}}
@@ -138,7 +138,7 @@ so long as the quit command is not sent to the driver.
 **Note**: This is already the default behavior in Java.
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L54" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L51" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 **Note**: This is already the default behavior in .NET.
@@ -166,10 +166,10 @@ Set excluded arguments on options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L79" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L78" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L65" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L62" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L76" >}}
@@ -203,13 +203,13 @@ To change the logging output to save to a specific file:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L87" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L100" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L74" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L71" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L86" >}}
@@ -233,7 +233,7 @@ To change the logging output to display in the console as STDOUT:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L101" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L113" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
@@ -265,13 +265,13 @@ so this example is just setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L116" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L126-L127" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `ChromiumDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L97" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L93" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -299,13 +299,13 @@ The log output will be managed by the driver, not the process, so minor differen
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L133-L134" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L142-L143" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `EdgeDriverService.EDGE_DRIVER_APPEND_LOG_PROPERTY` and `EdgeDriverService.EDGE_DRIVER_READABLE_TIMESTAMP`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L108" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L104" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -331,13 +331,13 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L152" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L160-L161" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_DISABLE_BUILD_CHECK`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L119" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L155" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
@@ -22,10 +22,10 @@ Capabilities unique to Chromium are documented at Google's page for
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L39-L40" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L37-L38" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L12-L13" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L9-L10" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L30-L31" >}}
@@ -54,10 +54,10 @@ There are two excellent resources for investigating these arguments:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L47" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L45" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L21" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L18" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L39" >}}
@@ -82,10 +82,10 @@ Add a browser location to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L56" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#32">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L29">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L49" >}}
@@ -111,10 +111,10 @@ Add an extension to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L67" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L65" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L43" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L40" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L61" >}}
@@ -140,7 +140,7 @@ so long as the quit command is not sent to the driver.
 **Note**: This is already the default behavior in Java.
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L54" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L51" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 **Note**: This is already the default behavior in .NET.
@@ -168,10 +168,10 @@ Set excluded arguments on options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L79" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L78" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L65" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L62" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L76" >}}
@@ -205,13 +205,13 @@ To change the logging output to save to a specific file:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L87" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L100" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L74" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L71" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L86" >}}
@@ -235,7 +235,7 @@ To change the logging output to display in the console as STDOUT:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L101" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L113" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
@@ -267,13 +267,13 @@ so this example is just setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L116" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L126-L127" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `ChromiumDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L97" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L93" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -301,13 +301,13 @@ The log output will be managed by the driver, not the process, so minor differen
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L133-L134" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L142-L143" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `EdgeDriverService.EDGE_DRIVER_APPEND_LOG_PROPERTY` and `EdgeDriverService.EDGE_DRIVER_READABLE_TIMESTAMP`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L108" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L104" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -333,13 +333,13 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L152" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L160-L161" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_DISABLE_BUILD_CHECK`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L119" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L155" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md
@@ -22,10 +22,10 @@ Este é um exemplo de como iniciar uma sessão Edge com um conjunto de opções 
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L39-L40" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L37-L38" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L12-L13" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L9-L10" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L30-L31" >}}
@@ -54,10 +54,10 @@ Adicione uma opção:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L47" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L45" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L21" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L18" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L39" >}}
@@ -82,10 +82,10 @@ Add a browser location to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L56" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#32">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L29">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L49" >}}
@@ -111,10 +111,10 @@ Add an extension to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L67" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L65" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L43" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L40" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L61" >}}
@@ -140,7 +140,7 @@ so long as the quit command is not sent to the driver.
 **Note**: This is already the default behavior in Java.
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L54" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L51" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 **Note**: This is already the default behavior in .NET.
@@ -168,10 +168,10 @@ Set excluded arguments on options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L79" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L78" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L65" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L62" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L76" >}}
@@ -205,13 +205,13 @@ To change the logging output to save to a specific file:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L87" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L100" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L74" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L71" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L86" >}}
@@ -235,7 +235,7 @@ To change the logging output to display in the console as STDOUT:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L101" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L113" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
@@ -267,13 +267,13 @@ so this example is just setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L116" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L126-L127" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `ChromiumDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L97" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L93" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -301,13 +301,13 @@ The log output will be managed by the driver, not the process, so minor differen
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L133-L134" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L142-L143" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `EdgeDriverService.EDGE_DRIVER_APPEND_LOG_PROPERTY` and `EdgeDriverService.EDGE_DRIVER_READABLE_TIMESTAMP`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L108" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L104" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -333,13 +333,13 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L152" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L160-L161" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_DISABLE_BUILD_CHECK`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L119" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L155" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md
@@ -22,10 +22,10 @@ Capabilities unique to Chromium are documented at Google's page for
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L39-L40" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L37-L38" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L12-L13" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L9-L10" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L30-L31" >}}
@@ -54,10 +54,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L47" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L45" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L21" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L18" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L39" >}}
@@ -82,10 +82,10 @@ Add a browser location to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L56" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#32">}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L29">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L49" >}}
@@ -111,10 +111,10 @@ Add an extension to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L67" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L65" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L43" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L40" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L61" >}}
@@ -140,7 +140,7 @@ so long as the quit command is not sent to the driver.
 **Note**: This is already the default behavior in Java.
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L54" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L51" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 **Note**: This is already the default behavior in .NET.
@@ -168,10 +168,10 @@ Set excluded arguments on options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L79" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L78" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L65" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L62" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L76" >}}
@@ -205,13 +205,13 @@ To change the logging output to save to a specific file:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L87" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L100" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L74" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L71" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L86" >}}
@@ -235,7 +235,7 @@ To change the logging output to display in the console as STDOUT:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L101" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L113" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
@@ -267,13 +267,13 @@ so this example is just setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L116" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L126-L127" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `ChromiumDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L97" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L93" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -301,13 +301,13 @@ The log output will be managed by the driver, not the process, so minor differen
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L133-L134" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L142-L143" >}}
 **Note**: Java also allows toggling these features by System Property:\
 Property keys: `EdgeDriverService.EDGE_DRIVER_APPEND_LOG_PROPERTY` and `EdgeDriverService.EDGE_DRIVER_READABLE_TIMESTAMP`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L108" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L104" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -333,13 +333,13 @@ Note that this is an unsupported feature, and bugs will not be investigated.
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L152" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java#L160-L161" >}}
 **Note**: Java also allows disabling build checks by System Property:\
 Property key: `EdgeDriverService.EDGE_DRIVER_DISABLE_BUILD_CHECK`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L119" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_edge.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs#L155" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
@@ -21,10 +21,10 @@ Starting a Firefox session with basic defined options looks like this:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L42-L43" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L36-L37" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L12-L13" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L10-L11" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L34-L35" >}}
@@ -49,10 +49,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L50" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L44" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L21" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L19" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L43" >}}
@@ -77,10 +77,10 @@ Add a browser location to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L60" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L30" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L28" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L53" >}}
@@ -163,14 +163,14 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L68" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L62-L63" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L38" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -194,14 +194,14 @@ To change the logging output to display in the console:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L82" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L76-L77" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L50" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L48" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -228,14 +228,14 @@ so this examples is just for setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L97" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L90-L91" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `FirefoxDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L61" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L59" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -260,14 +260,14 @@ Firefox truncates lines by default. To turn off truncation:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L114" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L106-L107" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_NO_TRUNCATE`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L72" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L70" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -292,13 +292,13 @@ or want profiles to be created some place specific, you can change the profile r
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L126" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L118-L119" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_PROFILE_ROOT`\
 Property value: String representing path to profile root directory
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_firefox.py#L83" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_firefox.py#L81" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -335,10 +335,10 @@ A signed xpi file you would get from [Mozilla Addon page](https://addons.mozilla
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L140" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L132" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L96" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L94" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L137" >}}
@@ -360,14 +360,14 @@ Uninstalling an addon requires knowing its id. The id can be obtained from the r
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L153" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L146" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L108" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L106" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.5" >}}
-{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L151" >}}
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L152" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L106" >}}
@@ -388,10 +388,10 @@ example with a directory:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L164" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L157" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L117" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.5" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
@@ -22,10 +22,10 @@ Firefox に固有のCapabilityは、Mozilla のページの [firefoxOptions](htt
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L42-L43" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L36-L37" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L12-L13" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L10-L11" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L34-L35" >}}
@@ -52,10 +52,10 @@ Firefox に固有のCapabilityは、Mozilla のページの [firefoxOptions](htt
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L50" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L44" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L21" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L19" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L43" >}}
@@ -81,10 +81,10 @@ Firefox に固有のCapabilityは、Mozilla のページの [firefoxOptions](htt
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L60" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L30" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L28" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L53" >}}
@@ -168,14 +168,14 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L68" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L62-L63" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L38" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -199,14 +199,14 @@ To change the logging output to display in the console:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L82" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L76-L77" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L50" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L48" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -233,14 +233,14 @@ so this examples is just for setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L97" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L90-L91" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `FirefoxDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L61" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L59" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -265,14 +265,14 @@ Firefox truncates lines by default. To turn off truncation:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L114" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L106-L107" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_NO_TRUNCATE`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L72" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L70" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -297,13 +297,13 @@ or want profiles to be created some place specific, you can change the profile r
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L126" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L118-L119" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_PROFILE_ROOT`\
 Property value: String representing path to profile root directory
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_firefox.py#L83" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_firefox.py#L81" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -341,10 +341,10 @@ please refer to the
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L140" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L132" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L96" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L94" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L137" >}}
@@ -367,14 +367,14 @@ IDはアドオンインストール時の戻り値から取得できます。
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L153" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L146" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L108" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L106" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.5" >}}
-{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L151" >}}
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L152" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L106" >}}
@@ -395,10 +395,10 @@ IDはアドオンインストール時の戻り値から取得できます。
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L164" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L157" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L117" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.5" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
@@ -21,10 +21,10 @@ Este é um exemplo de como iniciar uma sessão Firefox com um conjunto de opçõ
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L42-L43" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L36-L37" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L12-L13" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L10-L11" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L34-L35" >}}
@@ -51,10 +51,10 @@ Adicione uma opção:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L50" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L44" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L21" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L19" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L43" >}}
@@ -80,10 +80,10 @@ Adicionar uma localização:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L60" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L30" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L28" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L53" >}}
@@ -167,14 +167,14 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L68" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L62-L63" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L38" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -198,14 +198,14 @@ To change the logging output to display in the console:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L82" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L76-L77" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L50" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L48" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -232,14 +232,14 @@ so this examples is just for setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L97" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L90-L91" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `FirefoxDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L61" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L59" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -264,14 +264,14 @@ Firefox truncates lines by default. To turn off truncation:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L114" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L106-L107" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_NO_TRUNCATE`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L72" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L70" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -296,13 +296,13 @@ or want profiles to be created some place specific, you can change the profile r
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L126" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L118-L119" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_PROFILE_ROOT`\
 Property value: String representing path to profile root directory
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_firefox.py#L83" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_firefox.py#L81" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -340,10 +340,10 @@ Um arquivo xpi que pode ser obtido da [página Mozilla Extras](https://addons.mo
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L140" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L132" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L96" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L94" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L137" >}}
@@ -365,14 +365,14 @@ Desinstalar uma extensão implica saber o seu id que pode ser obtido como valor 
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L153" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L146" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L108" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L106" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.5" >}}
-{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L151" >}}
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L152" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L106" >}}
@@ -393,10 +393,10 @@ uma pasta, este é um exemplo com uma pasta:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L164" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L157" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L117" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.5" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
@@ -21,10 +21,10 @@ Starting a Firefox session with basic defined options looks like this:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L42-L43" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L36-L37" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L12-L13" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L10-L11" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L34-L35" >}}
@@ -51,10 +51,10 @@ Add an argument to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L50" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L44" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L21" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L19" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L43" >}}
@@ -79,10 +79,10 @@ Add a browser location to options:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L60" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L54" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L30" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L28" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L53" >}}
@@ -166,14 +166,14 @@ To change the logging output to save to a specific file:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L68" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L62-L63" >}}
 **Note**: Java also allows setting file output by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L38" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -197,14 +197,14 @@ To change the logging output to display in the console:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L82" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L76-L77" >}}
 **Note**: Java also allows setting console output by System Property;\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_PROPERTY`\
 Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L50" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L48" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -231,14 +231,14 @@ so this examples is just for setting the log level generically:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L97" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L90-L91" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_LEVEL_PROPERTY`\
 Property value: String representation of `FirefoxDriverLogLevel` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L61" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L59" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -263,14 +263,14 @@ Firefox truncates lines by default. To turn off truncation:
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L114" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L106-L107" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_LOG_NO_TRUNCATE`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L72" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L70" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -295,13 +295,13 @@ or want profiles to be created some place specific, you can change the profile r
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
 {{< badge-version version="4.10" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L126" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L118-L119" >}}
 **Note**: Java also allows setting log level by System Property:\
 Property key: `GeckoDriverService.GECKO_DRIVER_PROFILE_ROOT`\
 Property value: String representing path to profile root directory
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_firefox.py#L83" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_firefox.py#L81" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -337,10 +337,10 @@ A signed xpi file you would get from [Mozilla Addon page](https://addons.mozilla
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L140" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L132" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L96" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L94" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L137" >}}
@@ -362,14 +362,14 @@ Uninstalling an addon requires knowing its id. The id can be obtained from the r
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L153" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L146" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L108" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L106" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.5" >}}
-{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L151" >}}
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs#L152" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L106" >}}
@@ -390,10 +390,10 @@ example with a directory:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L164" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L157" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L117" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L115" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.5" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.en.md
@@ -32,13 +32,13 @@ Starting a Microsoft Edge browser in Internet Explorer Compatibility mode with b
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#38-L41" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L13-L16" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L11-L14" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L35-L38" >}}
 {{% /tab %}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L8-L11" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L10-L13" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -62,13 +62,13 @@ So, if IE is not on the system, you only need:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#46-L47" >}}
 {{< /tab >}}
 {{% tab header="Python" text=true %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L23-L24" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L21-L22" >}}
 {{% /tab %}}
 {{% tab header="CSharp" text=true %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L44-L45" >}}
 {{% /tab %}}
 {{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L15-L16" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L17-L18" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 let driver = await new Builder()
@@ -605,7 +605,7 @@ Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L31" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L29" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -636,7 +636,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L43" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L41" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -665,7 +665,7 @@ Property key: `InternetExplorerDriverService.IE_DRIVER_LOGLEVEL_PROPERTY`\
 Property value: String representation of `InternetExplorerDriverLogLevel.DEBUG.toString()` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L55" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L53" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L85" >}}
@@ -693,7 +693,7 @@ Property value: String representing path to supporting files directory
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L67" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L65" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L98" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.ja.md
@@ -32,13 +32,13 @@ Starting a Microsoft Edge browser in Internet Explorer Compatibility mode with b
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#38-L41" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L13-L16" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L11-L14" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L35-L38" >}}
 {{% /tab %}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L8-L11" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L10-L13" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -61,13 +61,13 @@ So, if IE is not on the system, you only need:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#46-L47" >}}
 {{< /tab >}}
 {{% tab header="Python" text=true %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L23-L24" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L21-L22" >}}
 {{% /tab %}}
 {{% tab header="CSharp" text=true %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L44-L45" >}}
 {{% /tab %}}
 {{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L15-L16" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L17-L18" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 let driver = await new Builder()
@@ -593,7 +593,7 @@ Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L31" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L29" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -624,7 +624,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L43" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L41" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -653,7 +653,7 @@ Property key: `InternetExplorerDriverService.IE_DRIVER_LOGLEVEL_PROPERTY`\
 Property value: String representation of `InternetExplorerDriverLogLevel.DEBUG.toString()` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L55" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L53" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L85" >}}
@@ -681,7 +681,7 @@ Property value: String representing path to supporting files directory
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L67" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L65" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L98" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.pt-br.md
@@ -32,13 +32,13 @@ usando um conjunto de opções básicas:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#38-L41" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L13-L16" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L11-L14" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L35-L38" >}}
 {{% /tab %}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L8-L11" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L10-L13" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -62,13 +62,13 @@ So, if IE is not on the system, you only need:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#46-L47" >}}
 {{< /tab >}}
 {{% tab header="Python" text=true %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L23-L24" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L21-L22" >}}
 {{% /tab %}}
 {{% tab header="CSharp" text=true %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L44-L45" >}}
 {{% /tab %}}
 {{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L15-L16" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L17-L18" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 let driver = await new Builder()
@@ -610,7 +610,7 @@ Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L31" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L29" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -641,7 +641,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L43" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L41" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -670,7 +670,7 @@ Property key: `InternetExplorerDriverService.IE_DRIVER_LOGLEVEL_PROPERTY`\
 Property value: String representation of `InternetExplorerDriverLogLevel.DEBUG.toString()` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L55" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L53" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L85" >}}
@@ -698,7 +698,7 @@ Property value: String representing path to supporting files directory
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L67" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L65" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L98" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/internet_explorer.zh-cn.md
@@ -32,13 +32,13 @@ Starting a Microsoft Edge browser in Internet Explorer Compatibility mode with b
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#38-L41" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L13-L16" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L11-L14" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L35-L38" >}}
 {{% /tab %}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L8-L11" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L10-L13" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -61,13 +61,13 @@ So, if IE is not on the system, you only need:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/InternetExplorerTest.java#46-L47" >}}
 {{< /tab >}}
 {{% tab header="Python" text=true %}}
-{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L23-L24" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_internet_explorer.py#L21-L22" >}}
 {{% /tab %}}
 {{% tab header="CSharp" text=true %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L44-L45" >}}
 {{% /tab %}}
 {{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L15-L16" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/internet_explorer_spec.rb#L17-L18" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 let driver = await new Builder()
@@ -603,7 +603,7 @@ Property key: `InternetExplorerDriverService.IE_DRIVER_LOGFILE_PROPERTY`\
 Property value: String representing path to log file
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L31" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L29" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -634,7 +634,7 @@ Property value: `DriverService.LOG_STDOUT` or `DriverService.LOG_STDERR`
 {{% /tab %}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L43" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L41" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-implementation >}}
@@ -663,7 +663,7 @@ Property key: `InternetExplorerDriverService.IE_DRIVER_LOGLEVEL_PROPERTY`\
 Property value: String representation of `InternetExplorerDriverLogLevel.DEBUG.toString()` enum
 {{% /tab %}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L55" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L53" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L85" >}}
@@ -691,7 +691,7 @@ Property value: String representing path to supporting files directory
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L67" >}}
+{{< gh-codeblock path="examples/python/tests/browsers/test_internet_explorer.py#L65" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs#L98" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/service.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/service.en.md
@@ -18,7 +18,7 @@ To start a driver with a default service instance:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{% tab header="Java" %}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L34-L36" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L15-L16" >}}
 **Note**: Java Service classes only allow values to be set during construction with a Builder pattern.
 {{% /tab %}}
 {{% tab header="Python" %}}
@@ -31,7 +31,7 @@ To start a driver with a default service instance:
 **Note**: .NET Service classes allow values to be set as properties.
 {{% /tab %}}
 {{% tab header="Ruby" %}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L12-L13" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L14-L15" >}}
 **Note**: Ruby Service classes allow values to be set either as arguments in the constructor or as attributes.
 {{% /tab %}}
 {{< tab header="JavaScript" >}}
@@ -49,19 +49,19 @@ If you cannot update Selenium or have an advanced use case, here is how to speci
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L35" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L25-L26" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L12" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L15" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.9" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L24" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L25" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L18" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L22" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -77,18 +77,18 @@ If you want the driver to run on a specific port, you may specify it as follows:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L44" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L33" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L20" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L23" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L33" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L34" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L25" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L29" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/service.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/service.ja.md
@@ -18,7 +18,7 @@ To start a driver with a default service instance:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L34-L36" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L15-L16" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
@@ -28,7 +28,7 @@ To start a driver with a default service instance:
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L17-L18" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L12-L13" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L14-L15" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -45,19 +45,19 @@ If you can not update Selenium or have an advanced use case here is how to speci
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L35" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L25-L26" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L12" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L15" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.9" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L24" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L25" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L18" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L22" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -73,18 +73,18 @@ If you want the driver to run on a specific port, you may specify it as follows:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L44" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L33" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L20" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L23" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L33" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L34" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L25" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L29" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/service.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/service.pt-br.md
@@ -18,7 +18,7 @@ To start a driver with a default service instance:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L34-L36" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L15-L16" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
@@ -28,7 +28,7 @@ To start a driver with a default service instance:
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L17-L18" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L12-L13" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L14-L15" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -45,19 +45,19 @@ If you can not update Selenium or have an advanced use case here is how to speci
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L35" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L25-L26" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L12" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L15" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.9" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L24" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L25" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L18" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L22" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -73,18 +73,18 @@ If you want the driver to run on a specific port, you may specify it as follows:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L44" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L33" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L20" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L23" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L33" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L34" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L25" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L29" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/service.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/service.zh-cn.md
@@ -18,7 +18,7 @@ To start a driver with a default service instance:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L34-L36" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L15-L16" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
@@ -28,7 +28,7 @@ To start a driver with a default service instance:
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L17-L18" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L12-L13" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L14-L15" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -45,19 +45,19 @@ If you can not update Selenium or have an advanced use case here is how to speci
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L35" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L25-L26" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L12" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L15" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.9" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L24" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L25" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L18" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L22" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -73,18 +73,18 @@ If you want the driver to run on a specific port, you may specify it as follows:
 
 {{< tabpane text=true langEqualsHeader=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L44" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java#L33" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.11" >}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L20" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_service.py#L23" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L33" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs#L34" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-version version="4.8" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L25" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L29" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -67,16 +67,16 @@ Solving our example with an implicit wait looks like this:
 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L45-L49" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L50" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27-L31" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39-L44" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28-L32" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 {{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L37-L41" >}}
@@ -100,18 +100,18 @@ Another nice feature is that, by default, the Selenium Wait class automatically 
   {{% tab header="Java" %}}
 This example shows the condition being waited for as a _lambda_. Java also supports
 [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L67-L68" >}}
   {{% /tab %}}
   {{% tab header="Python" %}}
 This example shows the condition being waited for as a _lambda_. Python also supports
 [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L41-L42" >}}
   {{% /tab %}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L53-L59" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L56-L57" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L42-L43" >}}
   {{< /tab >}}
   {{% tab header="JavaScript" %}}
 JavaScript also supports [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
@@ -139,16 +139,16 @@ make sure that the code returns `true` when it is successful):
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
 The easiest way to customize Waits in Java is to use the `FluentWait` class:
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L70-L80" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L82-L92" >}}
   {{% /tab %}}
   {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L50-L55" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L53-L55" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L67-L78" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L70-L79" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L51-L59" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L54-L60" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -67,16 +67,16 @@ Solving our example with an implicit wait looks like this:
 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L45-L49" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L50" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27-L31" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39-L44" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28-L32" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 {{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L37-L41" >}}
@@ -100,18 +100,18 @@ Another nice feature is that, by default, the Selenium Wait class automatically 
   {{% tab header="Java" %}}
 This example shows the condition being waited for as a _lambda_. Java also supports
 [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L67-L68" >}}
   {{% /tab %}}
   {{% tab header="Python" %}}
 This example shows the condition being waited for as a _lambda_. Python also supports
 [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L41-L42" >}}
   {{% /tab %}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L53-L59" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L56-L57" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L42-L43" >}}
   {{< /tab >}}
   {{% tab header="JavaScript" %}}
 JavaScript also supports [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
@@ -139,16 +139,16 @@ make sure that the code returns `true` when it is successful):
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
 The easiest way to customize Waits in Java is to use the `FluentWait` class:
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L70-L80" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L82-L92" >}}
   {{% /tab %}}
   {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L50-L55" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L53-L55" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L67-L78" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L70-L79" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L51-L59" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L54-L60" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -67,16 +67,16 @@ Solving our example with an implicit wait looks like this:
 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L45-L49" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L50" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27-L31" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39-L44" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28-L32" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 {{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L37-L41" >}}
@@ -100,18 +100,18 @@ Another nice feature is that, by default, the Selenium Wait class automatically 
   {{% tab header="Java" %}}
 This example shows the condition being waited for as a _lambda_. Java also supports
 [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L67-L68" >}}
   {{% /tab %}}
   {{% tab header="Python" %}}
 This example shows the condition being waited for as a _lambda_. Python also supports
 [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L41-L42" >}}
   {{% /tab %}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L53-L59" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L56-L57" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L42-L43" >}}
   {{< /tab >}}
   {{% tab header="JavaScript" %}}
 JavaScript also supports [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
@@ -139,16 +139,16 @@ make sure that the code returns `true` when it is successful):
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
 The easiest way to customize Waits in Java is to use the `FluentWait` class:
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L70-L80" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L82-L92" >}}
   {{% /tab %}}
   {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L50-L55" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L53-L55" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L67-L78" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L70-L79" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L51-L59" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L54-L60" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -67,16 +67,16 @@ Solving our example with an implicit wait looks like this:
 
 {{< tabpane text=true langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L45-L49" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L50" >}}
   {{< /tab >}}
   {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27-L31" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L27" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39-L44" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L39" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28-L32" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 {{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L37-L41" >}}
@@ -100,18 +100,18 @@ Another nice feature is that, by default, the Selenium Wait class automatically 
   {{% tab header="Java" %}}
 This example shows the condition being waited for as a _lambda_. Java also supports
 [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L57-L63" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L67-L68" >}}
   {{% /tab %}}
   {{% tab header="Python" %}}
 This example shows the condition being waited for as a _lambda_. Python also supports
 [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L38-L44" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L41-L42" >}}
   {{% /tab %}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L53-L59" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L56-L57" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L39-L45" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L42-L43" >}}
   {{< /tab >}}
   {{% tab header="JavaScript" %}}
 JavaScript also supports [Expected Conditions]({{< ref "support_features/expected_conditions" >}})
@@ -139,16 +139,16 @@ make sure that the code returns `true` when it is successful):
 {{< tabpane text=true langEqualsHeader=true >}}
   {{% tab header="Java" %}}
 The easiest way to customize Waits in Java is to use the `FluentWait` class:
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L70-L80" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/waits/WaitsTest.java#L82-L92" >}}
   {{% /tab %}}
   {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L50-L55" >}}
+{{< gh-codeblock path="examples/python/tests/waits/test_waits.py#L53-L55" >}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L67-L78" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Waits/WaitsTest.cs#L70-L79" >}}
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L51-L59" >}}
+{{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L54-L60" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
Fixing failures the right way for 4.15.0 is a process, I need to do it with a PR. Lots of testing still.

* https://deploy-preview-1520--selenium-dev.netlify.app/documentation/webdriver/bidirectional/chrome_devtools/cdp_api/
* Each of these https://deploy-preview-1520--selenium-dev.netlify.app/documentation/webdriver/browsers/
* https://deploy-preview-1520--selenium-dev.netlify.app/documentation/webdriver/drivers/service/
* https://deploy-preview-1520--selenium-dev.netlify.app/documentation/webdriver/waits/