### PR TITLE
[py] Update test_remote_webdriver.py to use file_names #1568

### DIFF
--- a/examples/python/tests/drivers/test_remote_webdriver.py
+++ b/examples/python/tests/drivers/test_remote_webdriver.py
@@ -47,7 +47,7 @@ def test_downloads(server, temp_dir):
     files = driver.get_downloadable_files()
 
     assert sorted(files) == sorted(file_names)
-    downloadable_file = files[0]
+    downloadable_file = file_names[0]
     target_directory = temp_dir
 
     driver.download_file(downloadable_file, target_directory)


### PR DESCRIPTION
files does not get returned in a consistent order from get_downloadable_files() which is why the sort is needed in the assert.  Use file_names instead

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
