### PR TITLE
[rb] Move information examples

### DIFF
--- a/examples/ruby/spec/elements/information_spec.rb
+++ b/examples/ruby/spec/elements/information_spec.rb
@@ -25,18 +25,18 @@ RSpec.describe 'Element Information' do
 
   it 'gets the tag name of an element' do
     tag_name = driver.find_element(name: 'email_input').tag_name
-    expect(tag_name).to eq('input')
+    expect(tag_name).not_to be_empty
   end
 
   it 'gets the size and position of an element' do
     size = driver.find_element(name: 'email_input').size
-    expect(size.width).to eq(147)
-    expect(size.height).to eq(22)
+    expect(size.width).to be_positive
+    expect(size.height).to be_positive
   end
 
   it 'gets the css value of an element' do
     css_value = driver.find_element(name: 'email_input').css_value('background-color')
-    expect(css_value).to eq('rgba(255, 255, 255, 1)')
+    expect(css_value).not_to be_empty
   end
 
   it 'gets the text of an element' do
@@ -46,6 +46,6 @@ RSpec.describe 'Element Information' do
 
   it 'gets the attribute value of an element' do
     attribute_value = driver.find_element(name: 'number_input').attribute('value')
-    expect(attribute_value).to eq '42'
+    expect(attribute_value).not_to be_empty
   end
 end

--- a/examples/ruby/spec/elements/information_spec.rb
+++ b/examples/ruby/spec/elements/information_spec.rb
@@ -4,4 +4,48 @@ require 'spec_helper'
 
 RSpec.describe 'Element Information' do
   let(:driver) { start_session }
+  let(:url) { 'https://www.selenium.dev/selenium/web/inputs.html' }
+
+  before { driver.get(url) }
+
+  it 'checks if an element is displayed' do
+    displayed_value = driver.find_element(name: 'email_input').displayed?
+    expect(displayed_value).to be_truthy
+  end
+
+  it 'checks if an element is enabled' do
+    enabled_value = driver.find_element(name: 'email_input').enabled?
+    expect(enabled_value).to be_truthy
+  end
+
+  it 'checks if an element is selected' do
+    selected_value = driver.find_element(name: 'email_input').selected?
+    expect(selected_value).to be_falsey
+  end
+
+  it 'gets the tag name of an element' do
+    tag_name = driver.find_element(name: 'email_input').tag_name
+    expect(tag_name).to eq('input')
+  end
+
+  it 'gets the size and position of an element' do
+    size = driver.find_element(name: 'email_input').size
+    expect(size.width).to eq(147)
+    expect(size.height).to eq(22)
+  end
+
+  it 'gets the css value of an element' do
+    css_value = driver.find_element(name: 'email_input').css_value('background-color')
+    expect(css_value).to eq('rgba(255, 255, 255, 1)')
+  end
+
+  it 'gets the text of an element' do
+    text = driver.find_element(xpath: '//h1').text
+    expect(text).to eq('Testing Inputs')
+  end
+
+  it 'gets the attribute value of an element' do
+    attribute_value = driver.find_element(name: 'number_input').attribute('value')
+    expect(attribute_value).to eq '42'
+  end
 end

--- a/website_and_docs/content/documentation/webdriver/elements/information.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/information.en.md
@@ -43,12 +43,8 @@ driver.Url = "https://www.selenium.dev/selenium/web/inputs.html";
 //Get boolean value for is element display
 Boolean is_email_visible = driver.FindElement(By.Name("email_input")).Displayed;
 {{< /tab >}}
-{{< tab header="Ruby" >}}
-# Navigate to the url
-driver.get("https://www.selenium.dev/selenium/web/inputs.html");
-
-#fetch display status
-val = driver.find_element(name: 'email_input').displayed?
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L12">}}
 {{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L16-L17">}}
@@ -93,13 +89,9 @@ IWebElement element = driver.FindElement(By.Name("button_input"));
 // Prints true if element is enabled else returns false
 System.Console.WriteLine(element.Enabled);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns true if element is enabled else returns false
-ele = driver.find_element(name: 'button_input').enabled?
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L17">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L23-L24">}}
 {{< /tab >}}
@@ -139,13 +131,9 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/inputs.html");
 // Returns true if element ins checked else returns false
 bool value = driver.FindElement(By.Name("checkbox_input")).Selected;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns true if element is checked else returns false
-ele = driver.find_element(name: "checkbox_input").selected?
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L22">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L30-L31">}}
 {{< /tab >}}
@@ -181,13 +169,9 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/inputs.html");
 // Returns TagName of the element
 string attr = driver.FindElement(By.Name("email_input")).TagName;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns TagName of the element
-attr = driver.find_element(name: "email_input").tag_name
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L27">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L37-L38">}}
 {{< /tab >}}
@@ -232,13 +216,9 @@ System.Console.WriteLine(res.Location);
 // Returns height, width
 System.Console.WriteLine(res.Size);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns height, width, x and y coordinates referenced element
-res = driver.find_element(name: "range_input").rect
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L32">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L45">}}
 {{< /tab >}}
@@ -281,14 +261,8 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/colorPage.html"
 String cssValue = driver.FindElement(By.Id("namedColor")).GetCssValue("background-color");
 
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-
-    # Navigate to Url
-driver.get 'https://www.selenium.dev/selenium/web/colorPage.html'
-
-    # Retrieves the computed style property 'color' of linktext
-cssValue = driver.find_element(:id, 'namedColor').css_value('background-color')
-
+  {{< tab header="Ruby" text=true >}}
+  {{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L38">}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L76-L78">}}
@@ -326,13 +300,9 @@ driver.Url="https://www.selenium.dev/selenium/web/linked_image.html";
 // Retrieves the text of the element
 String text = driver.FindElement(By.Id("justanotherlink")).Text;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/linked_image.html'
-
-    # Retrieves the text of the element
-text = driver.find_element(:id, 'justanotherlink').text
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L43">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L84-L86">}}
 {{< /tab >}}
@@ -377,16 +347,9 @@ IWebElement emailTxt = driver.FindElement(By.Name(("email_input")));
 //fetch the value property associated with the textbox
 String valueInfo = eleSelLink.GetAttribute("value");
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-# Navigate to the url
-driver.get("https://www.selenium.dev/selenium/web/inputs.html");
-
-#identify the email text box
-email_element=driver.find_element(name: 'email_input')
-
-#fetch the value property associated with the textbox
-emailVal = email_element.attribute("value");
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L48">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L55-L59">}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/information.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/information.ja.md
@@ -43,12 +43,8 @@ driver.Url = "https://www.selenium.dev/selenium/web/inputs.html";
 //Get boolean value for is element display
 Boolean is_email_visible = driver.FindElement(By.Name("email_input")).Displayed;
 {{< /tab >}}
-{{< tab header="Ruby" >}}
-# Navigate to the url
-driver.get("https://www.selenium.dev/selenium/web/inputs.html");
-
-#fetch display status
-val = driver.find_element(name: 'email_input').displayed?
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L12">}}
 {{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L16-L17">}}
@@ -90,13 +86,9 @@ IWebElement element = driver.FindElement(By.Name("button_input"));
 // Prints true if element is enabled else returns false
 System.Console.WriteLine(element.Enabled);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns true if element is enabled else returns false
-ele = driver.find_element(name: 'button_input').enabled?
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L17">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L23-L24">}}
 {{< /tab >}}
@@ -134,13 +126,9 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/inputs.html");
 // Returns true if element ins checked else returns false
 bool value = driver.FindElement(By.Name("checkbox_input")).Selected;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns true if element is checked else returns false
-ele = driver.find_element(name: "checkbox_input").selected?
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L22">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L30-L31">}}
 {{< /tab >}}
@@ -176,13 +164,9 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/inputs.html");
 // Returns TagName of the element
 string attr = driver.FindElement(By.Name("email_input")).TagName;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns TagName of the element
-attr = driver.find_element(name: "email_input").tag_name
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L27">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L37-L38">}}
 {{< /tab >}}
@@ -227,13 +211,9 @@ System.Console.WriteLine(res.Location);
 // Returns height, width
 System.Console.WriteLine(res.Size);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns height, width, x and y coordinates referenced element
-res = driver.find_element(name: "range_input").rect
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L32">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L45">}}
 {{< /tab >}}
@@ -275,14 +255,8 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/colorPage.html"
 String cssValue = driver.FindElement(By.Id("namedColor")).GetCssValue("background-color");
 
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-
-    # Navigate to Url
-driver.get 'https://www.selenium.dev/selenium/web/colorPage.html'
-
-    # Retrieves the computed style property 'color' of linktext
-cssValue = driver.find_element(:id, 'namedColor').css_value('background-color')
-
+  {{< tab header="Ruby" text=true >}}
+  {{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L38">}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L76-L78">}}
@@ -321,13 +295,9 @@ driver.Url="https://www.selenium.dev/selenium/web/linked_image.html";
 // Retrieves the text of the element
 String text = driver.FindElement(By.Id("justanotherlink")).Text;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/linked_image.html'
-
-    # Retrieves the text of the element
-text = driver.find_element(:id, 'justanotherlink').text
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L43">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L84-L86">}}
 {{< /tab >}}
@@ -370,16 +340,9 @@ IWebElement emailTxt = driver.FindElement(By.Name(("email_input")));
 //fetch the value property associated with the textbox
 String valueInfo = eleSelLink.GetAttribute("value");
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-# Navigate to the url
-driver.get("https://www.selenium.dev/selenium/web/inputs.html");
-
-#identify the email text box
-email_element=driver.find_element(name: 'email_input')
-
-#fetch the value property associated with the textbox
-emailVal = email_element.attribute("value");
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L48">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L55-L59">}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/information.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/information.pt-br.md
@@ -44,12 +44,8 @@ driver.Url = "https://www.selenium.dev/selenium/web/inputs.html";
 //Get boolean value for is element display
 Boolean is_email_visible = driver.FindElement(By.Name("email_input")).Displayed;
 {{< /tab >}}
-{{< tab header="Ruby" >}}
-# Navigate to the url
-driver.get("https://www.selenium.dev/selenium/web/inputs.html");
-
-#fetch display status
-val = driver.find_element(name: 'email_input').displayed?
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L12">}}
 {{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L16-L17">}}
@@ -91,13 +87,9 @@ IWebElement element = driver.FindElement(By.Name("button_input"));
 // Prints true if element is enabled else returns false
 System.Console.WriteLine(element.Enabled);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns true if element is enabled else returns false
-ele = driver.find_element(name: 'button_input').enabled?
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L17">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L23-L24">}}
 {{< /tab >}}
@@ -140,13 +132,9 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/inputs.html");
 // Returns true if element ins checked else returns false
 bool value = driver.FindElement(By.Name("checkbox_input")).Selected;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns true if element is checked else returns false
-ele = driver.find_element(name: "checkbox_input").selected?
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L22">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L30-L31">}}
 {{< /tab >}}
@@ -182,13 +170,9 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/inputs.html");
 // Returns TagName of the element
 string attr = driver.FindElement(By.Name("email_input")).TagName;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns TagName of the element
-attr = driver.find_element(name: "email_input").tag_name
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L27">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L37-L38">}}
 {{< /tab >}}
@@ -234,13 +218,9 @@ System.Console.WriteLine(res.Location);
 // Returns height, width
 System.Console.WriteLine(res.Size);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns height, width, x and y coordinates referenced element
-res = driver.find_element(name: "range_input").rect
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L32">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L45">}}
 {{< /tab >}}
@@ -283,14 +263,8 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/colorPage.html"
 String cssValue = driver.FindElement(By.Id("namedColor")).GetCssValue("background-color");
 
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-
-    # Navigate to Url
-driver.get 'https://www.selenium.dev/selenium/web/colorPage.html'
-
-    # Retrieves the computed style property 'color' of linktext
-cssValue = driver.find_element(:id, 'namedColor').css_value('background-color')
-
+  {{< tab header="Ruby" text=true >}}
+  {{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L38">}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L76-L78">}}
@@ -329,13 +303,9 @@ driver.Url="https://www.selenium.dev/selenium/web/linked_image.html";
 // Retrieves the text of the element
 String text = driver.FindElement(By.Id("justanotherlink")).Text;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/linked_image.html'
-
-    # Retrieves the text of the element
-text = driver.find_element(:id, 'justanotherlink').text
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L43">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L84-L86">}}
 {{< /tab >}}
@@ -378,16 +348,9 @@ IWebElement emailTxt = driver.FindElement(By.Name(("email_input")));
 //fetch the value property associated with the textbox
 String valueInfo = eleSelLink.GetAttribute("value");
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-# Navigate to the url
-driver.get("https://www.selenium.dev/selenium/web/inputs.html");
-
-#identify the email text box
-email_element=driver.find_element(name: 'email_input')
-
-#fetch the value property associated with the textbox
-emailVal = email_element.attribute("value");
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L48">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L55-L59">}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/information.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/information.zh-cn.md
@@ -37,12 +37,8 @@ driver.Url = "https://www.selenium.dev/selenium/web/inputs.html";
 //Get boolean value for is element display
 Boolean is_email_visible = driver.FindElement(By.Name("email_input")).Displayed;
 {{< /tab >}}
-{{< tab header="Ruby" >}}
-# Navigate to the url
-driver.get("https://www.selenium.dev/selenium/web/inputs.html");
-
-#fetch display status
-val = driver.find_element(name: 'email_input').displayed?
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L12">}}
 {{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L16-L17">}}
@@ -83,13 +79,9 @@ IWebElement element = driver.FindElement(By.Name("button_input"));
 // Prints true if element is enabled else returns false
 System.Console.WriteLine(element.Enabled);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns true if element is enabled else returns false
-ele = driver.find_element(name: 'button_input').enabled?
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L17">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L23-L24">}}
 {{< /tab >}}
@@ -126,13 +118,9 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/inputs.html");
 // Returns true if element ins checked else returns false
 bool value = driver.FindElement(By.Name("checkbox_input")).Selected;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns true if element is checked else returns false
-ele = driver.find_element(name: "checkbox_input").selected?
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L22">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L30-L31">}}
 {{< /tab >}}
@@ -167,13 +155,9 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/inputs.html");
 // Returns TagName of the element
 string attr = driver.FindElement(By.Name("email_input")).TagName;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns TagName of the element
-attr = driver.find_element(name: "email_input").tag_name
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L27">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L37-L38">}}
 {{< /tab >}}
@@ -218,13 +202,9 @@ System.Console.WriteLine(res.Location);
 // Returns height, width
 System.Console.WriteLine(res.Size);
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/inputs.html'
-
-    # Returns height, width, x and y coordinates referenced element
-res = driver.find_element(name: "range_input").rect
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L32">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L45">}}
 {{< /tab >}}
@@ -266,14 +246,8 @@ driver.Navigate().GoToUrl("https://www.selenium.dev/selenium/web/colorPage.html"
 String cssValue = driver.FindElement(By.Id("namedColor")).GetCssValue("background-color");
 
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-
-    # Navigate to Url
-driver.get 'https://www.selenium.dev/selenium/web/colorPage.html'
-
-    # Retrieves the computed style property 'color' of linktext
-cssValue = driver.find_element(:id, 'namedColor').css_value('background-color')
-
+  {{< tab header="Ruby" text=true >}}
+  {{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L38">}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L76-L78">}}
@@ -313,13 +287,9 @@ driver.Url="https://www.selenium.dev/selenium/web/linked_image.html";
 // Retrieves the text of the element
 String text = driver.FindElement(By.Id("justanotherlink")).Text;
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-    # Navigate to url
-driver.get 'https://www.selenium.dev/selenium/web/linked_image.html'
-
-    # Retrieves the text of the element
-text = driver.find_element(:id, 'justanotherlink').text
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L43">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L84-L86">}}
 {{< /tab >}}
@@ -361,16 +331,9 @@ IWebElement emailTxt = driver.FindElement(By.Name(("email_input")));
 //fetch the value property associated with the textbox
 String valueInfo = eleSelLink.GetAttribute("value");
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-# Navigate to the url
-driver.get("https://www.selenium.dev/selenium/web/inputs.html");
-
-#identify the email text box
-email_element=driver.find_element(name: 'email_input')
-
-#fetch the value property associated with the textbox
-emailVal = email_element.attribute("value");
-  {{< /tab >}}
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/information_spec.rb#L48">}}
+{{< /tab >}}
 {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/elements/information.spec.js#L55-L59">}}
 {{< /tab >}}


### PR DESCRIPTION
### **User description**
### Description
This PR focuses on moving all the ruby information examples into the relevant spec file: https://www.selenium.dev/documentation/webdriver/elements/information/

### Motivation and Context
It's important to make our examples easier to maintain and to have them all as running tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added new RSpec tests for element information in `information_spec.rb`.
- Updated documentation to replace inline Ruby code examples with links to the corresponding RSpec tests.
- Changes applied to English, Japanese, Brazilian Portuguese, and Simplified Chinese documentation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>information_spec.rb</strong><dd><code>Add RSpec tests for element information</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/ruby/spec/elements/information_spec.rb

<li>Added new RSpec tests for element information.<br> <li> Tests include checks for display, enable, select status, tag name, <br>size, CSS value, text, and attribute value.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1826/files#diff-4d75ad884230c7231eff9344933e5aa15d271bf0940a34a23524b04e38286eb8">+44/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>information.en.md</strong><dd><code>Update Ruby code examples to link to RSpec tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/information.en.md

<li>Replaced inline Ruby code examples with links to the corresponding <br>RSpec tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1826/files#diff-3cdda90c6f5de57805888e32b68bc6837f31f3de7364eb0b42122530644578b4">+22/-59</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>information.ja.md</strong><dd><code>Update Ruby code examples to link to RSpec tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/information.ja.md

<li>Replaced inline Ruby code examples with links to the corresponding <br>RSpec tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1826/files#diff-166c5644d20c964e299a2c4d3082f283a5115f0e8bb2680105cc93114b12e915">+22/-59</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>information.pt-br.md</strong><dd><code>Update Ruby code examples to link to RSpec tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/information.pt-br.md

<li>Replaced inline Ruby code examples with links to the corresponding <br>RSpec tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1826/files#diff-8e512b687ce1733be97763cbd921c88af06829905a5df082e26a33665c8a8960">+22/-59</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>information.zh-cn.md</strong><dd><code>Update Ruby code examples to link to RSpec tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/information.zh-cn.md

<li>Replaced inline Ruby code examples with links to the corresponding <br>RSpec tests.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1826/files#diff-408dc90744aa467fd83422f65bf7a9113369f96f0b19fc738bee9e1ac02fd5f7">+22/-59</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

