### PR TITLE
tiny grammar change: remove use of word 'so'

### DIFF
--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -92,7 +92,7 @@ _Explicit waits_ are loops added to the code that poll the application
 for a specific condition to evaluate as true before it exits the loop and
 continues to the next command in the code. If the condition is not met before a designated timeout value, 
 the code will give a timeout error. Since there are many ways for the application not to be in the desired state,
-so explicit waits are a great choice to specify the exact condition to wait for
+explicit waits are a great choice to specify the exact condition to wait for
 in each place it is needed. 
 Another nice feature is that, by default, the Selenium Wait class automatically waits for the designated element to exist.
 


### PR DESCRIPTION
## **User description**
### Description
I edited one sentence to remove a word that I deem unnecessary.
The sentence I edited begins with 'since'. 
Because it begins with 'since', the second clause of the sentence is a conclusion. 
'so' indicates a conclusion follows. 
The sentence I edited used both 'since' and 'so', but 'since' is enough to indicate a conclusion follows, so I remove 'so'.

### Motivation and Context
The change improves the flow of the sentence.


___

## **Type**
Documentation


___

## **Description**
- This PR improves the documentation by editing a sentence to remove the redundant conjunction 'so', enhancing readability and grammatical correctness.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>waits.en.md</strong><dd><code>Improve Grammar by Removing Redundant Conjunction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/waits.en.md

<li>Removed the word 'so' to improve sentence flow and avoid redundancy in <br>conjunction usage.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1681/files#diff-0f903beeec94e44f636d84011042a3269fca16724e0f9157750468627d2fbcf1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

