### PR TITLE
[rb] Update safari technological review example

### DIFF
--- a/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
@@ -102,7 +102,7 @@ Apple provides a development version of their browser — [Safari Technology Pre
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L36-L37" >}}
+{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L38-L39" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
@@ -102,7 +102,7 @@ To use this version in your code:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L36-L37" >}}
+{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L38-L39" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
@@ -102,7 +102,7 @@ To use this version in your code:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L36-L37" >}}
+{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L38-L39" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
@@ -106,7 +106,7 @@ Apple 提供了其浏览器的开发版本 — [Safari Technology Preview](https
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L36-L37" >}}
+{{< gh-codeblock path="examples/ruby/spec/browsers/safari_spec.rb#L38-L39" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
 {{< badge-code >}}


### PR DESCRIPTION
### **User description**
### Description
This PR updates the reference lines for safari technological examples for ruby so the lines match the actual example

This is how it currently looks for all translations:

<img width="1238" alt="Screenshot 2024-07-05 at 23 52 59" src="https://github.com/SeleniumHQ/seleniumhq.github.io/assets/33221555/ff584e0f-c788-4e7e-979e-3adc5bcc659a">


### Motivation and Context
It's important to always keep the documentation up to date so the users have concrete examples of how selenium works

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
Documentation


___

### **Description**
- Updated the Ruby code reference lines in the Safari documentation for multiple languages (English, Japanese, Portuguese, Chinese).
- Ensured that the documentation reflects the correct lines in the example code.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>safari.en.md</strong><dd><code>Update Ruby code reference in Safari documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/safari.en.md

- Updated Ruby code reference lines in the Safari documentation.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1799/files#diff-634ecb7644504a2d7735debd2017c7d9091a4d042dd336cea63c521ffb9d9737">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safari.ja.md</strong><dd><code>Update Ruby code reference in Safari documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/safari.ja.md

- Updated Ruby code reference lines in the Safari documentation.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1799/files#diff-3843e74951875d9f02381b4a032de51b438b32a454e95d14a195a2f161646aee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safari.pt-br.md</strong><dd><code>Update Ruby code reference in Safari documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md

- Updated Ruby code reference lines in the Safari documentation.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1799/files#diff-5bef1737606138f9714d746b1385f5a2b3de0002ed856fabf3e3e4c57ffe8bc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>safari.zh-cn.md</strong><dd><code>Update Ruby code reference in Safari documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md

- Updated Ruby code reference lines in the Safari documentation.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1799/files#diff-a7937d029700732a1a80db8aaab9b545b2a5e14015ff3875aedc43f4a239aca8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

