### PR TITLE
doc: add more noob fdly code

### DIFF
--- a/examples/javascript/test/getting_started/firstScript.spec.js
+++ b/examples/javascript/test/getting_started/firstScript.spec.js
@@ -1,4 +1,3 @@
-// doc: https://www.npmjs.com/package/selenium-webdriver?activeTab=code
 const {By, Builder, Browser} = require('selenium-webdriver');
 const assert = require("assert");
 

--- a/examples/javascript/test/getting_started/firstScript.spec.js
+++ b/examples/javascript/test/getting_started/firstScript.spec.js
@@ -1,11 +1,12 @@
-const {By, Builder} = require('selenium-webdriver');
+// doc: https://www.npmjs.com/package/selenium-webdriver?activeTab=code
+const {By, Builder, Browser} = require('selenium-webdriver');
 const assert = require("assert");
 
 (async function firstTest() {
   let driver;
   
   try {
-    driver = await new Builder().forBrowser('chrome').build();
+    driver = await new Builder().forBrowser(Browser.CHROME).build();
     await driver.get('https://www.selenium.dev/selenium/web/web-form.html');
   
     let title = await driver.getTitle();

--- a/examples/javascript/test/hello/helloSelenium.js
+++ b/examples/javascript/test/hello/helloSelenium.js
@@ -1,7 +1,7 @@
-const {Builder} = require('selenium-webdriver');
+const {By, Builder, Browser} = require('selenium-webdriver');
 
 (async function helloSelenium() {
-  let driver = await new Builder().forBrowser('chrome').build();
+  let driver = await new Builder().forBrowser(Browser.CHROME).build();
 
   await driver.get('https://selenium.dev');
 

--- a/examples/javascript/test/hello/helloSelenium.js
+++ b/examples/javascript/test/hello/helloSelenium.js
@@ -1,4 +1,4 @@
-const {By, Builder, Browser} = require('selenium-webdriver');
+const {Builder, Browser} = require('selenium-webdriver');
 
 (async function helloSelenium() {
   let driver = await new Builder().forBrowser(Browser.CHROME).build();


### PR DESCRIPTION
# background
the quickstart for the javascript is oversimple. it takes time for noob like my self to dig into the source to check the rightway.

# file needs to be changed
https://github.com/SeleniumHQ/seleniumhq.github.io/blob/trunk/examples/javascript/test/getting_started/firstScript.spec.js

# propose
```js
// doc: https://www.npmjs.com/package/selenium-webdriver?activeTab=code
const {Builder, Browser} = require('selenium-webdriver');

(async function helloSelenium() {
  let driver = await new Builder().forBrowser(Browser.CHROME).build();

  await driver.get('https://selenium.dev');

  await driver.quit();
})();
```
I would create a PR for update the doc for noob to pickup the framework more smoothly