### PR TITLE
#1697 - Fixed Hugo depericate warning on custom params

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f
         with:
-          hugo-version: '0.110.0'
+          hugo-version: '0.124.1'
           extended: true
       - name: Build
         run: chmod +x build-site.sh && ./build-site.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f
         with:
-          hugo-version: '0.124.1'
+          hugo-version: ' 0.125.4'
           extended: true
       - name: Build
         run: chmod +x build-site.sh && ./build-site.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f
         with:
-          hugo-version: '0.110.0'
+          hugo-version: '0.124.1'
           extended: true
       - name: Build
         run: chmod +x build-site.sh && ./build-site.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f
         with:
-          hugo-version: '0.124.1'
+          hugo-version: '0.125.4'
           extended: true
       - name: Build
         run: chmod +x build-site.sh && ./build-site.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the repository used to build and publish the official Selenium [website]
 We use [Hugo](https://gohugo.io/) and the [Docsy theme](https://www.docsy.dev/)
 to build and render the site. You will need the **extended**
 Sass/SCSS version of the Hugo binary to work on this site. We recommend
-to use Hugo 0.110.0.
+to use Hugo 0.124.1.
 
 Steps needed to have this working locally and work on it:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the repository used to build and publish the official Selenium [website]
 We use [Hugo](https://gohugo.io/) and the [Docsy theme](https://www.docsy.dev/)
 to build and render the site. You will need the **extended**
 Sass/SCSS version of the Hugo binary to work on this site. We recommend
-to use Hugo 0.124.1.
+to use Hugo 0.125.4
 
 Steps needed to have this working locally and work on it:
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "chmod +x build-site.sh && ./build-site.sh"
 
 [context.production.environment]
 NODE_VERSION = "18.14.1"
-HUGO_VERSION = "0.110.0"
+HUGO_VERSION = "0.124.1"
 GO_VERSION = "1.20.1"
 HUGO_ENV = "production"
 
@@ -13,7 +13,7 @@ command = "chmod +x build-site.sh && ./build-site.sh"
 
 [context.deploy-preview.environment]
 NODE_VERSION = "18.14.1"
-HUGO_VERSION = "0.110.0"
+HUGO_VERSION = "0.124.1"
 GO_VERSION = "1.20.1"
 
 [context.branch-deploy]
@@ -21,5 +21,5 @@ command = "chmod +x build-site.sh && ./build-site.sh"
 
 [context.branch-deploy.environment]
 NODE_VERSION = "18.14.1"
-HUGO_VERSION = "0.110.0"
+HUGO_VERSION = "0.124.1"
 GO_VERSION = "1.20.1"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "chmod +x build-site.sh && ./build-site.sh"
 
 [context.production.environment]
 NODE_VERSION = "18.14.1"
-HUGO_VERSION = "0.124.1"
+HUGO_VERSION = "0.125.4"
 GO_VERSION = "1.20.1"
 HUGO_ENV = "production"
 
@@ -13,7 +13,7 @@ command = "chmod +x build-site.sh && ./build-site.sh"
 
 [context.deploy-preview.environment]
 NODE_VERSION = "18.14.1"
-HUGO_VERSION = "0.124.1"
+HUGO_VERSION = "0.125.4"
 GO_VERSION = "1.20.1"
 
 [context.branch-deploy]
@@ -21,5 +21,5 @@ command = "chmod +x build-site.sh && ./build-site.sh"
 
 [context.branch-deploy.environment]
 NODE_VERSION = "18.14.1"
-HUGO_VERSION = "0.124.1"
+HUGO_VERSION = "0.125.4"
 GO_VERSION = "1.20.1"

--- a/website_and_docs/go.mod
+++ b/website_and_docs/go.mod
@@ -3,6 +3,6 @@ module github.com/SeleniumHQseleniumhq.github.io
 go 1.20
 
 require (
-	github.com/google/docsy v0.8.0 // indirect
+	github.com/google/docsy v0.9.1 // indirect
 	github.com/google/docsy/dependencies v0.7.2 // indirect
 )

--- a/website_and_docs/go.mod
+++ b/website_and_docs/go.mod
@@ -3,6 +3,6 @@ module github.com/SeleniumHQseleniumhq.github.io
 go 1.20
 
 require (
-	github.com/google/docsy v0.9.1 // indirect
+	github.com/google/docsy v0.10.0 // indirect
 	github.com/google/docsy/dependencies v0.7.2 // indirect
 )

--- a/website_and_docs/go.sum
+++ b/website_and_docs/go.sum
@@ -1,8 +1,11 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.7.2 h1:KzhFgTd3taF1jq9HDemH3omlUqn9qfdE68sxRyTySpM=
 github.com/google/docsy v0.7.2/go.mod h1:ol3w2s1FBUzENdKSAEeNjtuaISUzHYHTw60xv5QH3Dg=
 github.com/google/docsy v0.8.0 h1:RgHyKRTo8YwScMThrf01Ky2yCGpUS1hpkspwNv6szT4=
 github.com/google/docsy v0.8.0/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
+github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
+github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
 github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
 github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/website_and_docs/go.sum
+++ b/website_and_docs/go.sum
@@ -1,11 +1,15 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.7.2 h1:KzhFgTd3taF1jq9HDemH3omlUqn9qfdE68sxRyTySpM=
 github.com/google/docsy v0.7.2/go.mod h1:ol3w2s1FBUzENdKSAEeNjtuaISUzHYHTw60xv5QH3Dg=
 github.com/google/docsy v0.8.0 h1:RgHyKRTo8YwScMThrf01Ky2yCGpUS1hpkspwNv6szT4=
 github.com/google/docsy v0.8.0/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
 github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
 github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
+github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
+github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
 github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
 github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
+github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/website_and_docs/hugo.toml
+++ b/website_and_docs/hugo.toml
@@ -53,35 +53,40 @@ anchor = "smart"
 [languages]
 [languages.en]
 title = "Selenium"
-description = "Selenium automates browsers. That's it!"
 languageName ="English"
 weight = 1
+[languages.en.params]
+description = "Selenium automates browsers. That's it!"
 [languages.pt-br]
 title = "Selenium"
-description = "Selenium automates browsers. That's it!"
 languageName ="Português (Brasileiro)"
 weight = 2
+[languages.pt-br.params]
+description = "Selenium automates browsers. That's it!"
 [languages.zh-cn]
 title = "Selenium"
-description = "Selenium automates browsers. That's it!"
 languageName = "中文简体"
 weight = 3
+[languages.zh-cn.params]
+description = "Selenium automates browsers. That's it!"
 [languages.ja]
 title = "Selenium"
-description = "Selenium automates browsers. That's it!"
 languageName = "日本語"
 weight = 4
+[languages.ja.params]
+description = "Selenium automates browsers. That's it!"
 [languages.other]
 title = "Selenium"
-description = "Selenium automates browsers. That's it!"
 languageName ="Other"
 weight = 5
+[languages.other.params]
+description = "Selenium automates browsers. That's it!"
 
 # Import docsy theme as module
 [module]
   proxy = "direct"
   # uncomment line below for temporary local development of module
-  # replacements = "github.com/google/docsy -> ../../docsy"
+  #replacements = "github.com/google/docsy -> ../../docsy"
   [module.hugoVersion]
     extended = true
     min = "0.73.0"


### PR DESCRIPTION
## **User description**
Fixed Hugo depericate warning "custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.126.0"

Fix for https://github.com/SeleniumHQ/seleniumhq.github.io/issues/1697

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
After updating hugo v0.125.4 , I'm getting "custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.126.0"for several translations.

### Motivation and Context
So as a fix, we need to put the values as suggested.
[languages.zh-cn.params]

Source
https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ X] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ X] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
Enhancement


___

## **Description**
- Updated `hugo.toml` to move language-specific 'description' fields into a new 'params' sub-table for each language.
- This modification is in response to deprecation warnings from Hugo, ensuring compatibility with future Hugo versions.
- Affected languages include English, Portuguese (Brazilian), Simplified Chinese, Japanese, and an unspecified 'Other' language.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hugo.toml</strong><dd><code>Update Language Configurations to New Hugo Params Structure</code></dd></summary>
<hr>
      
website_and_docs/hugo.toml

<li>Moved 'description' for each language into a new 'params' sub-table to <br>adhere to Hugo's updated requirements.<br> <li> This change affects multiple language configurations including <br>English, Portuguese (Brazilian), Simplified Chinese, Japanese, and <br>Other.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1699/files#diff-7c7b0a30aca04da823c578a790ae39208bfb7bc0195ccc764f74a3f2a049e467">+11/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

