### PR TITLE
Edit code reference (L18->L19) to align Python example with other languages (programming languages and spoken languages)

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
@@ -183,7 +183,7 @@ Elements store a lot of [information that can be requested]({{< ref "/documentat
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L27" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="examples/python/tests/getting_started/first_script.py#L18" >}}
+{{< gh-codeblock path="examples/python/tests/getting_started/first_script.py#L19" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L26" >}}


### PR DESCRIPTION
### **User description**
### Description

On page
https://www.selenium.dev/documentation/webdriver/getting_started/first_script/ in section "7. Request element information"
Python example shows getting message element
```python3
message = driver.find_element(by=By.ID, value="message")
```
instead of getting message element information
```python3
text = message.text
```

![20241006-selenium-website-codeblock-python-get-message-element-english](https://github.com/user-attachments/assets/eb46e8d6-c370-4595-ad59-fd7009a3f898)


The examples for other programming languages show getting the `text` attribute of the `message` element, e.g.

![20241006-selenium-website-codeblock-java-get-message-element-attribute](https://github.com/user-attachments/assets/14a92e10-7cc8-44d5-b6e3-acbc64c36b87)

And the examples for Python in other spoken languages show getting the `text` attribute of the `message` element.

![20241006-selenium-website-codeblock-python-get-message-element-not-english](https://github.com/user-attachments/assets/d8fdb608-be6d-4862-9008-223a603f33e9)


This commit changes the English markdown file. It edits the code reference to the Python file from L18 to L19.
This makes the Python example show getting the `text` attribute from the `message` element.


After this change:
- the Python example is like the examples for other programming languages
- the Python example on first_script.en.md is like the Python example for these: first_script.{zh-cn,pt-br,ja}.md

### Motivation and Context
Align code examples across programming languages and spoken languages.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
documentation


___

### **Description**
- Updated the Python example in the Selenium documentation to retrieve the `text` attribute of the `message` element, aligning it with examples in other programming languages.
- Changed the code reference in the English markdown file from line 18 to line 19 to reflect this update.
- Ensured consistency across different spoken languages by making the Python example similar to those in first_script.{zh-cn,pt-br,ja}.md.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>first_script.en.md</strong><dd><code>Align Python code example with other languages in documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md

<li>Updated code reference from line 18 to line 19 in the Python example.<br> <li> Ensured consistency with other language examples by showing how to get <br>the <code>text</code> attribute.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1982/files#diff-0757312e3d52b8201ca35b35c4bdad191db3e0978681a45c0cad1bebeb49fd3c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information