### PR TITLE
Correct initialization of custom node in grid advanced features

### DIFF
--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
@@ -95,8 +95,8 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, URI uri, Secret registrationSecret) {
-    super(tracer, new NodeId(UUID.randomUUID()), uri, registrationSecret);
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
+	super(tracer, nodeId, uri, registrationSecret);
   }
 
   public static Node create(Config config) {
@@ -109,7 +109,9 @@ public class DecoratedLoggingNode extends Node {
     Node node = LocalNodeFactory.create(config);
 
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
-        uri, secretOptions.getRegistrationSecret());
+				node.getId(),
+				uri,
+				secretOptions.getRegistrationSecret());
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
@@ -100,8 +100,8 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, URI uri, Secret registrationSecret) {
-    super(tracer, new NodeId(UUID.randomUUID()), uri, registrationSecret);
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
+	super(tracer, nodeId, uri, registrationSecret);
   }
 
   public static Node create(Config config) {
@@ -114,7 +114,9 @@ public class DecoratedLoggingNode extends Node {
     Node node = LocalNodeFactory.create(config);
 
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
-        uri, secretOptions.getRegistrationSecret());
+				node.getId(),
+				uri,
+				secretOptions.getRegistrationSecret());
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
@@ -90,8 +90,8 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, URI uri, Secret registrationSecret) {
-    super(tracer, new NodeId(UUID.randomUUID()), uri, registrationSecret);
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
+	super(tracer, nodeId, uri, registrationSecret);
   }
 
   public static Node create(Config config) {
@@ -104,7 +104,9 @@ public class DecoratedLoggingNode extends Node {
     Node node = LocalNodeFactory.create(config);
 
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
-        uri, secretOptions.getRegistrationSecret());
+				node.getId(),
+				uri,
+				secretOptions.getRegistrationSecret());
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
@@ -100,8 +100,8 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, URI uri, Secret registrationSecret) {
-    super(tracer, new NodeId(UUID.randomUUID()), uri, registrationSecret);
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
+	super(tracer, nodeId, uri, registrationSecret);
   }
 
   public static Node create(Config config) {
@@ -114,7 +114,9 @@ public class DecoratedLoggingNode extends Node {
     Node node = LocalNodeFactory.create(config);
 
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
-        uri, secretOptions.getRegistrationSecret());
+				node.getId(),
+				uri,
+				secretOptions.getRegistrationSecret());
     wrapper.node = node;
     return wrapper;
   }


### PR DESCRIPTION
	
<!--- Provide a general summary of your changes in the Title above -->

### Description
This change corrects the way the DecoratedLoggingNode is initialized when creating a custom node. We provide it the node id of the wrapped node.

### Motivation and Context
Current example had an issue as 2 node ids were created, and when the node registers itself to hub, it don't see it's registered (see issue #1571)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
