### PR TITLE
[dotnet] Added troubleshooting logging docs

### DIFF
--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.en.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.en.md
@@ -29,9 +29,7 @@ level module. So to work with all loggers in selenium module, you can do this:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L5" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET logger is managed with a static class, so all access to logging is managed simply by referencing `Log` from the `OpenQA.Selenium.Internal.Logging` namespace.
   {{% /tab %}}
   {{% tab header="Ruby" %}}
 If you want to see as much debugging as possible in all the classes,
@@ -93,9 +91,11 @@ logging.basicConfig(level=logging.WARN)
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET has 6 logger levels: `Error`, `Warn`, `Info`, `Debug`, `Trace` and `None`. The default level is `Info`.
+
+To change the level of the logger:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L18" >}}
+
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
@@ -147,8 +147,11 @@ WARNING  selenium:test_logging.py:23 this is a warning
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs actionable content at logger level `Warn`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 WARN LoggingTest: this is a warning
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -193,8 +196,11 @@ INFO     selenium:test_logging.py:22 this is useful information
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs useful information at logger level `Info`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 INFO LoggingTest: this is useful information
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -237,8 +243,11 @@ DEBUG    selenium:test_logging.py:24 this is detailed debug information
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs most debug content at logger level `Debug`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 DEBUG LoggingTest: this is detailed debug information
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -273,9 +282,8 @@ handler with either a `StreamHandler` or a `FileHandler`:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L9-L10" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+By default all logs are sent to `Console.Error` output. To direct output somewhere else, you need to add a handler with a `FileLogHandler`:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L20" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   By default, logs are sent to the console in `stdout`.  
@@ -312,9 +320,8 @@ different levels for different modules:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L12-L13" >}}
   {{< /tab >}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET logging is managed on a per class level, set the level you want to use on a per-class basis:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L22-L23" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
 Ruby's logger allows you to opt in ("allow") or opt out ("ignore") of log messages based on their IDs.

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.en.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.en.md
@@ -95,7 +95,6 @@ logging.basicConfig(level=logging.WARN)
 
 To change the level of the logger:
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L18" >}}
-
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
@@ -282,7 +281,7 @@ handler with either a `StreamHandler` or a `FileHandler`:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L9-L10" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-By default all logs are sent to `Console.Error` output. To direct output somewhere else, you need to add a handler with a `FileLogHandler`:
+By default all logs are sent to `System.Console.Error` output. To direct output somewhere else, you need to add a handler with a `FileLogHandler`:
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L20" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.ja.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.ja.md
@@ -29,9 +29,7 @@ level module. So to work with all loggers in selenium module, you can do this:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L5" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET logger is managed with a static class, so all access to logging is managed simply by referencing `Log` from the `OpenQA.Selenium.Internal.Logging` namespace.
   {{% /tab %}}
   {{% tab header="Ruby" %}}
 If you want to see as much debugging as possible in all the classes,
@@ -92,9 +90,10 @@ logging.basicConfig(level=logging.WARN)
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET has 6 logger levels: `Error`, `Warn`, `Info`, `Debug`, `Trace` and `None`. The default level is `Info`.
+
+To change the level of the logger:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L18" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
@@ -145,8 +144,11 @@ WARNING  selenium:test_logging.py:23 this is a warning
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs actionable content at logger level `Warn`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 WARN LoggingTest: this is a warning
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -191,8 +193,11 @@ INFO     selenium:test_logging.py:22 this is useful information
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs useful information at logger level `Info`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 INFO LoggingTest: this is useful information
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -235,8 +240,11 @@ DEBUG    selenium:test_logging.py:24 this is detailed debug information
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs most debug content at logger level `Debug`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 DEBUG LoggingTest: this is detailed debug information
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -271,9 +279,8 @@ handler with either a `StreamHandler` or a `FileHandler`:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L9-L10" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+By default all logs are sent to `System.Console.Error` output. To direct output somewhere else, you need to add a handler with a `FileLogHandler`:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L20" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   By default, logs are sent to the console in `stdout`.  
@@ -309,9 +316,8 @@ different levels for different modules:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L12-L13" >}}
   {{< /tab >}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET logging is managed on a per class level, set the level you want to use on a per-class basis:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L22-L23" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
 Ruby's logger allows you to opt in ("allow") or opt out ("ignore") of log messages based on their IDs.

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.pt-br.md
@@ -29,9 +29,7 @@ level module. So to work with all loggers in selenium module, you can do this:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L5" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET logger is managed with a static class, so all access to logging is managed simply by referencing `Log` from the `OpenQA.Selenium.Internal.Logging` namespace.
   {{% /tab %}}
   {{% tab header="Ruby" %}}
 If you want to see as much debugging as possible in all the classes,
@@ -92,9 +90,10 @@ logging.basicConfig(level=logging.WARN)
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET has 6 logger levels: `Error`, `Warn`, `Info`, `Debug`, `Trace` and `None`. The default level is `Info`.
+
+To change the level of the logger:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L18" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
@@ -145,8 +144,11 @@ WARNING  selenium:test_logging.py:23 this is a warning
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs actionable content at logger level `Warn`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 WARN LoggingTest: this is a warning
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -191,8 +193,11 @@ INFO     selenium:test_logging.py:22 this is useful information
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs useful information at logger level `Info`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 INFO LoggingTest: this is useful information
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -235,8 +240,11 @@ DEBUG    selenium:test_logging.py:24 this is detailed debug information
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs most debug content at logger level `Debug`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 DEBUG LoggingTest: this is detailed debug information
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -271,9 +279,8 @@ handler with either a `StreamHandler` or a `FileHandler`:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L9-L10" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+By default all logs are sent to `System.Console.Error` output. To direct output somewhere else, you need to add a handler with a `FileLogHandler`:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L20" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   By default, logs are sent to the console in `stdout`.  
@@ -309,9 +316,8 @@ different levels for different modules:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L12-L13" >}}
   {{< /tab >}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET logging is managed on a per class level, set the level you want to use on a per-class basis:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L22-L23" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
 Ruby's logger allows you to opt in ("allow") or opt out ("ignore") of log messages based on their IDs.

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/logging.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/logging.zh-cn.md
@@ -32,9 +32,7 @@ level module. So to work with all loggers in selenium module, you can do this:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L5" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET logger is managed with a static class, so all access to logging is managed simply by referencing `Log` from the `OpenQA.Selenium.Internal.Logging` namespace.
   {{% /tab %}}
   {{% tab header="Ruby" %}}
 If you want to see as much debugging as possible in all the classes,
@@ -95,9 +93,10 @@ logging.basicConfig(level=logging.WARN)
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET has 6 logger levels: `Error`, `Warn`, `Info`, `Debug`, `Trace` and `None`. The default level is `Info`.
+
+To change the level of the logger:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L18" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   Ruby logger has 5 logger levels: `:debug`, `:info`, `:warn`, `:error`, `:fatal`. 
@@ -149,8 +148,11 @@ WARNING  selenium:test_logging.py:23 this is a warning
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs actionable content at logger level `Warn`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 WARN LoggingTest: this is a warning
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -195,8 +197,11 @@ INFO     selenium:test_logging.py:22 this is useful information
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs useful information at logger level `Info`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 INFO LoggingTest: this is useful information
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -239,8 +244,11 @@ DEBUG    selenium:test_logging.py:24 this is detailed debug information
 ```
   {{% /tab %}}
   {{% tab header="CSharp" %}}
+.NET logs most debug content at logger level `Debug`.
+
+Example:
 ```text
-.NET does not currently have a Logging implementation
+11:04:40.986 DEBUG LoggingTest: this is detailed debug information
 ```
   {{% /tab %}}
   {{% tab header="Ruby" %}}
@@ -277,9 +285,8 @@ handler with either a `StreamHandler` or a `FileHandler`:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L9-L10" >}}
   {{% /tab %}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+By default all logs are sent to `System.Console.Error` output. To direct output somewhere else, you need to add a handler with a `FileLogHandler`:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L20" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
   By default, logs are sent to the console in `stdout`.  
@@ -316,9 +323,8 @@ different levels for different modules:
 {{< gh-codeblock path="/examples/python/tests/troubleshooting/test_logging.py#L12-L13" >}}
   {{< /tab >}}
   {{% tab header="CSharp" %}}
-```text
-.NET does not currently have a Logging implementation
-```
+.NET logging is managed on a per class level, set the level you want to use on a per-class basis:
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Troubleshooting/LoggingTest.cs#L22-L23" >}}
   {{% /tab %}}
   {{% tab header="Ruby" %}}
 Ruby's logger allows you to opt in ("allow") or opt out ("ignore") of log messages based on their IDs.


### PR DESCRIPTION
### Description
Adding recently implemented logging mechanism as documentation on the https://www.selenium.dev/documentation/webdriver/troubleshooting/logging/ page.

### Motivation and Context
To be aligned with other bindings.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
