### PR TITLE
[rb] Move examples for ruby elements interactions

### DIFF
--- a/examples/ruby/spec/elements/interaction_spec.rb
+++ b/examples/ruby/spec/elements/interaction_spec.rb
@@ -4,4 +4,15 @@ require 'spec_helper'
 
 RSpec.describe 'Element Interaction' do
   let(:driver) { start_session }
+
+  before { driver.get 'https://www.selenium.dev/selenium/web/inputs.html' }
+
+  it 'clicks an element' do
+    driver.find_element(name: 'color_input').click
+  end
+
+  it 'clears and send keys to an element' do
+    driver.find_element(name: 'email_input').clear
+    driver.find_element(name: 'email_input').send_keys 'admin@localhost.dev'
+  end
 end

--- a/website_and_docs/content/documentation/webdriver/elements/interactions.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/interactions.en.md
@@ -60,16 +60,9 @@ Selenium will return an [element click intercepted](https://w3c.github.io/webdri
   {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L17-L21" >}}
   {{< /tab >}}
-  
-  {{< tab header="Ruby" >}}
-
-    # Navigate to URL
-  driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Click the element
-  driver.find_element(name: 'color_input').click
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L11" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L20" >}}
   {{< /tab >}}
@@ -118,20 +111,11 @@ possible keystrokes that WebDriver Supports.
    {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L27-L33" >}}
   {{< /tab >}}
-  
 
-  {{< tab header="Ruby" >}}
 
-    # Navigate to URL
-	driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Clear field to empty it from any previous data
-	driver.find_element(name: 'email_input').clear
-	
-	# Enter Text
-	driver.find_element(name: 'email_input').send_keys 'admin@localhost.dev'
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L16" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/elements/interactions.spec.js#L21" >}}
   {{< /tab >}}
@@ -178,17 +162,11 @@ with a`content-editable` attribute. If these conditions are not met,
    {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L40-L43" >}}
   {{< /tab >}}
-  
 
-  {{< tab header="Ruby" >}}
 
-    # Navigate to URL
-	driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Clear field to empty it from any previous data
-	driver.find_element(name: 'email_input').clear
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L15" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/elements/interactions.spec.js#L20" >}}
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/interactions.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/interactions.ja.md
@@ -56,17 +56,11 @@ Selenium will return an [element click intercepted](https://w3c.github.io/webdri
  {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L17-L21" >}}
   {{< /tab >}}
-  
 
-  {{< tab header="Ruby" >}}
 
-    # Navigate to URL
-  driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Click the element
-  driver.find_element(name: 'color_input').click
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L11" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L20" >}}
   {{< /tab >}}
@@ -115,18 +109,9 @@ possible keystrokes that WebDriver Supports.
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L27-L33" >}}
   {{< /tab >}}
 
-  {{< tab header="Ruby" >}}
-
-    # Navigate to URL
-	driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Clear field to empty it from any previous data
-	driver.find_element(name: 'email_input').clear
-	
-	# Enter Text
-	driver.find_element(name: 'email_input').send_keys 'admin@localhost.dev'
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L16" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/elements/interactions.spec.js#L21" >}}
   {{< /tab >}}
@@ -172,17 +157,11 @@ with a`content-editable` attribute. If these conditions are not met,
    {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L40-L43" >}}
   {{< /tab >}}
- 
- 
-  {{< tab header="Ruby" >}}
 
-    # Navigate to URL
-	driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
 
-    # Clear field to empty it from any previous data
-	driver.find_element(name: 'email_input').clear
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L15" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/elements/interactions.spec.js#L20" >}}
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/interactions.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/interactions.pt-br.md
@@ -58,15 +58,9 @@ Selenium will return an [element click intercepted](https://w3c.github.io/webdri
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L17-L21" >}}
   {{< /tab >}}
 
-  {{< tab header="Ruby" >}}
-
-    # Navigate to URL
-  driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Click the element
-  driver.find_element(name: 'color_input').click
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L11" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L20" >}}
   {{< /tab >}}
@@ -116,18 +110,9 @@ possible keystrokes that WebDriver Supports.
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L27-L33" >}}
   {{< /tab >}}
 
-  {{< tab header="Ruby" >}}
-
-    # Navigate to URL
-	driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Clear field to empty it from any previous data
-	driver.find_element(name: 'email_input').clear
-	
-	# Enter Text
-	driver.find_element(name: 'email_input').send_keys 'admin@localhost.dev'
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L16" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/elements/interactions.spec.js#L21" >}}
   {{< /tab >}}
@@ -173,16 +158,10 @@ with a`content-editable` attribute. If these conditions are not met,
    {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L40-L43" >}}
   {{< /tab >}}
-  
-  {{< tab header="Ruby" >}}
 
-    # Navigate to URL
-	driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Clear field to empty it from any previous data
-	driver.find_element(name: 'email_input').clear
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L15" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/elements/interactions.spec.js#L20" >}}
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/interactions.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/interactions.zh-cn.md
@@ -59,16 +59,10 @@ Selenium将返回一个 [元素点击中断](https://w3c.github.io/webdriver/#df
   {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L17-L21" >}}
   {{< /tab >}}
-  
-  {{< tab header="Ruby" >}}
 
-    # Navigate to URL
-  driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Click the element
-  driver.find_element(name: 'color_input').click
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L11" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L20" >}}
   {{< /tab >}}
@@ -117,20 +111,11 @@ Selenium将返回一个 [元素点击中断](https://w3c.github.io/webdriver/#df
    {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L27-L33" >}}
   {{< /tab >}}
-  
-  
-  {{< tab header="Ruby" >}}
 
-    # Navigate to URL
-	driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
 
-    # Clear field to empty it from any previous data
-	driver.find_element(name: 'email_input').clear
-	
-	# Enter Text
-	driver.find_element(name: 'email_input').send_keys 'admin@localhost.dev'
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L16" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/elements/interactions.spec.js#L21" >}}
   {{< /tab >}}
@@ -177,16 +162,10 @@ Selenium将返回一个 [元素点击中断](https://w3c.github.io/webdriver/#df
      {{< tab header="CSharp" text=true >}}
 	{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Elements/InteractionTest.cs#L40-L43" >}}
   {{< /tab >}}
-  
-  {{< tab header="Ruby" >}}
 
-    # Navigate to URL
-	driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Clear field to empty it from any previous data
-	driver.find_element(name: 'email_input').clear
-
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/elements/interaction_spec.rb#L15" >}}
+{{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="examples/javascript/test/elements/interactions.spec.js#L20" >}}
   {{< /tab >}}


### PR DESCRIPTION
### **User description**
### Description
This PR moves the examples for ruby regarding element interactions

### Motivation and Context
It's important to make our documentation more maintainable for future contributors to keep the examples up to date

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Added new RSpec tests for element interactions in Ruby.
- Updated documentation to reference the new RSpec tests instead of inline Ruby code.
- Applied changes to multiple language versions of the documentation (English, Japanese, Portuguese, Chinese).



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interaction_spec.rb</strong><dd><code>Add RSpec tests for element interactions in Ruby</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/ruby/spec/elements/interaction_spec.rb

<li>Added a new RSpec test for clicking an element.<br> <li> Added a new RSpec test for clearing and sending keys to an element.<br> <li> Included a <code>before</code> block to navigate to a specific URL before each <br>test.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1815/files#diff-052780b3021b3424286fd0c7da70a500124568d1dbd1a62e38e84e78770af8aa">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interactions.en.md</strong><dd><code>Update Ruby interaction examples to use RSpec tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/interactions.en.md

<li>Updated Ruby code examples to reference new RSpec tests.<br> <li> Removed inline Ruby code and replaced with links to the new examples.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1815/files#diff-29d62989f3269b6b730dc88f73f03cabf16c33e75b906f87e1b6d0db12270dcc">+9/-31</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>interactions.ja.md</strong><dd><code>Update Ruby interaction examples to use RSpec tests (Japanese)</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/interactions.ja.md

<li>Updated Ruby code examples to reference new RSpec tests.<br> <li> Removed inline Ruby code and replaced with links to the new examples.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1815/files#diff-80e55b2874f0cea62563522565857a9b984cdafdaa099c4af1b79b3142c56258">+9/-30</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>interactions.pt-br.md</strong><dd><code>Update Ruby interaction examples to use RSpec tests (Portuguese)</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/interactions.pt-br.md

<li>Updated Ruby code examples to reference new RSpec tests.<br> <li> Removed inline Ruby code and replaced with links to the new examples.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1815/files#diff-6581c27a0c871c49cbd0269483a9c5a60dfd71c05e3052f3de006295a04c7dfa">+9/-30</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>interactions.zh-cn.md</strong><dd><code>Update Ruby interaction examples to use RSpec tests (Chinese)</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/interactions.zh-cn.md

<li>Updated Ruby code examples to reference new RSpec tests.<br> <li> Removed inline Ruby code and replaced with links to the new examples.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1815/files#diff-d44ba58dffdc9c7df5966d49d205f2702627d9c439ed4ca36355f9b50de00985">+9/-30</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

