### PR TITLE
Updates the safari technology preview example for ruby

### DIFF
--- a/examples/ruby/spec/browsers/safari_spec.rb
+++ b/examples/ruby/spec/browsers/safari_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe 'Safari', exclusive: {platform: :macosx} do
       }.to raise_error(Selenium::WebDriver::Error::WebDriverError, /Safari Service does not support setting log output/)
     end
   end
+
+  it 'sets the technology preview' do
+    Selenium::WebDriver::Safari.technology_preview!
+    local_driver = Selenium::WebDriver.for :safari
+    expect(local_driver.capabilities.browser_name).to eq 'Safari Technology Preview'
+  end
 end

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
@@ -102,7 +102,7 @@ Apple provides a development version of their browser — [Safari Technology Pre
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L36-L37" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
@@ -102,7 +102,7 @@ To use this version in your code:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L36-L37" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
@@ -102,7 +102,7 @@ To use this version in your code:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L36-L37" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
@@ -102,7 +102,7 @@ To use this version in your code:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L36-L37" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
### Description

This PR updates the ruby example for the safari technological preview in all the languages


### Motivation and Context

It's important that all the examples are up to date and they clearly reflect the usage of Selenium Webdriver

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.



___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added a new test in Ruby to verify setting Safari Technology Preview.
- Updated documentation in multiple languages (English, Japanese, Portuguese, Chinese) to link to the new Ruby test for Safari Technology Preview.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>safari_spec.rb</strong><dd><code>Add test for Safari Technology Preview in Ruby</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/ruby/spec/browsers/safari_spec.rb

<li>Added a test for setting Safari Technology Preview.<br> <li> Verified the browser name is 'Safari Technology Preview'.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1771/files#diff-bdb8fc856236b527e2aaf2466380587350d356f1a1ba23496b66ab97f7e11189">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>safari.en.md</strong><dd><code>Update Ruby example link for Safari Technology Preview</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/safari.en.md

<li>Updated Ruby example to link to the new Safari Technology Preview <br>test.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1771/files#diff-634ecb7644504a2d7735debd2017c7d9091a4d042dd336cea63c521ffb9d9737">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safari.ja.md</strong><dd><code>Update Ruby example link for Safari Technology Preview</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/safari.ja.md

<li>Updated Ruby example to link to the new Safari Technology Preview <br>test.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1771/files#diff-3843e74951875d9f02381b4a032de51b438b32a454e95d14a195a2f161646aee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safari.pt-br.md</strong><dd><code>Update Ruby example link for Safari Technology Preview</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md

<li>Updated Ruby example to link to the new Safari Technology Preview <br>test.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1771/files#diff-5bef1737606138f9714d746b1385f5a2b3de0002ed856fabf3e3e4c57ffe8bc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safari.zh-cn.md</strong><dd><code>Update Ruby example link for Safari Technology Preview</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md

<li>Updated Ruby example to link to the new Safari Technology Preview <br>test.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1771/files#diff-a7937d029700732a1a80db8aaab9b545b2a5e14015ff3875aedc43f4a239aca8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

