### PR TITLE
Update windows.en.md

### DIFF
--- a/examples/ruby/spec/interactions/windows_spec.rb
+++ b/examples/ruby/spec/interactions/windows_spec.rb
@@ -4,4 +4,22 @@ require 'spec_helper'
 
 RSpec.describe 'Windows' do
   let(:driver) { start_session }
+
+  it 'opens new tab' do
+    driver.get 'https://www.selenium.dev/documentation/webdriver/interactions/'
+
+    driver.switch_to.new_window(:tab)
+    driver.get 'https://www.selenium.dev/documentation/webdriver/interactions/windows/#create-new-window-or-new-tab-and-switch'
+
+    expect(driver.window_handles.size).to eq 2
+  end
+
+  it 'opens new window' do
+    driver.get 'https://www.selenium.dev/documentation/webdriver/interactions/'
+
+    driver.switch_to.new_window(:window)
+    driver.get 'https://www.selenium.dev/documentation/webdriver/interactions/windows/#create-new-window-or-new-tab-and-switch'
+
+    expect(driver.window_handles.size).to eq 2
+  end
 end

--- a/examples/ruby/spec/interactions/windows_spec.rb
+++ b/examples/ruby/spec/interactions/windows_spec.rb
@@ -6,19 +6,13 @@ RSpec.describe 'Windows' do
   let(:driver) { start_session }
 
   it 'opens new tab' do
-    driver.get 'https://www.selenium.dev/documentation/webdriver/interactions/'
-
     driver.switch_to.new_window(:tab)
-    driver.get 'https://www.selenium.dev/documentation/webdriver/interactions/windows/#create-new-window-or-new-tab-and-switch'
 
     expect(driver.window_handles.size).to eq 2
   end
 
   it 'opens new window' do
-    driver.get 'https://www.selenium.dev/documentation/webdriver/interactions/'
-
     driver.switch_to.new_window(:window)
-    driver.get 'https://www.selenium.dev/documentation/webdriver/interactions/windows/#create-new-window-or-new-tab-and-switch'
 
     expect(driver.window_handles.size).to eq 2
   end

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
@@ -236,14 +236,11 @@ driver.SwitchTo().NewWindow(WindowType.Tab)
 driver.SwitchTo().NewWindow(WindowType.Window)
   {{< /tab >}}
   {{< tab header="Ruby" >}}
-    # Note: The new_window in ruby only opens a new tab (or) Window and will not switch automatically
-    # The user has to switch to new tab (or) new window
-
     # Opens a new tab and switches to new tab
-    driver.switch_to.new_window(:tab)
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9-L12" >}}
 
     # Opens a new window and switches to new window
-    driver.switch_to.new_window(:window)
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L18-L21" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
@@ -240,10 +240,10 @@ driver.SwitchTo().NewWindow(WindowType.Window)
     # The user has to switch to new tab (or) new window
 
     # Opens a new tab and switches to new tab
-driver.manage.new_window(:tab)
+    driver.switch_to.new_window(:tab)
 
     # Opens a new window and switches to new window
-driver.manage.new_window(:window)
+    driver.switch_to.new_window(:window)
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
@@ -235,13 +235,13 @@ driver.SwitchTo().NewWindow(WindowType.Tab)
 // Opens a new window and switches to new window
 driver.SwitchTo().NewWindow(WindowType.Window)
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Opens a new tab and switches to new tab
-    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9-L12" >}}
+  {{% tab header="Ruby" text=true %}}
+    Opens a new tab and switches to new tab
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9" >}}
 
-    # Opens a new window and switches to new window
-    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L18-L21" >}}
-  {{< /tab >}}
+    Opens a new window and switches to new window
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L15" >}}
+  {{% /tab %}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab
 await driver.switchTo().newWindow('tab');

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
@@ -225,16 +225,13 @@ driver.SwitchTo().NewWindow(WindowType.Tab)
 // Opens a new window and switches to new window
 driver.SwitchTo().NewWindow(WindowType.Window)
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Note: The new_window in ruby only opens a new tab (or) Window and will not switch automatically
-    # The user has to switch to new tab (or) new window
+  {{% tab header="Ruby" text=true %}}
+    Opens a new tab and switches to new tab
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9" >}}
 
-    # Opens a new tab and switches to new tab
-    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9-L12" >}}
-
-    # Opens a new window and switches to new window
-    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L18-L21" >}}
-  {{< /tab >}}
+    Opens a new window and switches to new window
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L15" >}}
+  {{% /tab %}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab
 await driver.switchTo().newWindow('tab');

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
@@ -230,10 +230,10 @@ driver.SwitchTo().NewWindow(WindowType.Window)
     # The user has to switch to new tab (or) new window
 
     # Opens a new tab and switches to new tab
-    driver.switch_to.new_window(:tab)
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9-L12" >}}
 
     # Opens a new window and switches to new window
-    driver.switch_to.new_window(:window)
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L18-L21" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
@@ -230,10 +230,10 @@ driver.SwitchTo().NewWindow(WindowType.Window)
     # The user has to switch to new tab (or) new window
 
     # Opens a new tab and switches to new tab
-driver.manage.new_window(:tab)
+    driver.switch_to.new_window(:tab)
 
     # Opens a new window and switches to new window
-driver.manage.new_window(:window)
+    driver.switch_to.new_window(:window)
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
@@ -231,16 +231,13 @@ driver.SwitchTo().NewWindow(WindowType.Tab)
 // Opens a new window and switches to new window
 driver.SwitchTo().NewWindow(WindowType.Window)
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Note: The new_window in ruby only opens a new tab (or) Window and will not switch automatically
-    # The user has to switch to new tab (or) new window
+  {{% tab header="Ruby" text=true %}}
+    Opens a new tab and switches to new tab
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9" >}}
 
-    # Opens a new tab and switches to new tab
-    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9-L12" >}}
-
-    # Opens a new window and switches to new window
-    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L18-L21" >}}
-  {{< /tab >}}
+    Opens a new window and switches to new window
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L15" >}}
+  {{% /tab %}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab
 await driver.switchTo().newWindow('tab');

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
@@ -236,10 +236,10 @@ driver.SwitchTo().NewWindow(WindowType.Window)
     # The user has to switch to new tab (or) new window
 
     # Opens a new tab and switches to new tab
-    driver.switch_to.new_window(:tab)
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9-L12" >}}
 
     # Opens a new window and switches to new window
-    driver.switch_to.new_window(:window)
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L18-L21" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
@@ -236,10 +236,10 @@ driver.SwitchTo().NewWindow(WindowType.Window)
     # The user has to switch to new tab (or) new window
 
     # Opens a new tab and switches to new tab
-driver.manage.new_window(:tab)
+    driver.switch_to.new_window(:tab)
 
     # Opens a new window and switches to new window
-driver.manage.new_window(:window)
+    driver.switch_to.new_window(:window)
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 // Opens a new tab and switches to new tab

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
@@ -218,16 +218,13 @@ driver.SwitchTo().NewWindow(WindowType.Tab)
 // 打开一个新窗口并切换到新窗口
 driver.SwitchTo().NewWindow(WindowType.Window)
 {{< /tab >}}
-{{< tab header="Ruby" >}}
-    # 注意：ruby 中的 new_window 只打开一个新标签页(或)窗口，不会自动切换
-    # 用户必须切换到新选项卡 (或) 新窗口
+  {{% tab header="Ruby" text=true %}}
+    打开新标签页并切换到新标签页
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9" >}}
 
-    # 打开新标签页并切换到新标签页
-    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9-L12" >}}
-
-    # 打开一个新窗口并切换到新窗口
-    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L18-L21" >}}
-{{< /tab >}}
+    打开一个新窗口并切换到新窗口
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L15" >}}
+  {{% /tab %}}
 {{< tab header="JavaScript" >}}
 // 打开新标签页并切换到新标签页
 await driver.switchTo().newWindow('tab');

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
@@ -223,10 +223,10 @@ driver.SwitchTo().NewWindow(WindowType.Window)
     # 用户必须切换到新选项卡 (或) 新窗口
 
     # 打开新标签页并切换到新标签页
-    driver.switch_to.new_window(:tab)
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L9-L12" >}}
 
     # 打开一个新窗口并切换到新窗口
-    driver.switch_to.new_window(:window)
+    {{< gh-codeblock path="/examples/ruby/spec/interactions/windows_spec.rb#L18-L21" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 // 打开新标签页并切换到新标签页

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
@@ -223,10 +223,10 @@ driver.SwitchTo().NewWindow(WindowType.Window)
     # 用户必须切换到新选项卡 (或) 新窗口
 
     # 打开新标签页并切换到新标签页
-driver.manage.new_window(:tab)
+    driver.switch_to.new_window(:tab)
 
     # 打开一个新窗口并切换到新窗口
-driver.manage.new_window(:window)
+    driver.switch_to.new_window(:window)
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 // 打开新标签页并切换到新标签页


### PR DESCRIPTION
fixed sample code to open a new window or tab using ruby

<!--- Provide a general summary of your changes in the Title above -->

### Description
current sample code doesn't work, with this change user will be pointed to the right direction on how to open a new window or tab using ruby

### Motivation and Context
I was trying to achieve this and following the sample code didn't work, after looking at other languages I figured it out, maybe some people won't do that I will think the feature is just not working in ruby

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
