### PR TITLE
Expand documentation on fresh browser per test

### DIFF
--- a/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md
@@ -15,20 +15,30 @@ at least start a new WebDriver for each test.
 Most browser drivers like GeckoDriver and ChromeDriver will start with a clean
 known state with a new user profile, by default.
 
-A new browser per test can be achieved by using a test framework's "before each test" hook or fixture. This also implies using the "after each test" hook to close the browser
-
-Using a Java framework with hooks
-```java
-# Before each test create a new WebDriver instance
-WebDriver driver = new FirefoxDriver();
-```
+A new browser per test can be achieved by using a test framework's "before each test" hook or fixture. This also implies using the "after each test" hook to close the browser.
 
 ```java
-# After each test close the browser
-driver.close();
+# Using a class variable
+public abstract class BaseTest {
+	protected WebDriver driver;
+    ...
+
+    # Before each test hook
+    public void setupTest() {
+        driver = new FirefoxDriver();
+        ...
+    }
+
+    # After each test hook
+    public void teardownTest() {
+        ...
+        driver.quit();
+    }
+}
 ```
 
 Using python fixtures
+
 ```python
 @pytest.fixture(autouse=True, scope='function')
 def driver(self, request, page: Page):
@@ -42,3 +52,22 @@ def driver(self, request, page: Page):
     driver.quit()
 ```
 
+A static WebDriver will cause multiple issues both with parallel test execution but also with keeping alignment with this approach of one browser per test. Aditionally this forces the code to deal with ThreadLocal type techniques that unneccesarily complicate the code.
+
+```java
+# Using a static variable
+
+# This forces the ThreadLocal<WebDriver> variable to call driver.get() every time the driver wants to be used.
+
+# In general static variables in non-thread safe code can have unintended consequences and increase the maintanance effort in the code base.
+
+public abstract class BaseTest {
+	protected ThreadLocal<WebDriver> driver;
+    ...
+    # Before each test hook
+    public void setupTest() {
+        BaseTest.driver = ThreadLocal.withInitial(()->new FirefoxDriver());
+        ...
+    }
+}
+```

--- a/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md
@@ -18,18 +18,18 @@ known state with a new user profile, by default.
 A new browser per test can be achieved by using a test framework's "before each test" hook or fixture. This also implies using the "after each test" hook to close the browser.
 
 ```java
-# Using a class variable
+// Using a class variable
 public abstract class BaseTest {
 	protected WebDriver driver;
     ...
 
-    # Before each test hook
+    // Before each test hook
     public void setupTest() {
         driver = new FirefoxDriver();
         ...
     }
 
-    # After each test hook
+    // After each test hook
     public void teardownTest() {
         ...
         driver.quit();
@@ -37,9 +37,8 @@ public abstract class BaseTest {
 }
 ```
 
-Using python fixtures
-
 ```python
+# Using python fixtures
 @pytest.fixture(autouse=True, scope='function')
 def driver(self, request, page: Page):
     # Create the driver
@@ -64,7 +63,7 @@ A static WebDriver will cause multiple issues both with parallel test execution 
 public abstract class BaseTest {
 	protected ThreadLocal<WebDriver> driver;
     ...
-    # Before each test hook
+    // Before each test hook
     public void setupTest() {
         BaseTest.driver = ThreadLocal.withInitial(()->new FirefoxDriver());
         ...

--- a/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md
@@ -14,6 +14,13 @@ If spinning up a new virtual machine is not practical,
 at least start a new WebDriver for each test.
 Most browser drivers like GeckoDriver and ChromeDriver will start with a clean
 known state with a new user profile, by default.
+
+A new browser per test can be achieved by using a test framework's "before each test" hook. This also implies using the "after each test" hook to close the browser
+
 ```java
 WebDriver driver = new FirefoxDriver();
+```
+
+```java
+driver.close();
 ```

--- a/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md
@@ -15,12 +15,30 @@ at least start a new WebDriver for each test.
 Most browser drivers like GeckoDriver and ChromeDriver will start with a clean
 known state with a new user profile, by default.
 
-A new browser per test can be achieved by using a test framework's "before each test" hook. This also implies using the "after each test" hook to close the browser
+A new browser per test can be achieved by using a test framework's "before each test" hook or fixture. This also implies using the "after each test" hook to close the browser
 
+Using a Java framework with hooks
 ```java
+# Before each test create a new WebDriver instance
 WebDriver driver = new FirefoxDriver();
 ```
 
 ```java
+# After each test close the browser
 driver.close();
 ```
+
+Using python fixtures
+```python
+@pytest.fixture(autouse=True, scope='function')
+def driver(self, request, page: Page):
+    # Create the driver
+    driver = webdriver.Firefox()
+    
+    # Return control to the test 
+    yield self.driver
+
+    # Test ends driver quits
+    driver.quit()
+```
+

--- a/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.ja.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.ja.md
@@ -15,6 +15,55 @@ aliases: [
 Firefoxの場合、既知のプロファイルでWebDriverを起動します。
 Most browser drivers like GeckoDriver and ChromeDriver will start with a clean
 known state with a new user profile, by default.
+
 ```java
-WebDriver driver = new FirefoxDriver();
+// Using a class variable
+public abstract class BaseTest {
+	protected WebDriver driver;
+    ...
+
+    // Before each test hook
+    public void setupTest() {
+        driver = new FirefoxDriver();
+        ...
+    }
+
+    // After each test hook
+    public void teardownTest() {
+        ...
+        driver.quit();
+    }
+}
+```
+
+```python
+# Using python fixtures
+@pytest.fixture(autouse=True, scope='function')
+def driver(self, request, page: Page):
+    # Create the driver
+    driver = webdriver.Firefox()
+    
+    # Return control to the test 
+    yield self.driver
+
+    # Test ends driver quits
+    driver.quit()
+```
+
+```java
+# Using a static variable
+
+# This forces the ThreadLocal<WebDriver> variable to call driver.get() every time the driver wants to be used.
+
+# In general static variables in non-thread safe code can have unintended consequences and increase the maintanance effort in the code base.
+
+public abstract class BaseTest {
+	protected ThreadLocal<WebDriver> driver;
+    ...
+    // Before each test hook
+    public void setupTest() {
+        BaseTest.driver = ThreadLocal.withInitial(()->new FirefoxDriver());
+        ...
+    }
+}
 ```

--- a/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.pt-br.md
@@ -15,5 +15,53 @@ pelo menos inicie um novo WebDriver para cada teste.
 Most browser drivers like GeckoDriver and ChromeDriver will start with a clean
 known state with a new user profile, by default.
 ```java
-WebDriver driver = new FirefoxDriver();
+// Using a class variable
+public abstract class BaseTest {
+	protected WebDriver driver;
+    ...
+
+    // Before each test hook
+    public void setupTest() {
+        driver = new FirefoxDriver();
+        ...
+    }
+
+    // After each test hook
+    public void teardownTest() {
+        ...
+        driver.quit();
+    }
+}
+```
+
+```python
+# Using python fixtures
+@pytest.fixture(autouse=True, scope='function')
+def driver(self, request, page: Page):
+    # Create the driver
+    driver = webdriver.Firefox()
+    
+    # Return control to the test 
+    yield self.driver
+
+    # Test ends driver quits
+    driver.quit()
+```
+
+```java
+# Using a static variable
+
+# This forces the ThreadLocal<WebDriver> variable to call driver.get() every time the driver wants to be used.
+
+# In general static variables in non-thread safe code can have unintended consequences and increase the maintanance effort in the code base.
+
+public abstract class BaseTest {
+	protected ThreadLocal<WebDriver> driver;
+    ...
+    // Before each test hook
+    public void setupTest() {
+        BaseTest.driver = ThreadLocal.withInitial(()->new FirefoxDriver());
+        ...
+    }
+}
 ```

--- a/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.zh-cn.md
@@ -15,5 +15,53 @@ aliases: [
 对于Firefox, 请使用您已知的配置文件去启动WebDriver.
 大多数浏览器驱动器，像GeckoDriver和ChromeDriver那样，默认都会以干净的已知状态和一个新的用户配置文件开始。
 ```java
-WebDriver driver = new FirefoxDriver();
+// Using a class variable
+public abstract class BaseTest {
+	protected WebDriver driver;
+    ...
+
+    // Before each test hook
+    public void setupTest() {
+        driver = new FirefoxDriver();
+        ...
+    }
+
+    // After each test hook
+    public void teardownTest() {
+        ...
+        driver.quit();
+    }
+}
+```
+
+```python
+# Using python fixtures
+@pytest.fixture(autouse=True, scope='function')
+def driver(self, request, page: Page):
+    # Create the driver
+    driver = webdriver.Firefox()
+    
+    # Return control to the test 
+    yield self.driver
+
+    # Test ends driver quits
+    driver.quit()
+```
+
+```java
+# Using a static variable
+
+# This forces the ThreadLocal<WebDriver> variable to call driver.get() every time the driver wants to be used.
+
+# In general static variables in non-thread safe code can have unintended consequences and increase the maintanance effort in the code base.
+
+public abstract class BaseTest {
+	protected ThreadLocal<WebDriver> driver;
+    ...
+    // Before each test hook
+    public void setupTest() {
+        BaseTest.driver = ThreadLocal.withInitial(()->new FirefoxDriver());
+        ...
+    }
+}
 ```


### PR DESCRIPTION
## **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Added an extended explanation and code examples on how to implement a fresh browser per test. Tried to avoid specific framework code like JUnit vs TestNG.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I see a lot of Selenium automation project in the industry with a static WebDriver that gets shared between tests and across all these teams there has always been confusion on how to get started with a fresh browser per test. This is made more prominent with requirements to run tests is parallel and a lot of automation coders not understanding the implications a static driver (without ThreadLocal which brings its own complications) has in attempts to run parallel tests in multi-threaded languages like Java or C#

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
documentation, enhancement


___

## **Description**
- Added comprehensive examples in Java and Python across English, Japanese, Portuguese, and Chinese documentation for setting up a fresh browser instance for each test.
- Discussed the drawbacks of using a static WebDriver, especially in the context of parallel testing, and recommended using ThreadLocal for maintaining thread safety.
- Aimed at clarifying best practices for test isolation and reducing confusion around setting up WebDriver instances for Selenium tests.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fresh_browser_per_test.en.md</strong><dd><code>Enhance Documentation with Fresh Browser Per Test Examples</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.en.md

<li>Added detailed explanation and Java, Python code examples for <br>implementing a fresh browser per test.<br> <li> Highlighted issues with using a static WebDriver and recommended using <br>ThreadLocal for thread safety.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1671/files#diff-786fff254c3bf832904eb9df5e183fb9d15f1065b64f717c1d1baed745d8f8bc">+54/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fresh_browser_per_test.ja.md</strong><dd><code>Add Fresh Browser Per Test Examples in Japanese Documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.ja.md

<li>Added Java code examples for setting up a fresh browser per test.<br> <li> Discussed the drawbacks of using a static WebDriver in parallel test <br>execution.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1671/files#diff-bd0ac1ff4ace1b426937149e2a43a11bc5100cf59e8bc4d3f839d644606a063d">+50/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fresh_browser_per_test.pt-br.md</strong><dd><code>Update Portuguese Documentation with Browser Per Test Strategy</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.pt-br.md

<li>Introduced Java and Python examples for initiating a new browser <br>instance per test.<br> <li> Explained the complications of using static WebDriver with ThreadLocal <br>for thread safety.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1671/files#diff-b2e2095a59aa668e4521856ccabf56e24709e72c5a615a735b101cc79f0c96c9">+49/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>fresh_browser_per_test.zh-cn.md</strong><dd><code>Enhance Chinese Documentation with New Browser Per Test Examples</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/test_practices/encouraged/fresh_browser_per_test.zh-cn.md

<li>Provided Java, Python examples for fresh browser setup per test.<br> <li> Addressed the issue of using static WebDriver and the importance of <br>ThreadLocal in test isolation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1671/files#diff-3fda3436ad6658e22aee995735460aa9c44ed181096d796c3d91a1c3cd7ffe3e">+49/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

