### PR TITLE
Update Custom Node Initialization in Grid Advanced Features

### DIFF
--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
@@ -95,7 +95,7 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecretm, Duration sessionTimeout) {
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, Duration sessionTimeout) {
 	super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
@@ -96,7 +96,7 @@ public class DecoratedLoggingNode extends Node {
   private Node node;
 
   protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
-	super(tracer, nodeId, uri, registrationSecret);
+	super(tracer, nodeId, uri, registrationSecret, Duration sessionTimeout);
   }
 
   public static Node create(Config config) {
@@ -104,6 +104,8 @@ public class DecoratedLoggingNode extends Node {
     BaseServerOptions serverOptions = new BaseServerOptions(config);
     URI uri = serverOptions.getExternalUri();
     SecretOptions secretOptions = new SecretOptions(config);
+    NodeOptions nodeOptions = new NodeOptions(config);
+    Duration sessionTimeout = nodeOptions.getSessionTimeout();
 
     // Refer to the foot notes for additional context on this line.
     Node node = LocalNodeFactory.create(config);
@@ -111,7 +113,9 @@ public class DecoratedLoggingNode extends Node {
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
 				node.getId(),
 				uri,
-				secretOptions.getRegistrationSecret());
+				secretOptions.getRegistrationSecret(),
+        sessionTimeout
+        );
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
@@ -114,8 +114,7 @@ public class DecoratedLoggingNode extends Node {
 				node.getId(),
 				uri,
 				secretOptions.getRegistrationSecret(),
-        sessionTimeout
-        );
+        sessionTimeout);
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
@@ -96,7 +96,7 @@ public class DecoratedLoggingNode extends Node {
   private Node node;
 
   protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, Duration sessionTimeout) {
-	super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
+    super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 
   public static Node create(Config config) {
@@ -111,9 +111,9 @@ public class DecoratedLoggingNode extends Node {
     Node node = LocalNodeFactory.create(config);
 
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
-				node.getId(),
-				uri,
-				secretOptions.getRegistrationSecret(),
+        node.getId(),
+        uri,
+        secretOptions.getRegistrationSecret(),
         sessionTimeout);
     wrapper.node = node;
     return wrapper;

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md
@@ -95,8 +95,8 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
-	super(tracer, nodeId, uri, registrationSecret, Duration sessionTimeout);
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecretm, Duration sessionTimeout) {
+	super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 
   public static Node create(Config config) {

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
@@ -101,7 +101,7 @@ public class DecoratedLoggingNode extends Node {
   private Node node;
 
   protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, Duration sessionTimeout) {
-  super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
+    super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 
   public static Node create(Config config) {

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
@@ -100,8 +100,8 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
-  super(tracer, nodeId, uri, registrationSecret, Duration sessionTimeout);
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, Duration sessionTimeout) {
+  super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 
   public static Node create(Config config) {

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
@@ -101,7 +101,7 @@ public class DecoratedLoggingNode extends Node {
   private Node node;
 
   protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
-	super(tracer, nodeId, uri, registrationSecret);
+  super(tracer, nodeId, uri, registrationSecret, Duration sessionTimeout);
   }
 
   public static Node create(Config config) {
@@ -109,14 +109,18 @@ public class DecoratedLoggingNode extends Node {
     BaseServerOptions serverOptions = new BaseServerOptions(config);
     URI uri = serverOptions.getExternalUri();
     SecretOptions secretOptions = new SecretOptions(config);
+    NodeOptions nodeOptions = new NodeOptions(config);
+    Duration sessionTimeout = nodeOptions.getSessionTimeout();
 
     // Refer to the foot notes for additional context on this line.
     Node node = LocalNodeFactory.create(config);
 
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
-				node.getId(),
-				uri,
-				secretOptions.getRegistrationSecret());
+        node.getId(),
+        uri,
+        secretOptions.getRegistrationSecret(),
+        sessionTimeout
+        );
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md
@@ -119,8 +119,7 @@ public class DecoratedLoggingNode extends Node {
         node.getId(),
         uri,
         secretOptions.getRegistrationSecret(),
-        sessionTimeout
-        );
+        sessionTimeout);
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
@@ -91,7 +91,7 @@ public class DecoratedLoggingNode extends Node {
   private Node node;
 
   protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
-	super(tracer, nodeId, uri, registrationSecret);
+  super(tracer, nodeId, uri, registrationSecret, Duration sessionTimeout);
   }
 
   public static Node create(Config config) {
@@ -99,14 +99,18 @@ public class DecoratedLoggingNode extends Node {
     BaseServerOptions serverOptions = new BaseServerOptions(config);
     URI uri = serverOptions.getExternalUri();
     SecretOptions secretOptions = new SecretOptions(config);
+    NodeOptions nodeOptions = new NodeOptions(config);
+    Duration sessionTimeout = nodeOptions.getSessionTimeout();
 
     // Refer to the foot notes for additional context on this line.
     Node node = LocalNodeFactory.create(config);
 
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
-				node.getId(),
-				uri,
-				secretOptions.getRegistrationSecret());
+        node.getId(),
+        uri,
+        secretOptions.getRegistrationSecret(),
+        sessionTimeout
+        );
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
@@ -90,8 +90,8 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
-  super(tracer, nodeId, uri, registrationSecret, Duration sessionTimeout);
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, Duration sessionTimeout) {
+  super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 
   public static Node create(Config config) {

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
@@ -91,7 +91,7 @@ public class DecoratedLoggingNode extends Node {
   private Node node;
 
   protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, Duration sessionTimeout) {
-  super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
+    super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 
   public static Node create(Config config) {

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md
@@ -109,8 +109,7 @@ public class DecoratedLoggingNode extends Node {
         node.getId(),
         uri,
         secretOptions.getRegistrationSecret(),
-        sessionTimeout
-        );
+        sessionTimeout);
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
@@ -101,7 +101,7 @@ public class DecoratedLoggingNode extends Node {
   private Node node;
 
   protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, Duration sessionTimeout) {
-  super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
+    super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 
   public static Node create(Config config) {

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
@@ -100,8 +100,8 @@ public class DecoratedLoggingNode extends Node {
 
   private Node node;
 
-  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
-  super(tracer, nodeId, uri, registrationSecret, Duration sessionTimeout);
+  protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret, Duration sessionTimeout) {
+  super(tracer, nodeId, uri, registrationSecret, sessionTimeout);
   }
 
   public static Node create(Config config) {

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
@@ -101,7 +101,7 @@ public class DecoratedLoggingNode extends Node {
   private Node node;
 
   protected DecoratedLoggingNode(Tracer tracer, NodeId nodeId, URI uri, Secret registrationSecret) {
-	super(tracer, nodeId, uri, registrationSecret);
+  super(tracer, nodeId, uri, registrationSecret, Duration sessionTimeout);
   }
 
   public static Node create(Config config) {
@@ -109,14 +109,18 @@ public class DecoratedLoggingNode extends Node {
     BaseServerOptions serverOptions = new BaseServerOptions(config);
     URI uri = serverOptions.getExternalUri();
     SecretOptions secretOptions = new SecretOptions(config);
+    NodeOptions nodeOptions = new NodeOptions(config);
+    Duration sessionTimeout = nodeOptions.getSessionTimeout();
 
     // Refer to the foot notes for additional context on this line.
     Node node = LocalNodeFactory.create(config);
 
     DecoratedLoggingNode wrapper = new DecoratedLoggingNode(loggingOptions.getTracer(),
-				node.getId(),
-				uri,
-				secretOptions.getRegistrationSecret());
+        node.getId(),
+        uri,
+        secretOptions.getRegistrationSecret(),
+        sessionTimeout
+        );
     wrapper.node = node;
     return wrapper;
   }

--- a/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
+++ b/website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md
@@ -119,8 +119,7 @@ public class DecoratedLoggingNode extends Node {
         node.getId(),
         uri,
         secretOptions.getRegistrationSecret(),
-        sessionTimeout
-        );
+        sessionTimeout);
     wrapper.node = node;
     return wrapper;
   }


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**


<!--- Provide a general summary of your changes in the Title above -->

### Description
With this [change](https://github.com/SeleniumHQ/selenium/commit/72562d8d88e9f2e2492c461910e6dd6124e0e954), the `Node` constructor now requires a the `sessionTimeout` argument. Updating code sample to pass it along to the `DecoratedLoggingNode` constructor.

### Motivation and Context
Current example will error out with the following error:

```
constructor Node in class org.openqa.selenium.grid.node.Node cannot be applied to given types;
62.49 [ERROR]   required: org.openqa.selenium.remote.tracing.Tracer,org.openqa.selenium.grid.data.NodeId,java.net.URI,org.openqa.selenium.grid.security.Secret,java.time.Duration
62.49 [ERROR]   found: org.openqa.selenium.remote.tracing.Tracer,org.openqa.selenium.grid.data.NodeId,java.net.URI,org.openqa.selenium.grid.security.Secret
62.49 [ERROR]   reason: actual and formal argument lists differ in length
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
bug_fix, enhancement


___

### **Description**
- Updated the `DecoratedLoggingNode` constructor across multiple language versions (English, Japanese, Portuguese-BR, Chinese) to include a new `sessionTimeout` parameter.
- Modified the `create` method in each language version to fetch `sessionTimeout` from `NodeOptions` and pass it correctly to the `DecoratedLoggingNode` constructor.
- This change ensures compatibility with the updated `Node` constructor requirements, preventing initialization errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customize_node.en.md</strong><dd><code>Update Node Initialization to Include Session Timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/grid/advanced_features/customize_node.en.md

<li>Updated the constructor of <code>DecoratedLoggingNode</code> to include <br><code>sessionTimeout</code> parameter.<br> <li> Adjusted the <code>create</code> method to fetch <code>sessionTimeout</code> from <code>NodeOptions</code> <br>and pass it to the constructor.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1729/files#diff-26dd9e1ce0f611040fb6fdd019d9c40892f87ee8ae0ad95cfbf9630ce4597ba7">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>customize_node.ja.md</strong><dd><code>Update Node Initialization to Include Session Timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/grid/advanced_features/customize_node.ja.md

<li>Updated the constructor of <code>DecoratedLoggingNode</code> to include <br><code>sessionTimeout</code> parameter.<br> <li> Adjusted the <code>create</code> method to fetch <code>sessionTimeout</code> from <code>NodeOptions</code> <br>and pass it to the constructor.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1729/files#diff-afdf67135cb26acd8d3f0a4966e88b50537ea66aaf7383403c05a3e1fb0db94e">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>customize_node.pt-br.md</strong><dd><code>Update Node Initialization to Include Session Timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/grid/advanced_features/customize_node.pt-br.md

<li>Updated the constructor of <code>DecoratedLoggingNode</code> to include <br><code>sessionTimeout</code> parameter.<br> <li> Adjusted the <code>create</code> method to fetch <code>sessionTimeout</code> from <code>NodeOptions</code> <br>and pass it to the constructor.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1729/files#diff-3c26b5f73e1b285f4e8de650c31b5323569b9ca4c022a774b93364cf7b7c9e4d">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>customize_node.zh-cn.md</strong><dd><code>Update Node Initialization to Include Session Timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/grid/advanced_features/customize_node.zh-cn.md

<li>Updated the constructor of <code>DecoratedLoggingNode</code> to include <br><code>sessionTimeout</code> parameter.<br> <li> Adjusted the <code>create</code> method to fetch <code>sessionTimeout</code> from <code>NodeOptions</code> <br>and pass it to the constructor.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1729/files#diff-382b63cbb45edfd02222e79b419219e741bf9e0999f56c9c31ef98bb4401a4e1">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

