### PR TITLE
fixed implicit wait javascript example

### DIFF
--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -79,7 +79,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-{{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L37" >}}
+{{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -79,7 +79,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-{{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L37" >}}
+{{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -79,7 +79,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-{{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L37" >}}
+{{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -79,7 +79,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="examples/ruby/spec/waits/waits_spec.rb#L28" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-{{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L37" >}}
+{{< gh-codeblock path="examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
 {{< badge-code >}}


### PR DESCRIPTION
### **User description**
Implicit wait's javascript example was referencing an empty line in the example file, I fixed the reference

### Description
changed code reference in waits.md's implicit wait javascript example from line 37 to line 39 in examples/javascript/test/waits/waits.spec.js

### Motivation and Context
fixed code example

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
documentation


___

### **Description**
- Corrected the JavaScript example code reference in the implicit wait documentation across multiple languages.
- Changed the line reference from 37 to 39 in the JavaScript example for English, Japanese, Portuguese, and Chinese documentation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>waits.en.md</strong><dd><code>Correct JavaScript code reference in English documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/waits.en.md

- Updated JavaScript example code reference from line 37 to line 39.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1909/files#diff-0f903beeec94e44f636d84011042a3269fca16724e0f9157750468627d2fbcf1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>waits.ja.md</strong><dd><code>Correct JavaScript code reference in Japanese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/waits.ja.md

- Updated JavaScript example code reference from line 37 to line 39.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1909/files#diff-f2a1e275d6460bc8bbd76d7286d4aba317fee68f1d67e896e329a083a28a979a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>waits.pt-br.md</strong><dd><code>Correct JavaScript code reference in Portuguese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/waits.pt-br.md

- Updated JavaScript example code reference from line 37 to line 39.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1909/files#diff-527b5c5c4b7c1eeca060671f7532d5cb791033f313ed8a89d3d9f38291dcb43d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>waits.zh-cn.md</strong><dd><code>Correct JavaScript code reference in Chinese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/waits.zh-cn.md

- Updated JavaScript example code reference from line 37 to line 39.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1909/files#diff-1425a343085ce58500c63c9673d9c352f76169844cfa3e9110a610ee3b37fc7e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

