### PR TITLE
Add the http client configuration example for ruby

### DIFF
--- a/examples/ruby/spec/drivers/http_client_spec.rb
+++ b/examples/ruby/spec/drivers/http_client_spec.rb
@@ -1,6 +1,17 @@
-# frozen_string_literal: true
-
 require 'spec_helper'
 
 RSpec.describe 'HTTP Client' do
+  let(:url) { 'https://www.selenium.dev/selenium/web/' }
+
+  it 'sets client configuration' do
+    client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: 30, read_timeout: 30)
+    expect(client.open_timeout).to eq 30
+  end
+
+  it 'uses the custom http client' do
+    client = Selenium::WebDriver::Remote::Http::Default.new
+    driver = Selenium::WebDriver.for :chrome, http_client: client
+    driver.get(url)
+    driver.quit
+  end
 end

--- a/website_and_docs/content/documentation/webdriver/drivers/http_client.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/http_client.en.md
@@ -17,7 +17,7 @@ These allow you to set various parameters for the HTTP library
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L9-L10" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/http_client.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/http_client.ja.md
@@ -17,7 +17,7 @@ These allow you to set various parameters for the HTTP library
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L9-L10" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/http_client.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/http_client.pt-br.md
@@ -17,7 +17,7 @@ These allow you to set various parameters for the HTTP library
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L9-L10" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/http_client.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/http_client.zh-cn.md
@@ -17,7 +17,7 @@ weight: 3
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L9-L10" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
### Description

This PR adds tests to exemplify the configuration of the HTTP client that is possible to use with Selenium webdriver from a ruby perspective

<img width="1152" alt="Screenshot 2024-05-02 at 19 51 49" src="https://github.com/SeleniumHQ/seleniumhq.github.io/assets/33221555/81c38f62-139a-4323-b9ac-ef61dad8ce72">


### Motivation and Context

It's important to keep examples of all the features for everyone using Selenium to be able to understand the full capabilities

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

