### PR TITLE
added badge codes and fixed ruby code example

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/finders.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.en.md
@@ -131,14 +131,16 @@ var shadowHost = _driver.FindElement(By.CssSelector("#shadow_host"));
 var shadowRoot = shadowHost.GetShadowRoot();
 var shadowContent = shadowRoot.FindElement(By.CssSelector("#shadow_content"));
 {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
+{{< tab header="Ruby" >}}
 shadow_host = @driver.find_element(css: '#shadow_host')
 shadow_root = shadow_host.shadow_root
 shadow_content = shadow_root.find_element(css: '#shadow_content')
 {{< /tab >}}
-{{< tab header="JavaScript" >}}
+{{< tab header="JavaScript" text=true >}}
+{{< badge-code >}}
 {{< /tab >}}
-{{< tab header="Kotlin" >}}
+{{< tab header="Kotlin" text=true >}}
+{{< badge-code >}}
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
@@ -124,14 +124,16 @@ var shadowHost = _driver.FindElement(By.CssSelector("#shadow_host"));
 var shadowRoot = shadowHost.GetShadowRoot();
 var shadowContent = shadowRoot.FindElement(By.CssSelector("#shadow_content"));
 {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
+{{< tab header="Ruby" >}}
 shadow_host = @driver.find_element(css: '#shadow_host')
 shadow_root = shadow_host.shadow_root
 shadow_content = shadow_root.find_element(css: '#shadow_content')
 {{< /tab >}}
-{{< tab header="JavaScript" >}}
+{{< tab header="JavaScript" text=true >}}
+{{< badge-code >}}
 {{< /tab >}}
-{{< tab header="Kotlin" >}}
+{{< tab header="Kotlin" text=true >}}
+{{< badge-code >}}
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
@@ -127,14 +127,16 @@ var shadowHost = _driver.FindElement(By.CssSelector("#shadow_host"));
 var shadowRoot = shadowHost.GetShadowRoot();
 var shadowContent = shadowRoot.FindElement(By.CssSelector("#shadow_content"));
 {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
+{{< tab header="Ruby" >}}
 shadow_host = @driver.find_element(css: '#shadow_host')
 shadow_root = shadow_host.shadow_root
 shadow_content = shadow_root.find_element(css: '#shadow_content')
 {{< /tab >}}
-{{< tab header="JavaScript" >}}
+{{< tab header="JavaScript" text=true >}}
+{{< badge-code >}}
 {{< /tab >}}
-{{< tab header="Kotlin" >}}
+{{< tab header="Kotlin" text=true >}}
+{{< badge-code >}}
 {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
@@ -130,14 +130,16 @@ var shadowHost = _driver.FindElement(By.CssSelector("#shadow_host"));
 var shadowRoot = shadowHost.GetShadowRoot();
 var shadowContent = shadowRoot.FindElement(By.CssSelector("#shadow_content"));
 {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
+{{< tab header="Ruby" >}}
 shadow_host = @driver.find_element(css: '#shadow_host')
 shadow_root = shadow_host.shadow_root
 shadow_content = shadow_root.find_element(css: '#shadow_content')
 {{< /tab >}}
-{{< tab header="JavaScript" >}}
+{{< tab header="JavaScript" text=true >}}
+{{< badge-code >}}
 {{< /tab >}}
-{{< tab header="Kotlin" >}}
+{{< tab header="Kotlin" text=true >}}
+{{< badge-code >}}
 {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
### **User description**
Made improvements to Shadow-Dom section: made ruby code of type code instead of text, added badge codes to missing exampes

### Description
added badge codes to missing examples in shadow dom sections
made ruby code of type code instead of type text

### Motivation and Context
increases readability

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
documentation


___

### **Description**
- Updated the Ruby code examples to be of type `code` instead of `text` across multiple language documentation files.
- Added badge codes to the JavaScript and Kotlin examples to enhance visibility and consistency.
- These changes improve the readability and presentation of the Shadow DOM examples in the documentation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>finders.en.md</strong><dd><code>Update code formatting and add badges in English documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/finders.en.md

<li>Changed Ruby tab from text to code type.<br> <li> Added badge codes to JavaScript and Kotlin examples.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1897/files#diff-e21fb1eabd6a7eaf605f8f733ad4e5406d5ad60908a37a6da9b2c363c021ceae">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>finders.ja.md</strong><dd><code>Update code formatting and add badges in Japanese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/finders.ja.md

<li>Changed Ruby tab from text to code type.<br> <li> Added badge codes to JavaScript and Kotlin examples.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1897/files#diff-c047d3fd7654069cb4ca13dcf34df864532041dd9a03abced9f295402313e42c">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>finders.pt-br.md</strong><dd><code>Update code formatting and add badges in Portuguese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md

<li>Changed Ruby tab from text to code type.<br> <li> Added badge codes to JavaScript and Kotlin examples.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1897/files#diff-eaadee9340583f10ee129591af6c74011a61c7535fb37bbd08c77bd6afaae437">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>finders.zh-cn.md</strong><dd><code>Update code formatting and add badges in Chinese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md

<li>Changed Ruby tab from text to code type.<br> <li> Added badge codes to JavaScript and Kotlin examples.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1897/files#diff-eab325a79563cf7c8c85aecf2de106c1cf35ff7b191245b1cf7eac5cfed1d6de">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

