### PR TITLE
Fixes and completes install_addon() tests on firefox

### DIFF
--- a/examples/python/tests/browsers/test_firefox.py
+++ b/examples/python/tests/browsers/test_firefox.py
@@ -88,10 +88,10 @@ def test_profile_location(temp_dir):
     driver.quit()
 
 
-def test_install_addon(firefox_driver, addon_path):
+def test_install_addon(firefox_driver, addon_path_xpi):
     driver = firefox_driver
 
-    driver.install_addon(addon_path)
+    driver.install_addon(addon_path_xpi)
 
     driver.get("https://www.selenium.dev/selenium/web/blank.html")
     injected = driver.find_element(webdriver.common.by.By.ID, "webextensions-selenium-example")
@@ -99,20 +99,31 @@ def test_install_addon(firefox_driver, addon_path):
     assert injected.text == "Content injected by webextensions-selenium-example"
 
 
-def test_uninstall_addon(firefox_driver, addon_path):
+def test_uninstall_addon(firefox_driver, addon_path_xpi):
     driver = firefox_driver
 
-    id = driver.install_addon(addon_path)
+    id = driver.install_addon(addon_path_xpi)
     driver.uninstall_addon(id)
 
     driver.get("https://www.selenium.dev/selenium/web/blank.html")
     assert len(driver.find_elements(webdriver.common.by.By.ID, "webextensions-selenium-example")) == 0
 
 
-def test_install_unsigned_addon_directory(firefox_driver, addon_path):
+def test_install_unsigned_addon_directory(firefox_driver, addon_path_dir):
     driver = firefox_driver
 
-    driver.install_addon(addon_path, temporary=True)
+    driver.install_addon(addon_path_dir, temporary=True)
+
+    driver.get("https://www.selenium.dev/selenium/web/blank.html")
+    injected = driver.find_element(webdriver.common.by.By.ID, "webextensions-selenium-example")
+
+    assert injected.text == "Content injected by webextensions-selenium-example"
+
+
+def test_install_unsigned_addon_directory_slash(firefox_driver, addon_path_dir_slash):
+    driver = firefox_driver
+
+    driver.install_addon(addon_path_dir_slash, temporary=True)
 
     driver.get("https://www.selenium.dev/selenium/web/blank.html")
     injected = driver.find_element(webdriver.common.by.By.ID, "webextensions-selenium-example")

--- a/examples/python/tests/conftest.py
+++ b/examples/python/tests/conftest.py
@@ -94,11 +94,31 @@ def log_path():
 
 
 @pytest.fixture(scope='function')
-def addon_path():
+def addon_path_xpi():
     if os.path.abspath("").endswith("tests"):
         path = os.path.abspath("extensions/webextensions-selenium-example.xpi")
     else:
         path = os.path.abspath("tests/extensions/webextensions-selenium-example.xpi")
+
+    yield path
+
+
+@pytest.fixture(scope='function')
+def addon_path_dir():
+    if os.path.abspath("").endswith("tests"):
+        path = os.path.abspath("extensions/webextensions-selenium-example")
+    else:
+        path = os.path.abspath("tests/extensions/webextensions-selenium-example")
+
+    yield path
+
+
+@pytest.fixture(scope='function')
+def addon_path_dir_slash():
+    if os.path.abspath("").endswith("tests"):
+        path = os.path.abspath("extensions/webextensions-selenium-example/")
+    else:
+        path = os.path.abspath("tests/extensions/webextensions-selenium-example/")
 
     yield path
 


### PR DESCRIPTION
## **User description**
test_install_addon_directory() was being called with an xpi file fixture instead of a directory fixture.

I fixed this by making a new fixture for
test_install_addon_directory() that points to the test extension directory. See details here below.

I also added an additional test and fixture so that the tests take into account whether a path to an extension directory ends with a trailing slash. See details here below.

This required renaming the existing addon_path fixture to avoid confusion among the three related fixtures:

- addon_path_xpi

  renamed fixture gives a path to the xpi file (was addon_path)

  updated test_install_addon() and test_unistall_addon()

- addon_path_dir

  new fixture that gives a path to the extension directory, ending without a '/'

  updated test_install_unsigned_addon_directory() to use it

- addon_path_dir_slash (new fixture, and test)

  new fixture that gives a path to the extension directory, ending with a '/'

  added new test: test_install_unsigned_addon_directory_slash()

Note that I don't have the appropriate environment to run these tests before pushing them.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
test_install_unsigned_addon_directory() was using the same fixture for test_install_addon(), which ended duplicating
the test, but not testing what was intended. I fixed this by declaring a new fixture that points to the intended
extension directory. 

I also added a new test to check that  install_addon() handles correctly directory paths that end with a '/'. This is
a recent bug I found in the firefox's webdriver (issue and PR already submitted). 

I added suffixes to the the three addon_path fixtures to be able to distinguish between them.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

It fixes test_install_unsigned_addon_directory() which  was using the wrong fixture.

It add a new test that allows to detect if install_addon() is handling correctly directory paths that end with a '/'.
Note that until a fix (my PR or some other one) is applied to firefox's webdrive, this test will fail.

Also note that I couldn't install the test environment on my box so these changes are proposed without having
been actually tested, hoping they work or that they can give hints to someone else on how to fix / improve
the install_addon() related tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement, tests


___

## **Description**
- Renamed the `addon_path` fixture to `addon_path_xpi` and updated relevant tests to use this fixture.
- Introduced two new fixtures, `addon_path_dir` and `addon_path_dir_slash`, to differentiate between directory paths with and without a trailing slash.
- Added a new test `test_install_unsigned_addon_directory_slash` to specifically test addon installation from a directory path ending with a slash.
- Updated `test_install_unsigned_addon_directory` to include an assertion for verifying the injected content, ensuring the addon is installed correctly.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_firefox.py</strong><dd><code>Enhance Firefox Addon Installation Tests and Add New Test for </code><br><code>Directory Paths Ending with Slash</code></dd></summary>
<hr>
      
examples/python/tests/browsers/test_firefox.py

<li>Updated <code>test_install_addon</code> and <code>test_uninstall_addon</code> to use the <br><code>addon_path_xpi</code> fixture.<br> <li> Modified <code>test_install_unsigned_addon_directory</code> to use the <br><code>addon_path_dir</code> fixture and added an assertion to check the injected <br>content.<br> <li> Added a new test <code>test_install_unsigned_addon_directory_slash</code> using the <br><code>addon_path_dir_slash</code> fixture to handle directory paths ending with a <br>slash.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1609/files#diff-0c150a20628e9efa5a2d236dd4cd1c861ecbfc8f25f32a2add0958f9155cccf0">+17/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Update Fixtures for Firefox Addon Installation Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/python/tests/conftest.py

<li>Renamed <code>addon_path</code> fixture to <code>addon_path_xpi</code> to clarify its purpose.<br> <li> Added new fixtures <code>addon_path_dir</code> and <code>addon_path_dir_slash</code> for testing <br>directory paths with and without a trailing slash.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1609/files#diff-046cf5671a09c47700a1903ecec9669341fe3c0602c91beb6bb529053e7af113">+21/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

