### PR TITLE
Correct wrong file path in options to provide the right browser version ruby example

### DIFF
--- a/website_and_docs/content/documentation/webdriver/drivers/options.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/options.en.md
@@ -67,7 +67,7 @@ it will be automatically downloaded by [Selenium Manager]({{< ref "../../seleniu
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L40" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/options_spec.rb#L40" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/options.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/options.ja.md
@@ -68,7 +68,7 @@ it will be automatically downloaded by [Selenium Manager]({{< ref "../../seleniu
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L40" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/options_spec.rb#L40" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/options.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/options.pt-br.md
@@ -80,7 +80,7 @@ tiver apenas 80 instalados, a criação da sessão falhará.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L40" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/options_spec.rb#L40" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/options.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/options.zh-cn.md
@@ -71,7 +71,7 @@ it will be automatically downloaded by [Selenium Manager]({{< ref "../../seleniu
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/service_spec.rb#L40" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/options_spec.rb#L40" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
## **User description**
### Description
While creating #1679 I accidentally mapped the wrong path to the options example, this PR fixes that path

### Motivation and Context
It's important to provide Selenium users with high-quality examples in the docs so they can use it in the best possible way, right now the example for the browser version looks like this:

<img width="1134" alt="Screenshot 2024-04-29 at 23 19 11" src="https://github.com/SeleniumHQ/seleniumhq.github.io/assets/33221555/d32a5015-5e66-4256-9059-39989dd014bb">

Which is not helpful for selenium users

### Types of changes
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

## **Type**
documentation


___

## **Description**
- Corrected the file path in Ruby code examples across multiple language versions of the documentation.
- Ensured that the Ruby examples point to the correct script (`options_spec.rb`) improving the accuracy and usefulness of the documentation.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>options.en.md</strong><dd><code>Fix Incorrect Ruby Example Path in English Documentation</code>&nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/drivers/options.en.md

<li>Corrected the file path in the Ruby code block from <code>service_spec.rb</code> to <br><code>options_spec.rb</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1701/files#diff-62bab9f28d27a7f462881a28eca384a0e534a730f849248f396d171820bc748e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>options.ja.md</strong><dd><code>Update Ruby Example Path in Japanese Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/drivers/options.ja.md

<li>Updated the file path in the Ruby code block from <code>service_spec.rb</code> to <br><code>options_spec.rb</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1701/files#diff-2ed475220bde1368cfa3883d71db179409ddaf9ccbaea847ed3f6ffe816321e4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>options.pt-br.md</strong><dd><code>Correct Ruby Example Path in Brazilian Portuguese Documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/drivers/options.pt-br.md

<li>Changed the file path in the Ruby code block from <code>service_spec.rb</code> to <br><code>options_spec.rb</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1701/files#diff-6eaa598a13e9d64c6afbd54b84aef470520557f08c4d183ffb28ceb9ed04d0bb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>options.zh-cn.md</strong><dd><code>Update Ruby Example Path in Chinese Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/drivers/options.zh-cn.md

<li>Modified the file path in the Ruby code block from <code>service_spec.rb</code> to <br><code>options_spec.rb</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1701/files#diff-9b23b749355db8154bfcc4a1d70f809b7d4e91a7b3044f9ac74a6c1a005873d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

