### PR TITLE
Update http client examples

### DIFF
--- a/website_and_docs/content/documentation/webdriver/drivers/http_client.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/http_client.en.md
@@ -17,7 +17,7 @@ These allow you to set various parameters for the HTTP library
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L9-L10" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L7-L8" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/http_client.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/http_client.ja.md
@@ -17,7 +17,7 @@ These allow you to set various parameters for the HTTP library
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L9-L10" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L7-L8" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/http_client.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/http_client.pt-br.md
@@ -17,7 +17,7 @@ These allow you to set various parameters for the HTTP library
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L9-L10" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L7-L8" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/http_client.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/http_client.zh-cn.md
@@ -17,7 +17,7 @@ weight: 3
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L9-L10" >}}
+{{< gh-codeblock path="examples/ruby/spec/drivers/http_client_spec.rb#L7-L8" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
## **User description**
### Description
This PR fixes the reference for the HTTP client examples

### Motivation and Context
It's important that all the examples are correct so users can use them as a reference, currently they look like this:

<img width="1118" alt="Screenshot 2024-05-05 at 13 33 02" src="https://github.com/SeleniumHQ/seleniumhq.github.io/assets/33221555/727041a4-d707-499c-acfb-8175dd63fc23">


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

## **Type**
documentation


___

## **Description**
- Updated the Ruby example code block references across multiple language versions of the WebDriver HTTP client documentation.
- Changes ensure that the documentation points to the correct lines of code in the Ruby examples.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_client.en.md</strong><dd><code>Update Ruby code block reference in English documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/drivers/http_client.en.md

<li>Updated the Ruby code block reference from lines 9-10 to lines 7-8.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1708/files#diff-901b1ac06baf146171309bb00e320fb300f355e1f4ff5c65a8d766cb8101810f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>http_client.ja.md</strong><dd><code>Update Ruby code block reference in Japanese documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/drivers/http_client.ja.md

<li>Updated the Ruby code block reference from lines 9-10 to lines 7-8.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1708/files#diff-acd7e6665eb2720f3f7e5c3ce9298d6ee59d2fc86d61e671b52e66a1ea1a5e62">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>http_client.pt-br.md</strong><dd><code>Update Ruby code block reference in Portuguese documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/drivers/http_client.pt-br.md

<li>Updated the Ruby code block reference from lines 9-10 to lines 7-8.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1708/files#diff-55ad58be7b1541a2e738e7a9a5d82d746b6b302f81617b6887991baf70aa9aee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>http_client.zh-cn.md</strong><dd><code>Update Ruby code block reference in Chinese documentation</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/drivers/http_client.zh-cn.md

<li>Updated the Ruby code block reference from lines 9-10 to lines 7-8.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1708/files#diff-163f3b07fc10d79dd1faa764adb9d8f3781adcf425e6bd60255c7b005978f2f8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

