### PR TITLE
Add permissions examples and update the log examples

### DIFF
--- a/examples/ruby/spec/browsers/chrome_spec.rb
+++ b/examples/ruby/spec/browsers/chrome_spec.rb
@@ -133,15 +133,25 @@ RSpec.describe 'Chrome' do
         'download_throughput' => 200,
         'upload_throughput' => 200)
     end
-  end
 
-  it 'gets the browser logs' do
-    @driver = Selenium::WebDriver.for :chrome
-    @driver.navigate.to 'https://www.selenium.dev/selenium/web/'
-    sleep 1
-    logs = @driver.logs.get(:browser)
+    it 'gets the browser logs' do
+      @driver = Selenium::WebDriver.for :chrome
+      @driver.navigate.to 'https://www.selenium.dev/selenium/web/'
+      sleep 1
+      logs = @driver.logs.get(:browser)
 
-    expect(logs.first.message).to include 'Failed to load resource'
+      expect(logs.first.message).to include 'Failed to load resource'
+    end
+
+    it 'sets permissions' do
+      @driver = Selenium::WebDriver.for :chrome
+      @driver.navigate.to 'https://www.selenium.dev/selenium/web/'
+      @driver.add_permission('camera', 'denied')
+      @driver.add_permissions('clipboard-read' => 'denied', 'clipboard-write' => 'prompt')
+      expect(permission('camera')).to eq('denied')
+      expect(permission('clipboard-read')).to eq('denied')
+      expect(permission('clipboard-write')).to eq('prompt')
+    end
   end
 
   def driver_finder
@@ -150,5 +160,10 @@ RSpec.describe 'Chrome' do
     finder = Selenium::WebDriver::DriverFinder.new(options, service)
     ENV['CHROMEDRIVER_BIN'] = finder.driver_path
     ENV['CHROME_BIN'] = finder.browser_path
+  end
+
+  def permission(name)
+    @driver.execute_async_script('callback = arguments[arguments.length - 1];' \
+                                 'callback(navigator.permissions.query({name: arguments[0]}));', name)['state']
   end
 end

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
@@ -428,7 +428,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L142" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L141" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -451,7 +451,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L149-L150" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
@@ -434,7 +434,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L142" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L141" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -457,7 +457,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L149-L150" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
@@ -431,7 +431,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L142" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L141" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -454,7 +454,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L149-L150" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
@@ -430,7 +430,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L142" >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L141" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -453,7 +453,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/chrome_spec.rb#L149-L150" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
### **User description**
### Description
This PR adds examples for permissions in Chrome using Ruby, it also updates and organizes the logs test so they are under the same describe group

### Motivation and Context

The documentation must be up to date so users can find concrete examples and be aware of all the possibilities that Selenium has to offer

Right now the example looks like this:

<img width="1245" alt="Screenshot 2024-05-20 at 17 40 55" src="https://github.com/SeleniumHQ/seleniumhq.github.io/assets/33221555/7d47ec2c-5059-4b87-b546-4f237a057401">


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added a new test for setting permissions in Chrome using Ruby.
- Refactored the existing test for getting browser logs in Chrome.
- Introduced a helper method `permission` to check permission states in tests.
- Updated code block references for Ruby examples in Chrome documentation across multiple languages (EN, JA, PT-BR, ZH-CN).



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome_spec.rb</strong><dd><code>Add and refactor tests for Chrome browser permissions and logs</code></dd></summary>
<hr>
      
examples/ruby/spec/browsers/chrome_spec.rb

<li>Added a new test for setting permissions in Chrome.<br> <li> Refactored the existing test for getting browser logs.<br> <li> Introduced a helper method <code>permission</code> to check permission states.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1731/files#diff-f3e68237826e1b64c37885dc12602e936e6e4ea29da653aeb659d466a465ffca">+22/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome.en.md</strong><dd><code>Update Ruby code block references in Chrome documentation (EN)</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/chrome.en.md

- Updated code block references for Ruby examples.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1731/files#diff-eccc7d2ca21e26be42c8c903fa062012754d5ea90f001a432f4f9961e87b078c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chrome.ja.md</strong><dd><code>Update Ruby code block references in Chrome documentation (JA)</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md

- Updated code block references for Ruby examples.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1731/files#diff-85cef9cb445defdf9de42ecc0dbd533e2ef2b0b47bcd8fb2aecc09f2114b3238">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chrome.pt-br.md</strong><dd><code>Update Ruby code block references in Chrome documentation (PT-BR)</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md

- Updated code block references for Ruby examples.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1731/files#diff-4d648f7aea25c7e23a591cdb153ae6a6857d909ab673354eafdf3c5a3b4c4aa7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chrome.zh-cn.md</strong><dd><code>Update Ruby code block references in Chrome documentation (ZH-CN)</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md

- Updated code block references for Ruby examples.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1731/files#diff-1aff253f48970f96fb108fece2476c5e0d815aec68c4275a2746b2bad32a377f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

