### PR TITLE
added feature #1539 to each translation

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/finders.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.en.md
@@ -308,12 +308,24 @@ from selenium.webdriver.common.by import By
 
 driver = webdriver.Chrome()
 driver.get("https://www.example.com")
+##get elements from parent element using TAG_NAME
 
     # Get element with tag name 'div'
 element = driver.find_element(By.TAG_NAME, 'div')
 
     # Get all the elements available with tag name 'p'
+    # NOTE: in order to utilize XPATH from current element, you must add "." to beginning of path
 elements = element.find_elements(By.TAG_NAME, 'p')
+for e in elements:
+    print(e.text)
+
+##get elements from parent element using XPATH
+
+    # Get first element of tag 'ul'
+element = driver.find_element(By.XPATH, '//ul')
+
+    # get children of tag 'ul' with tag 'li'
+elements  = driver.find_elements(By.XPATH, './/li')
 for e in elements:
     print(e.text)
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
@@ -294,12 +294,24 @@ from selenium.webdriver.common.by import By
 
 driver = webdriver.Chrome()
 driver.get("https://www.example.com")
+##get elements from parent element using TAG_NAME
 
     # Get element with tag name 'div'
 element = driver.find_element(By.TAG_NAME, 'div')
 
     # Get all the elements available with tag name 'p'
+    # NOTE: in order to utilize XPATH from current element, you must add "." to beginning of path
 elements = element.find_elements(By.TAG_NAME, 'p')
+for e in elements:
+    print(e.text)
+
+##get elements from parent element using XPATH
+
+    # Get first element of tag 'ul'
+element = driver.find_element(By.XPATH, '//ul')
+
+    # get children of tag 'ul' with tag 'li'
+elements  = driver.find_elements(By.XPATH, './/li')
 for e in elements:
     print(e.text)
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
@@ -293,17 +293,24 @@ Para realizar isso, o WebElement pai é encadeado com o 'findElements' para aces
   }
   {{< /tab >}}
   {{< tab header="Python" >}}
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-
-driver = webdriver.Chrome()
-driver.get("https://www.example.com")
+##get elements from parent element using TAG_NAME
 
     # Obtém o elemento com o nome da tag 'div'
 element = driver.find_element(By.TAG_NAME, 'div')
 
     # Obtém todos os elementos disponíveis com o nome da tag 'p'
+    # NOTE: in order to utilize XPATH from current element, you must add "." to beginning of path
 elements = element.find_elements(By.TAG_NAME, 'p')
+for e in elements:
+    print(e.text)
+
+##get elements from parent element using XPATH
+
+    # Get first element of tag 'ul'
+element = driver.find_element(By.XPATH, '//ul')
+
+    # get children of tag 'ul' with tag 'li'
+elements  = driver.find_elements(By.XPATH, './/li')
 for e in elements:
     print(e.text)
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
@@ -303,12 +303,24 @@ from selenium.webdriver.common.by import By
 
 driver = webdriver.Chrome()
 driver.get("https://www.example.com")
+##get elements from parent element using TAG_NAME
 
     # Get element with tag name 'div'
 element = driver.find_element(By.TAG_NAME, 'div')
 
     # Get all the elements available with tag name 'p'
+    # NOTE: in order to utilize XPATH from current element, you must add "." to beginning of path
 elements = element.find_elements(By.TAG_NAME, 'p')
+for e in elements:
+    print(e.text)
+
+##get elements from parent element using XPATH
+
+    # Get first element of tag 'ul'
+element = driver.find_element(By.XPATH, '//ul')
+
+    # get children of tag 'ul' with tag 'li'
+elements  = driver.find_elements(By.XPATH, './/li')
 for e in elements:
     print(e.text)
   {{< /tab >}}


### PR DESCRIPTION
Implemented feature #1539 - adding example of xpath differentiating b/w .// and // in find_element

### Description
extended example scripts in finders.XX.md for each translation

### Motivation and Context
necessary to make documentation more comprehensive

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
