### PR TITLE
Updated WebDriver alert interaction Python examples to reference code from Python tests

### DIFF
--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.en.md
@@ -39,19 +39,11 @@ String text = alert.getText();
 //Press the OK button
 alert.accept();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See an example alert").click()
 
-# Wait for the alert to be displayed and store it in a variable
-alert = wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L12-L18" >}}
+{{< /tab >}}
 
-# Store the alert text in a variable
-text = alert.text
-
-# Press the OK button
-alert.accept()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See an example alert")).Click();
@@ -78,9 +70,9 @@ alert_text = alert.text
 # Press on OK button
 alert.accept
   {{< /tab >}}
-  {{< tab header="JavaScript" text=true >}}
-  {{< gh-codeblock path="examples/javascript/test/interactions/alert.spec.js#L19-L21" >}}
-  {{< /tab >}}
+{{< tab header="JavaScript" text=true >}}
+{{< gh-codeblock path="examples/javascript/test/interactions/alert.spec.js#L19-L21" >}}
+{{< /tab >}}
   {{< tab header="Kotlin" >}}
 //Click the link to activate the alert
 driver.findElement(By.linkText("See an example alert")).click()
@@ -122,22 +114,11 @@ String text = alert.getText();
 //Press the Cancel button
 alert.dismiss();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See a sample confirm").click()
 
-# Wait for the alert to be displayed
-wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L26-L32" >}}
+{{< /tab >}}
 
-# Store the alert in a variable for reuse
-alert = driver.switch_to.alert
-
-# Store the alert text in a variable
-text = alert.text
-
-# Press the Cancel button
-alert.dismiss()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See a sample confirm")).Click();
@@ -167,9 +148,9 @@ alert_text = alert.text
 # Press on Cancel button
 alert.dismiss
   {{< /tab >}}
-  {{< tab header="JavaScript" text=true >}}
-  {{< gh-codeblock path="examples/javascript/test/interactions/alert.spec.js#L30-L32" >}}
-  {{< /tab >}}
+{{< tab header="JavaScript" text=true >}}
+{{< gh-codeblock path="examples/javascript/test/interactions/alert.spec.js#L30-L32" >}}
+{{< /tab >}}
   {{< tab header="Kotlin" >}}
 //Click the link to activate the alert
 driver.findElement(By.linkText("See a sample confirm")).click()
@@ -213,22 +194,11 @@ alert.sendKeys("Selenium");
 //Press the OK button
 alert.accept();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See a sample prompt").click()
 
-# Wait for the alert to be displayed
-wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L40-L47" >}}
+{{< /tab >}}
 
-# Store the alert in a variable for reuse
-alert = Alert(driver)
-
-# Type your message
-alert.send_keys("Selenium")
-
-# Press the OK button
-alert.accept()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See a sample prompt")).Click();

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.ja.md
@@ -34,19 +34,11 @@ String text = alert.getText();
 //Press the OK button
 alert.accept();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See an example alert").click()
 
-# Wait for the alert to be displayed and store it in a variable
-alert = wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L12-L18" >}}
+{{< /tab >}}
 
-# Store the alert text in a variable
-text = alert.text
-
-# Press the OK button
-alert.accept()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See an example alert")).Click();
@@ -115,22 +107,11 @@ String text = alert.getText();
 //Press the Cancel button
 alert.dismiss();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See a sample confirm").click()
 
-# Wait for the alert to be displayed
-wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L26-L32" >}}
+{{< /tab >}}
 
-# Store the alert in a variable for reuse
-alert = driver.switch_to.alert
-
-# Store the alert text in a variable
-text = alert.text
-
-# Press the Cancel button
-alert.dismiss()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See a sample confirm")).Click();
@@ -203,22 +184,11 @@ alert.sendKeys("Selenium");
 //Press the OK button
 alert.accept();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See a sample prompt").click()
 
-# Wait for the alert to be displayed
-wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L40-L47" >}}
+{{< /tab >}}
 
-# Store the alert in a variable for reuse
-alert = Alert(driver)
-
-# Type your message
-alert.send_keys("Selenium")
-
-# Press the OK button
-alert.accept()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See a sample prompt")).Click();

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.pt-br.md
@@ -38,32 +38,11 @@ String text = alert.getText();
 //Press the OK button
 alert.accept();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See an example alert").click()
 
-# Wait for the alert to be displayed and store it in a variable
-alert = wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L12-L18" >}}
+{{< /tab >}}
 
-# Store the alert text in a variable
-text = alert.text
-
-# Press the OK button
-alert.accept()
-  {{< /tab >}}
-  {{< tab header="CSharp" >}}
-//Click the link to activate the alert
-driver.FindElement(By.LinkText("See an example alert")).Click();
-
-//Wait for the alert to be displayed and store it in a variable
-IAlert alert = wait.Until(ExpectedConditions.AlertIsPresent());
-
-//Store the alert text in a variable
-string text = alert.Text;
-
-//Press the OK button
-alert.Accept();
-  {{< /tab >}}
   {{< tab header="Ruby" >}}
 # Click the link to activate the alert
 driver.find_element(:link_text, 'See an example alert').click
@@ -120,22 +99,11 @@ String text = alert.getText();
 //Press the Cancel button
 alert.dismiss();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See a sample confirm").click()
 
-# Wait for the alert to be displayed
-wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L26-L32" >}}
+{{< /tab >}}
 
-# Store the alert in a variable for reuse
-alert = driver.switch_to.alert
-
-# Store the alert text in a variable
-text = alert.text
-
-# Press the Cancel button
-alert.dismiss()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See a sample confirm")).Click();
@@ -210,22 +178,11 @@ alert.sendKeys("Selenium");
 //Press the OK button
 alert.accept();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See a sample prompt").click()
 
-# Wait for the alert to be displayed
-wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L40-L47" >}}
+{{< /tab >}}
 
-# Store the alert in a variable for reuse
-alert = Alert(driver)
-
-# Type your message
-alert.send_keys("Selenium")
-
-# Press the OK button
-alert.accept()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See a sample prompt")).Click();

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.zh-cn.md
@@ -31,19 +31,11 @@ String text = alert.getText();
 //Press the OK button
 alert.accept();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See an example alert").click()
 
-# Wait for the alert to be displayed and store it in a variable
-alert = wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L12-L18" >}}
+{{< /tab >}}
 
-# Store the alert text in a variable
-text = alert.text
-
-# Press the OK button
-alert.accept()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See an example alert")).Click();
@@ -111,22 +103,11 @@ String text = alert.getText();
 //Press the Cancel button
 alert.dismiss();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See a sample confirm").click()
 
-# Wait for the alert to be displayed
-wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L26-L32" >}}
+{{< /tab >}}
 
-# Store the alert in a variable for reuse
-alert = driver.switch_to.alert
-
-# Store the alert text in a variable
-text = alert.text
-
-# Press the Cancel button
-alert.dismiss()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See a sample confirm")).Click();
@@ -198,22 +179,11 @@ alert.sendKeys("Selenium");
 //Press the OK button
 alert.accept();
   {{< /tab >}}
-  {{< tab header="Python" >}}
-# Click the link to activate the alert
-driver.find_element(By.LINK_TEXT, "See a sample prompt").click()
 
-# Wait for the alert to be displayed
-wait.until(expected_conditions.alert_is_present())
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_alerts.py#L40-L47" >}}
+{{< /tab >}}
 
-# Store the alert in a variable for reuse
-alert = Alert(driver)
-
-# Type your message
-alert.send_keys("Selenium")
-
-# Press the OK button
-alert.accept()
-  {{< /tab >}}
   {{< tab header="CSharp" >}}
 //Click the link to activate the alert
 driver.FindElement(By.LinkText("See a sample prompt")).Click();

--- a/website_and_docs/hugo.toml
+++ b/website_and_docs/hugo.toml
@@ -6,7 +6,7 @@ enableRobotsTXT = true
 
 # Will give values to .Lastmod etc.
 enableGitInfo = true
-#ignoreErrors = ["error-remote-getjson"]
+ignoreErrors = ["error-remote-getjson"]
 # Language settings
 # contentDir = "content/en"
 defaultContentLanguage = "en"

--- a/website_and_docs/hugo.toml
+++ b/website_and_docs/hugo.toml
@@ -6,7 +6,7 @@ enableRobotsTXT = true
 
 # Will give values to .Lastmod etc.
 enableGitInfo = true
-ignoreErrors = ["error-remote-getjson"]
+#ignoreErrors = ["error-remote-getjson"]
 # Language settings
 # contentDir = "content/en"
 defaultContentLanguage = "en"


### PR DESCRIPTION
## **User description**
### Description
Updated the following markdown files to reference tested Python code in examples for using WebDriver to interact with alerts:
- alerts.en.md
- alerts.ja.md
- alerts.pt-br.md
- alerts.zh-cn.md

Additionally, fixed indentations for the JavaScript tabs in alerts.en.md because they were not being rendered correctly.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The documentation now includes tested code examples for WebDriver alert interactions using Python.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
documentation, enhancement


___

## **Description**
- Updated Python code examples across English, Japanese, Portuguese (Brazil), and Chinese (Simplified) versions of the WebDriver alerts documentation to reference externally tested code.
- Improved JavaScript tab formatting in the English version for better rendering.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>alerts.en.md</strong><dd><code>Update Python Examples and Fix JavaScript Formatting in English Alerts </code><br><code>Documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/interactions/alerts.en.md

<li>Replaced direct Python code examples with links to tested Python code <br>in <code>test_alerts.py</code>.<br> <li> Adjusted formatting for the JavaScript tab to ensure proper rendering.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1698/files#diff-fb8047c1306f4eb343402236341b2357428e788a6844249f5071781df60af720">+15/-45</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>alerts.ja.md</strong><dd><code>Update Python Examples in Japanese Alerts Documentation</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/interactions/alerts.ja.md

<li>Updated Python code examples to reference tested code from <br><code>test_alerts.py</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1698/files#diff-c712e78626eca36afd4aaa33cbf1520520ec89122a53d8c1ddf1b6df6e861feb">+9/-39</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>alerts.pt-br.md</strong><dd><code>Update Python Examples in Portuguese (Brazil) Alerts Documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/interactions/alerts.pt-br.md

<li>Updated Python code examples to reference tested code from <br><code>test_alerts.py</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1698/files#diff-dbad5b379774e2deef241e24f9d378bed778d03bb132cd2eaaa6c873615cea11">+9/-52</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>alerts.zh-cn.md</strong><dd><code>Update Python Examples in Chinese (Simplified) Alerts Documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/interactions/alerts.zh-cn.md

<li>Updated Python code examples to reference tested code from <br><code>test_alerts.py</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1698/files#diff-497c730502211ea2a2aabe5ecfd79a5160facc22b4e436cfce369a94ab872732">+9/-39</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

