### PR TITLE
moved python examples for Relative Locators

### DIFF
--- a/examples/python/tests/elements/test_locators.py
+++ b/examples/python/tests/elements/test_locators.py
@@ -1,2 +1,54 @@
 from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.relative_locator import locate_with
+
+
+def testAbove():
+    driver = webdriver.Chrome()
+    driver.get("https://www.selenium.dev/selenium/web/inputs.html")
+
+    password_input = driver.find_element(By.NAME, "password-input")
+    email = locate_with(By.TAG_NAME, "input").above(password_input)
+    email.send_keys("test@test.com")
+    
+def testBelow():
+    driver = webdriver.Chrome()
+    driver.get("https://www.selenium.dev/selenium/web/inputs.html")
+
+    password_input = driver.find_element(By.NAME, "password_input")
+    search = locate_with(By.TAG_NAME, "input").below(password_input)
+    search.send_keys("XXXXXXXXXXXXX")
+    
+def testNear():
+    driver = webdriver.Chrome()
+    driver.get("https://www.selenium.dev/selenium/web/inputs.html")
+
+    week_input = driver.find_element(By.NAME, "week_input")
+    button = locate_with(By.TAG_NAME, "input").near(week_input)
+    button.click()
+    
+def testToTheLeftOf():
+    driver = webdriver.Chrome()
+    driver.get("https://www.selenium.dev/selenium/web/inputs.html")
+
+    submit_input = driver.find_element(By.NAME, "submit_input")
+    reset = locate_with(By.TAG_NAME, "input").to_the_left_of(submit_input)
+    reset.click()
+    
+def testToTheRightOf():
+    driver = webdriver.Chrome()
+    driver.get("https://www.selenium.dev/selenium/web/inputs.html")
+
+    reset_input = driver.find_element(By.NAME, "reset_input")
+    submit = locate_with(By.TAG_NAME, "input").to_the_right_of(reset_input)
+    submit.click()
+    
+def testAboveAndBelow():
+    driver = webdriver.Chrome()
+    driver.get("https://www.selenium.dev/selenium/web/inputs.html")
+
+    password_input = driver.find_element(By.NAME, "password_input")
+    number_input = driver.find_element(By.NAME, "number_input")
+    email = locate_with(By.TAG_NAME, "input").above(password_input).below(number_input)
+    email.send_keys("test@test.com")
 

--- a/website_and_docs/content/documentation/webdriver/elements/locators.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.en.md
@@ -442,6 +442,7 @@ Let us consider the below example for understanding the relative locators.
 
 {{< figure src="/images/documentation/webdriver/relative_locators.png" class="img-responsive text-center" alt="Relative Locators">}}
 
+
 ### Available relative locators
 
 #### Above
@@ -450,12 +451,11 @@ If the email text field element is not easily identifiable for some reason, but 
 we can locate the text field element using the fact that it is an "input" element "above" the password element. 
 
 {{< tabpane langEqualsHeader=true >}}
-{{< badge-examples >}}
 {{< tab header="Java" >}}
 By emailLocator = RelativeLocator.with(By.tagName("input")).above(By.id("password"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-email_locator = locate_with(By.TAG_NAME, "input").above({By.ID: "password"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L7-L12" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var emailLocator = RelativeBy.WithLocator(By.TagName("input")).Above(By.Id("password"));
@@ -481,8 +481,8 @@ we can locate the text field element using the fact that it is an "input" elemen
 {{< tab header="Java" >}}
 By passwordLocator = RelativeLocator.with(By.tagName("input")).below(By.id("email"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-password_locator = locate_with(By.TAG_NAME, "input").below({By.ID: "email"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L15-L20" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var passwordLocator = RelativeBy.WithLocator(By.TagName("input")).Below(By.Id("email"));
@@ -508,8 +508,8 @@ we can locate the cancel button element using the fact that it is a "button" ele
 {{< tab header="Java" >}}
 By cancelLocator = RelativeLocator.with(By.tagName("button")).toLeftOf(By.id("submit"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-cancel_locator = locate_with(By.TAG_NAME, "button").to_left_of({By.ID: "submit"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L31-L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var cancelLocator = RelativeBy.WithLocator(By.tagName("button")).LeftOf(By.Id("submit"));
@@ -535,8 +535,8 @@ we can locate the submit button element using the fact that it is a "button" ele
 {{< tab header="Java" >}}
 By submitLocator = RelativeLocator.with(By.tagName("button")).toRightOf(By.id("cancel"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-submit_locator = locate_with(By.TAG_NAME, "button").to_right_of({By.ID: "cancel"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L39-L44" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var submitLocator = RelativeBy.WithLocator(By.tagName("button")).RightOf(By.Id("cancel"));
@@ -561,8 +561,8 @@ but its associated [input label element](https://developer.mozilla.org/en-US/doc
 
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
-{{< tab header="Java" >}}
-By emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-email"));
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L23-L28" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 email_locator = locate_with(By.TAG_NAME, "input").near({By.ID: "lbl-email"})
@@ -590,8 +590,8 @@ You can also chain locators if needed. Sometimes the element is most easily iden
 {{< tab header="Java" >}}
 By submitLocator = RelativeLocator.with(By.tagName("button")).below(By.id("email")).toRightOf(By.id("cancel"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-submit_locator = locate_with(By.TAG_NAME, "button").below({By.ID: "email"}).to_right_of({By.ID: "cancel"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L47-L53" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var submitLocator = RelativeBy.WithLocator(By.tagName("button")).Below(By.Id("email")).RightOf(By.Id("cancel"));

--- a/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
@@ -445,8 +445,8 @@ we can locate the text field element using the fact that it is an "input" elemen
 {{< tab header="Java" >}}
 By emailLocator = RelativeLocator.with(By.tagName("input")).above(By.id("password"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-email_locator = locate_with(By.TAG_NAME, "input").above({By.ID: "password"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L7-L12" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var emailLocator = RelativeBy.WithLocator(By.TagName("input")).Above(By.Id("password"));
@@ -468,11 +468,12 @@ If the password text field element is not easily identifiable for some reason, b
 we can locate the text field element using the fact that it is an "input" element "below" the email element.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By passwordLocator = RelativeLocator.with(By.tagName("input")).below(By.id("email"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-password_locator = locate_with(By.TAG_NAME, "input").below({By.ID: "email"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L15-L20" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var passwordLocator = RelativeBy.WithLocator(By.TagName("input")).Below(By.Id("email"));
@@ -494,11 +495,12 @@ If the cancel button is not easily identifiable for some reason, but the submit 
 we can locate the cancel button element using the fact that it is a "button" element to the "left of" the submit element.
     
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By cancelLocator = RelativeLocator.with(By.tagName("button")).toLeftOf(By.id("submit"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-cancel_locator = locate_with(By.TAG_NAME, "button").to_left_of({By.ID: "submit"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L31-L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var cancelLocator = RelativeBy.WithLocator(By.tagName("button")).LeftOf(By.Id("submit"));
@@ -520,11 +522,12 @@ If the submit button is not easily identifiable for some reason, but the cancel 
 we can locate the submit button element using the fact that it is a "button" element "to the right of" the cancel element.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By submitLocator = RelativeLocator.with(By.tagName("button")).toRightOf(By.id("cancel"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-submit_locator = locate_with(By.TAG_NAME, "button").to_right_of({By.ID: "cancel"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L39-L44" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var submitLocator = RelativeBy.WithLocator(By.tagName("button")).RightOf(By.Id("cancel"));
@@ -548,8 +551,9 @@ One great use case for this is to work with a form element that doesn't have an 
 but its associated [input label element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) does.
 
 {{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-By emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-email"));
+{{< badge-examples >}}
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L23-L28" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 email_locator = locate_with(By.TAG_NAME, "input").near({By.ID: "lbl-email"})
@@ -573,11 +577,12 @@ val emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-ema
 You can also chain locators if needed. Sometimes the element is most easily identified as being both above/below one element and right/left of another.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By submitLocator = RelativeLocator.with(By.tagName("button")).below(By.id("email")).toRightOf(By.id("cancel"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-submit_locator = locate_with(By.TAG_NAME, "button").below({By.ID: "email"}).to_right_of({By.ID: "cancel"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L47-L53" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var submitLocator = RelativeBy.WithLocator(By.tagName("button")).Below(By.Id("email")).RightOf(By.Id("cancel"));

--- a/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
@@ -448,8 +448,8 @@ we can locate the text field element using the fact that it is an "input" elemen
 {{< tab header="Java" >}}
 By emailLocator = RelativeLocator.with(By.tagName("input")).above(By.id("password"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-email_locator = locate_with(By.TAG_NAME, "input").above({By.ID: "password"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L7-L12" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var emailLocator = RelativeBy.WithLocator(By.TagName("input")).Above(By.Id("password"));
@@ -471,11 +471,12 @@ If the password text field element is not easily identifiable for some reason, b
 we can locate the text field element using the fact that it is an "input" element "below" the email element.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By passwordLocator = RelativeLocator.with(By.tagName("input")).below(By.id("email"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-password_locator = locate_with(By.TAG_NAME, "input").below({By.ID: "email"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L15-L20" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var passwordLocator = RelativeBy.WithLocator(By.TagName("input")).Below(By.Id("email"));
@@ -497,11 +498,12 @@ If the cancel button is not easily identifiable for some reason, but the submit 
 we can locate the cancel button element using the fact that it is a "button" element to the "left of" the submit element.
     
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By cancelLocator = RelativeLocator.with(By.tagName("button")).toLeftOf(By.id("submit"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-cancel_locator = locate_with(By.TAG_NAME, "button").to_left_of({By.ID: "submit"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L31-L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var cancelLocator = RelativeBy.WithLocator(By.tagName("button")).LeftOf(By.Id("submit"));
@@ -523,11 +525,12 @@ If the submit button is not easily identifiable for some reason, but the cancel 
 we can locate the submit button element using the fact that it is a "button" element "to the right of" the cancel element.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By submitLocator = RelativeLocator.with(By.tagName("button")).toRightOf(By.id("cancel"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-submit_locator = locate_with(By.TAG_NAME, "button").to_right_of({By.ID: "cancel"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L39-L44" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var submitLocator = RelativeBy.WithLocator(By.tagName("button")).RightOf(By.Id("cancel"));
@@ -551,8 +554,9 @@ One great use case for this is to work with a form element that doesn't have an 
 but its associated [input label element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) does.
 
 {{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-By emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-email"));
+{{< badge-examples >}}
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L23-L28" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 email_locator = locate_with(By.TAG_NAME, "input").near({By.ID: "lbl-email"})
@@ -576,11 +580,12 @@ val emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-ema
 You can also chain locators if needed. Sometimes the element is most easily identified as being both above/below one element and right/left of another.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By submitLocator = RelativeLocator.with(By.tagName("button")).below(By.id("email")).toRightOf(By.id("cancel"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-submit_locator = locate_with(By.TAG_NAME, "button").below({By.ID: "email"}).to_right_of({By.ID: "cancel"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L47-L53" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var submitLocator = RelativeBy.WithLocator(By.tagName("button")).Below(By.Id("email")).RightOf(By.Id("cancel"));

--- a/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
@@ -448,8 +448,8 @@ we can locate the text field element using the fact that it is an "input" elemen
 {{< tab header="Java" >}}
 By emailLocator = RelativeLocator.with(By.tagName("input")).above(By.id("password"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-email_locator = locate_with(By.TAG_NAME, "input").above({By.ID: "password"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L7-L12" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var emailLocator = RelativeBy.WithLocator(By.TagName("input")).Above(By.Id("password"));
@@ -471,11 +471,12 @@ If the password text field element is not easily identifiable for some reason, b
 we can locate the text field element using the fact that it is an "input" element "below" the email element.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By passwordLocator = RelativeLocator.with(By.tagName("input")).below(By.id("email"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-password_locator = locate_with(By.TAG_NAME, "input").below({By.ID: "email"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L15-L20" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var passwordLocator = RelativeBy.WithLocator(By.TagName("input")).Below(By.Id("email"));
@@ -497,11 +498,12 @@ If the cancel button is not easily identifiable for some reason, but the submit 
 we can locate the cancel button element using the fact that it is a "button" element to the "left of" the submit element.
     
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By cancelLocator = RelativeLocator.with(By.tagName("button")).toLeftOf(By.id("submit"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-cancel_locator = locate_with(By.TAG_NAME, "button").to_left_of({By.ID: "submit"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L31-L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var cancelLocator = RelativeBy.WithLocator(By.tagName("button")).LeftOf(By.Id("submit"));
@@ -523,11 +525,12 @@ If the submit button is not easily identifiable for some reason, but the cancel 
 we can locate the submit button element using the fact that it is a "button" element "to the right of" the cancel element.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By submitLocator = RelativeLocator.with(By.tagName("button")).toRightOf(By.id("cancel"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-submit_locator = locate_with(By.TAG_NAME, "button").to_right_of({By.ID: "cancel"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L39-L44" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var submitLocator = RelativeBy.WithLocator(By.tagName("button")).RightOf(By.Id("cancel"));
@@ -551,8 +554,9 @@ One great use case for this is to work with a form element that doesn't have an 
 but its associated [input label element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) does.
 
 {{< tabpane langEqualsHeader=true >}}
-{{< tab header="Java" >}}
-By emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-email"));
+{{< badge-examples >}}
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L23-L28" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 email_locator = locate_with(By.TAG_NAME, "input").near({By.ID: "lbl-email"})
@@ -576,11 +580,12 @@ val emailLocator = RelativeLocator.with(By.tagName("input")).near(By.id("lbl-ema
 You can also chain locators if needed. Sometimes the element is most easily identified as being both above/below one element and right/left of another.
 
 {{< tabpane langEqualsHeader=true >}}
+{{< badge-examples >}}
 {{< tab header="Java" >}}
 By submitLocator = RelativeLocator.with(By.tagName("button")).below(By.id("email")).toRightOf(By.id("cancel"));
 {{< /tab >}}
-{{< tab header="Python" >}}
-submit_locator = locate_with(By.TAG_NAME, "button").below({By.ID: "email"}).to_right_of({By.ID: "cancel"})
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="examples/python/tests/elements/test_locators.py#L47-L53" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var submitLocator = RelativeBy.WithLocator(By.tagName("button")).Below(By.Id("email")).RightOf(By.Id("cancel"));


### PR DESCRIPTION
### **User description**
moved python examples for relative locators

### Description
moved python examples for relative locators in all languages

### Motivation and Context
increase comprehensiveness of website

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added Python test examples demonstrating the use of relative locators in Selenium.
- Updated documentation in multiple languages (English, Japanese, Portuguese, Chinese) to include links to the new Python test examples.
- Enhanced the comprehensiveness of the website by integrating Python examples directly into the documentation using `gh-codeblock`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_locators.py</strong><dd><code>Add Python tests for relative locators demonstration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/elements/test_locators.py

<li>Added multiple test functions demonstrating relative locators.<br> <li> Utilized <code>locate_with</code> for different relative positions like above, <br>below, near, etc.<br> <li> Each test function opens a web page and interacts with elements using <br>relative locators.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1962/files#diff-37a84073184f55bf24b44b3a435c07704ca453e3d74fac87370df04efec76cb8">+52/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>locators.en.md</strong><dd><code>Update English documentation with Python example links</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/locators.en.md

<li>Updated Python code examples to use <code>gh-codeblock</code> for better <br>integration.<br> <li> Enhanced documentation with direct references to Python test file <br>lines.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1962/files#diff-bad5c08d78f84e8bd7528d1a2a3181973375147d3f8bc5b9678cfce7dbe76aab">+13/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>locators.ja.md</strong><dd><code>Update Japanese documentation with Python example links</code>&nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/locators.ja.md

<li>Updated Python code examples to use <code>gh-codeblock</code>.<br> <li> Improved documentation with direct references to Python test file <br>lines.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1962/files#diff-06ad92a757672227e965b2d837608b89da6bb02315528815d9e6fa2eac9114af">+18/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>locators.pt-br.md</strong><dd><code>Update Portuguese documentation with Python example links</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md

<li>Updated Python code examples to use <code>gh-codeblock</code>.<br> <li> Enhanced documentation with direct references to Python test file <br>lines.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1962/files#diff-d1f5d96e2cf4217d2473ebd28f060129cedf8bde199fc884493ffd01d205d994">+18/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>locators.zh-cn.md</strong><dd><code>Update Chinese documentation with Python example links</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md

<li>Updated Python code examples to use <code>gh-codeblock</code>.<br> <li> Improved documentation with direct references to Python test file <br>lines.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1962/files#diff-275209ad35c57329488099cdbd775ba45e6386d21561836642e99c0b67721f10">+18/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information