### PR TITLE
Add all special features examples for edge using ruby

### DIFF
--- a/website_and_docs/content/documentation/webdriver/browsers/edge.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.en.md
@@ -380,7 +380,7 @@ You can drive Chrome Cast devices with Edge, including sharing tabs
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L119-L123" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -405,7 +405,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L129" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -428,7 +428,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L141" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -451,7 +451,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L149-L150" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
@@ -382,7 +382,7 @@ You can drive Chrome Cast devices with Edge, including sharing tabs
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L119-L123" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -407,7 +407,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L129" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -430,7 +430,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L141" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -453,7 +453,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L149-L150" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md
@@ -382,7 +382,7 @@ You can drive Chrome Cast devices with Edge, including sharing tabs
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L119-L123" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -407,7 +407,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L129" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -430,7 +430,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L141" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -453,7 +453,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L149-L150" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md
@@ -382,7 +382,7 @@ You can drive Chrome Cast devices with Edge, including sharing tabs
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L119-L123" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -407,7 +407,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L129" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -430,7 +430,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L141" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -453,7 +453,7 @@ You can simulate various network conditions.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/edge_spec.rb#L149-L150" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
### **User description**
### Description
This PR adds extra tests to the edge spec file to add examples of special features in the browser, this PR is similar to #1711 and the related PRs

### Motivation and Context
Is important that all of the users and community member have access to examples so they can easily start automating and working with Selenium

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
Tests, Documentation


___

### **Description**
- Added new tests for special features in the Edge browser using Ruby, including casting, network conditions, browser logs, and permissions.
- Introduced a helper method `permission` to check permissions in the Edge browser.
- Updated Edge documentation in multiple languages (EN, JA, PT-BR, ZH-CN) to link Ruby code examples to specific lines in `edge_spec.rb`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edge_spec.rb</strong><dd><code>Add tests for special features in Edge browser using Ruby</code></dd></summary>
<hr>
      
examples/ruby/spec/browsers/edge_spec.rb

<li>Added tests for casting, network conditions, browser logs, and <br>permissions.<br> <li> Introduced helper method <code>permission</code> to check permissions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1740/files#diff-ce732d879039536c913cb3187ea74e6fa652d45886994b9d4c159319e57f1b20">+46/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>edge.en.md</strong><dd><code>Update Ruby code examples links in Edge documentation (EN)</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/edge.en.md

<li>Updated Ruby code examples to link to specific lines in <code>edge_spec.rb</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1740/files#diff-eba585ea4c9d1d71d09ee69558012785b4310856fd2b562e49433c4157766b36">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>edge.ja.md</strong><dd><code>Update Ruby code examples links in Edge documentation (JA)</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/edge.ja.md

<li>Updated Ruby code examples to link to specific lines in <code>edge_spec.rb</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1740/files#diff-3e852f27c226e1c9c7225112069d43d93dea6a09b6257647d8aaea9cd20e984b">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>edge.pt-br.md</strong><dd><code>Update Ruby code examples links in Edge documentation (PT-BR)</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md

<li>Updated Ruby code examples to link to specific lines in <code>edge_spec.rb</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1740/files#diff-6ff8b3969797826d7ffa95108a6aa14cd83e2bfe5839f931ab1136bbea61409c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>edge.zh-cn.md</strong><dd><code>Update Ruby code examples links in Edge documentation (ZH-CN)</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md

<li>Updated Ruby code examples to link to specific lines in <code>edge_spec.rb</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1740/files#diff-7909b00888234283f45940e23c22d33a7ce74bef4b4ae8385b034429c9a4aec8">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

