### PR TITLE
Add documentation to show the alternative use of an environment variable

### DIFF
--- a/website_and_docs/content/documentation/selenium_manager.en.md
+++ b/website_and_docs/content/documentation/selenium_manager.en.md
@@ -326,5 +326,23 @@ In this case, the library to be installed is the following:
 sudo apt-get install libatk-bridge2.0-0
 ```
 
+### Using an environment variable for the driver path
+It's possible to use an environment variable to specify the driver path without using Selenium Manager.
+The following environment variables are supported:
+
+* SE_CHROMEDRIVER
+* SE_EDGEDRIVER
+* SE_GECKODRIVER
+* SE_IEDRIVER
+* SE_SAFARIDRIVER
+
+For example, to specify the path to the chromedriver, you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
+The following bindings allow you to specify the driver path using an environment variable:
+
+* Ruby
+* Java
+
+This feature is available in the Selenium Ruby binding starting from version 4.25.0.
+
 ## Roadmap
 You can trace the work in progress in the [Selenium Manager project dashboard](https://github.com/orgs/SeleniumHQ/projects/5). Moreover, you can check the new features shipped with each Selenium Manager release in its [changelog file](https://github.com/SeleniumHQ/selenium/blob/trunk/rust/CHANGELOG.md).

--- a/website_and_docs/content/documentation/selenium_manager.en.md
+++ b/website_and_docs/content/documentation/selenium_manager.en.md
@@ -336,7 +336,8 @@ The following environment variables are supported:
 * SE_IEDRIVER
 * SE_SAFARIDRIVER
 
-For example, to specify the path to the chromedriver, you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
+For example, to specify the path to the chromedriver, 
+you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
 The following bindings allow you to specify the driver path using an environment variable:
 
 * Ruby

--- a/website_and_docs/content/documentation/selenium_manager.ja.md
+++ b/website_and_docs/content/documentation/selenium_manager.ja.md
@@ -326,5 +326,23 @@ In this case, the library to be installed is the following:
 sudo apt-get install libatk-bridge2.0-0
 ```
 
+### Using an environment variable for the driver path
+It's possible to use an environment variable to specify the driver path without using Selenium Manager.
+The following environment variables are supported:
+
+* SE_CHROMEDRIVER
+* SE_EDGEDRIVER
+* SE_GECKODRIVER
+* SE_IEDRIVER
+* SE_SAFARIDRIVER
+
+For example, to specify the path to the chromedriver, you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
+The following bindings allow you to specify the driver path using an environment variable:
+
+* Ruby
+* Java
+
+This feature is available in the Selenium Ruby binding starting from version 4.25.0.
+
 ## Roadmap
 You can trace the work in progress in the [Selenium Manager project dashboard](https://github.com/orgs/SeleniumHQ/projects/5). Moreover, you can check the new features shipped with each Selenium Manager release in its [changelog file](https://github.com/SeleniumHQ/selenium/blob/trunk/rust/CHANGELOG.md).

--- a/website_and_docs/content/documentation/selenium_manager.ja.md
+++ b/website_and_docs/content/documentation/selenium_manager.ja.md
@@ -336,7 +336,8 @@ The following environment variables are supported:
 * SE_IEDRIVER
 * SE_SAFARIDRIVER
 
-For example, to specify the path to the chromedriver, you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
+For example, to specify the path to the chromedriver,
+you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
 The following bindings allow you to specify the driver path using an environment variable:
 
 * Ruby

--- a/website_and_docs/content/documentation/selenium_manager.pt-br.md
+++ b/website_and_docs/content/documentation/selenium_manager.pt-br.md
@@ -326,5 +326,23 @@ In this case, the library to be installed is the following:
 sudo apt-get install libatk-bridge2.0-0
 ```
 
+### Using an environment variable for the driver path
+It's possible to use an environment variable to specify the driver path without using Selenium Manager.
+The following environment variables are supported:
+
+* SE_CHROMEDRIVER
+* SE_EDGEDRIVER
+* SE_GECKODRIVER
+* SE_IEDRIVER
+* SE_SAFARIDRIVER
+
+For example, to specify the path to the chromedriver, you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
+The following bindings allow you to specify the driver path using an environment variable:
+
+* Ruby
+* Java
+
+This feature is available in the Selenium Ruby binding starting from version 4.25.0.
+
 ## Roadmap
 You can trace the work in progress in the [Selenium Manager project dashboard](https://github.com/orgs/SeleniumHQ/projects/5). Moreover, you can check the new features shipped with each Selenium Manager release in its [changelog file](https://github.com/SeleniumHQ/selenium/blob/trunk/rust/CHANGELOG.md).

--- a/website_and_docs/content/documentation/selenium_manager.pt-br.md
+++ b/website_and_docs/content/documentation/selenium_manager.pt-br.md
@@ -336,7 +336,8 @@ The following environment variables are supported:
 * SE_IEDRIVER
 * SE_SAFARIDRIVER
 
-For example, to specify the path to the chromedriver, you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
+For example, to specify the path to the chromedriver,
+you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
 The following bindings allow you to specify the driver path using an environment variable:
 
 * Ruby

--- a/website_and_docs/content/documentation/selenium_manager.zh-cn.md
+++ b/website_and_docs/content/documentation/selenium_manager.zh-cn.md
@@ -326,5 +326,23 @@ In this case, the library to be installed is the following:
 sudo apt-get install libatk-bridge2.0-0
 ```
 
+### Using an environment variable for the driver path
+It's possible to use an environment variable to specify the driver path without using Selenium Manager.
+The following environment variables are supported:
+
+* SE_CHROMEDRIVER
+* SE_EDGEDRIVER
+* SE_GECKODRIVER
+* SE_IEDRIVER
+* SE_SAFARIDRIVER
+
+For example, to specify the path to the chromedriver, you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
+The following bindings allow you to specify the driver path using an environment variable:
+
+* Ruby
+* Java
+
+This feature is available in the Selenium Ruby binding starting from version 4.25.0.
+
 ## Roadmap
 You can trace the work in progress in the [Selenium Manager project dashboard](https://github.com/orgs/SeleniumHQ/projects/5). Moreover, you can check the new features shipped with each Selenium Manager release in its [changelog file](https://github.com/SeleniumHQ/selenium/blob/trunk/rust/CHANGELOG.md).

--- a/website_and_docs/content/documentation/selenium_manager.zh-cn.md
+++ b/website_and_docs/content/documentation/selenium_manager.zh-cn.md
@@ -336,7 +336,8 @@ The following environment variables are supported:
 * SE_IEDRIVER
 * SE_SAFARIDRIVER
 
-For example, to specify the path to the chromedriver, you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
+For example, to specify the path to the chromedriver,
+you can set the `SE_CHROMEDRIVER` environment variable to the path of the chromedriver executable.
 The following bindings allow you to specify the driver path using an environment variable:
 
 * Ruby


### PR DESCRIPTION
### Description

This PR adds to the selenium_manager a section that clarifies how to use environment variables as an alternative to set up the driver path

### Motivation and Context

After this feature was added https://github.com/SeleniumHQ/selenium/pull/14287 we need to update our documentation to reflect the possibility to use env variables to set the driver as an alternative to Selenium manager for the Selenium users

### Types of changes
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
Documentation


___

### **Description**
- Added documentation sections in multiple languages to explain how to use environment variables for specifying driver paths.
- Listed supported environment variables for different drivers such as `SE_CHROMEDRIVER`, `SE_EDGEDRIVER`, etc.
- Provided examples and noted the feature's availability in the Selenium Ruby binding starting from version 4.25.0.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.en.md</strong><dd><code>Document environment variable usage for driver paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/selenium_manager.en.md

<li>Added section on using environment variables for driver paths.<br> <li> Listed supported environment variables for different drivers.<br> <li> Provided example for setting <code>SE_CHROMEDRIVER</code>.<br> <li> Mentioned availability in Selenium Ruby binding version 4.25.0.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1950/files#diff-abfd3399fa93ee23ed8a6b8637b566cf12c67d477fda705ed877a10f013047b7">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.ja.md</strong><dd><code>Document environment variable usage for driver paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/selenium_manager.ja.md

<li>Added section on using environment variables for driver paths.<br> <li> Listed supported environment variables for different drivers.<br> <li> Provided example for setting <code>SE_CHROMEDRIVER</code>.<br> <li> Mentioned availability in Selenium Ruby binding version 4.25.0.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1950/files#diff-a84369b32708be4deb5da8f23f5b2c0adecb18e5eee5d30601e96f5d75e999f0">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.pt-br.md</strong><dd><code>Document environment variable usage for driver paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/selenium_manager.pt-br.md

<li>Added section on using environment variables for driver paths.<br> <li> Listed supported environment variables for different drivers.<br> <li> Provided example for setting <code>SE_CHROMEDRIVER</code>.<br> <li> Mentioned availability in Selenium Ruby binding version 4.25.0.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1950/files#diff-d8c0fd932e504044c81c242c7e255cb4533a7ea66e2b12d142c1cbb1680f6213">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.zh-cn.md</strong><dd><code>Document environment variable usage for driver paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/selenium_manager.zh-cn.md

<li>Added section on using environment variables for driver paths.<br> <li> Listed supported environment variables for different drivers.<br> <li> Provided example for setting <code>SE_CHROMEDRIVER</code>.<br> <li> Mentioned availability in Selenium Ruby binding version 4.25.0.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1950/files#diff-7b85ea66160081776015671c1e38dda6f8fd556f1217683dff9a0982fa71fc2b">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

