### PR TITLE
Added Python Examples to Organizing and Executing Selenium Code

### DIFF
--- a/examples/python/tests/getting_started/using_selenium_tests.py
+++ b/examples/python/tests/getting_started/using_selenium_tests.py
@@ -23,3 +23,11 @@ def test_eight_components():
     assert value == "Received!"
 
     driver.quit()
+
+def setup():
+    driver = webdriver.Chrome()
+    driver.get("https://www.selenium.dev/selenium/web/web-form.html")
+    return driver
+
+def teardown(driver):
+    driver.quit()

--- a/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.en.md
@@ -232,6 +232,7 @@ gradle clean test
 
 {{% /tab %}}
 {{% tab header="Python" %}}
+{{< gh-codeblock path="examples/python/README.md#L35" >}}
 {{< badge-code >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.en.md
@@ -174,6 +174,15 @@ In your project's `package.json`, add requirement to `dependencies`:
 
 {{% /tab %}}
 {{% tab header="Python" %}}
+
+### Set Up
+
+{{< gh-codeblock path="examples/python/tests/getting_started/using_selenium_tests.py#L27-L30" >}}
+
+### Tear Down
+
+{{< gh-codeblock path="examples/python/tests/getting_started/using_selenium_tests.py#L32-33" >}}
+
 {{< badge-code >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.ja.md
@@ -228,6 +228,7 @@ gradle clean test
 
 {{% /tab %}}
 {{% tab header="Python" %}}
+{{< gh-codeblock path="examples/python/README.md#L35" >}}
 {{< badge-code >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.ja.md
@@ -170,6 +170,15 @@ In your project's `package.json`, add requirement to `dependencies`:
 
 {{% /tab %}}
 {{% tab header="Python" %}}
+
+### Set Up
+
+{{< gh-codeblock path="examples/python/tests/getting_started/using_selenium_tests.py#L27-L30" >}}
+
+### Tear Down
+
+{{< gh-codeblock path="examples/python/tests/getting_started/using_selenium_tests.py#L32-33" >}}
+
 {{< badge-code >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}


### PR DESCRIPTION
### **User description**
Added Execution Example to Organizing and Executing Selenium Code

### Description
Updated english and japanese versions of Organizing and Executing Selenium Code page to include lines of python code for execution

### Motivation and Context
needed documentation

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Added `setup` and `teardown` functions in `using_selenium_tests.py` to manage WebDriver lifecycle.
- Updated English and Japanese documentation to include Python setup and teardown examples.
- Enhanced documentation to provide clearer guidance for Python Selenium tests.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>using_selenium_tests.py</strong><dd><code>Add setup and teardown functions for Selenium tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/getting_started/using_selenium_tests.py

<li>Added <code>setup</code> function to initialize the WebDriver and open a URL.<br> <li> Added <code>teardown</code> function to quit the WebDriver.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1869/files#diff-aa8c2cd4492a49444ef99b560ecda82475b27fc52ef5804d99b186c4a8c1bddc">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>using_selenium.en.md</strong><dd><code>Update English documentation with Python examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/getting_started/using_selenium.en.md

<li>Added Python setup and teardown code examples.<br> <li> Updated documentation to include Python-specific instructions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1869/files#diff-f521d4cd05fea84ac0fd18184a214f8ac2cd023a7f2c1a7e2b43495504b7b9f0">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>using_selenium.ja.md</strong><dd><code>Update Japanese documentation with Python examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/getting_started/using_selenium.ja.md

<li>Added Python setup and teardown code examples.<br> <li> Updated Japanese documentation to include Python-specific <br>instructions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1869/files#diff-53fac7bfd25fb50de7731415fedc5ea636bcdaa83166f476b3c9e13a691a6c7c">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

