### PR TITLE
Add firefox special features using ruby and migrate examples

### DIFF
--- a/examples/ruby/spec/browsers/firefox_spec.rb
+++ b/examples/ruby/spec/browsers/firefox_spec.rb
@@ -134,6 +134,15 @@ RSpec.describe 'Firefox' do
     end
   end
 
+  describe 'Profile' do
+    it 'creates a new profile' do
+      profile = Selenium::WebDriver::Firefox::Profile.new
+      profile['browser.download.dir'] = '/tmp/webdriver-downloads'
+      options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
+      expect(options.profile).to eq(profile)
+    end
+  end
+
   def driver_finder
     options = Selenium::WebDriver::Options.firefox(browser_version: 'stable')
     service = Selenium::WebDriver::Service.firefox

--- a/examples/ruby/spec/browsers/firefox_spec.rb
+++ b/examples/ruby/spec/browsers/firefox_spec.rb
@@ -118,6 +118,20 @@ RSpec.describe 'Firefox' do
       injected = driver.find_element(id: 'webextensions-selenium-example')
       expect(injected.text).to eq 'Content injected by webextensions-selenium-example'
     end
+
+    it 'takes full page screenshot' do
+      driver.navigate.to 'https://www.selenium.dev/selenium/web/blank.html'
+      Dir.mktmpdir('screenshot_test') do |dir|
+        screenshot = driver.save_full_page_screenshot(File.join(dir, 'screenshot.png'))
+
+        expect(screenshot).to be_a File
+      end
+    end
+
+    it 'sets the context' do
+      driver.context = 'content'
+      expect(driver.context).to eq 'content'
+    end
   end
 
   def driver_finder

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
@@ -122,11 +122,8 @@ var profile = new FirefoxProfile();
 options.Profile = profile;
 var driver = new FirefoxDriver(options);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-profile = Selenium::WebDriver::Firefox::Profile.new
-profile['browser.download.dir'] = "/tmp/webdriver-downloads"
-options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
-driver = Selenium::WebDriver.for :firefox, options: options
+  {{< tab header="Ruby" text=true >}}
+  {{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L139-L141" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 const { Builder } = require("selenium-webdriver");

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
@@ -426,7 +426,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L125" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -453,7 +453,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L132" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
@@ -126,11 +126,8 @@ var profile = new FirefoxProfile();
 options.Profile = profile;
 var driver = new RemoteWebDriver(options);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-profile = Selenium::WebDriver::Firefox::Profile.new
-profile['browser.download.dir'] = "/tmp/webdriver-downloads"
-options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
-driver = Selenium::WebDriver.for :firefox, options: options
+  {{< tab header="Ruby" text=true >}}
+  {{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L139-L141" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 const { Builder } = require("selenium-webdriver");

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
@@ -433,7 +433,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L125" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -460,7 +460,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L132" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
@@ -431,7 +431,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L125" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -458,7 +458,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L132" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
@@ -125,11 +125,8 @@ var profile = new FirefoxProfile();
 options.Profile = profile;
 var driver = new RemoteWebDriver(options);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-profile = Selenium::WebDriver::Firefox::Profile.new
-profile['browser.download.dir'] = "/tmp/webdriver-downloads"
-options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
-driver = Selenium::WebDriver.for :firefox, options: options
+  {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L139-L141" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 const { Builder } = require("selenium-webdriver");

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
@@ -428,7 +428,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L125" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}
@@ -455,7 +455,7 @@ please refer to the
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L132" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
@@ -124,11 +124,8 @@ var profile = new FirefoxProfile();
 options.Profile = profile;
 var driver = new RemoteWebDriver(options);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-profile = Selenium::WebDriver::Firefox::Profile.new
-profile['browser.download.dir'] = "/tmp/webdriver-downloads"
-options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
-driver = Selenium::WebDriver.for :firefox, options: options
+  {{< tab header="Ruby" text=true >}}
+    {{< gh-codeblock path="/examples/ruby/spec/browsers/firefox_spec.rb#L139-L141" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
 const { Builder } = require("selenium-webdriver");


### PR DESCRIPTION
### **User description**
### Description
This PR adds documentation for the following special features on firefox:

- Full page screenshot
- Context

It also migrates the ruby examples for profile to the correspondent spec file

### Motivation and Context

It's important to keep the documentation neat to make it easier for maintainers and users to contribute and read the documentation respectively, it's also important to have full-fledged documentation for users.

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Added new tests for Firefox special features in Ruby, including full page screenshot and context setting.
- Migrated the Ruby example for profile creation to the corresponding spec file.
- Updated Firefox documentation in multiple languages (English, Japanese, Portuguese, Chinese) to reference the new Ruby examples.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firefox_spec.rb</strong><dd><code>Add Firefox special features tests and migrate profile example.</code></dd></summary>
<hr>
      
examples/ruby/spec/browsers/firefox_spec.rb

<li>Added test for taking full page screenshot.<br> <li> Added test for setting the context.<br> <li> Migrated profile creation example to spec file.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1744/files#diff-ed6c60fe2c20c38edb5c152457f0b17e8f593961da2e1aebd08fe49f85ba3431">+23/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firefox.en.md</strong><dd><code>Update Firefox documentation with new Ruby examples.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/firefox.en.md

<li>Updated Ruby example for profile creation to use code block reference.<br> <li> Added references to new Ruby examples for full page screenshot and <br>context setting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1744/files#diff-b15295d3d29dd29126510a0f6512397f6bb5ec98c5eb17c33798ef7b532aa4cf">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox.ja.md</strong><dd><code>Update Firefox documentation with new Ruby examples (Japanese).</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md

<li>Updated Ruby example for profile creation to use code block reference.<br> <li> Added references to new Ruby examples for full page screenshot and <br>context setting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1744/files#diff-02b45056986e5b04a1d62e9a4d294f0209c87f8937167aa405dcb7eea33f7617">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox.pt-br.md</strong><dd><code>Update Firefox documentation with new Ruby examples (Portuguese).</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md

<li>Updated Ruby example for profile creation to use code block reference.<br> <li> Added references to new Ruby examples for full page screenshot and <br>context setting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1744/files#diff-a7846d2db0bfab86e7a78f751e043ce8fc58a4abe79a9798efedce6def25ea3b">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox.zh-cn.md</strong><dd><code>Update Firefox documentation with new Ruby examples (Chinese).</code></dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md

<li>Updated Ruby example for profile creation to use code block reference.<br> <li> Added references to new Ruby examples for full page screenshot and <br>context setting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1744/files#diff-44bf88c57d3d9f7aa384e74e0f3b5ea1479e7d42eba14f7ba16f3bffb70b27d7">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

