### PR TITLE
Fixed Incorrect Example Lines in PrintOptions Page

### DIFF
--- a/website_and_docs/content/documentation/webdriver/interactions/print_page.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/print_page.en.md
@@ -16,7 +16,7 @@ Using the `getOrientation()` and `setOrientation()` methods, you can get/set the
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L14-L20" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L12-L18" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -41,7 +41,7 @@ Using the `getPageRanges()` and `setPageRanges()` methods, you can get/set the r
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L23-L29" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L21-L27" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -66,7 +66,7 @@ Using the `getPaperSize()` and `setPaperSize()` methods, you can get/set the pap
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L32-L38" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L30-L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -91,7 +91,7 @@ Using the `getPageMargin()` and `setPageMargin()` methods, you can set the margi
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L41-L51" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L40-L49" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -116,7 +116,7 @@ Using `getScale()` and `setScale()` methods, you can get/set the scale of the pa
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L54-L60" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L52-L58" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -141,7 +141,7 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether b
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L63-L69" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L61-L67" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -166,7 +166,7 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether t
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L72-L78" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L70-L76" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/print_page.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/print_page.ja.md
@@ -16,7 +16,7 @@ Using the `getOrientation()` and `setOrientation()` methods, you can get/set the
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L14-L20" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L12-L18" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -41,7 +41,7 @@ Using the `getPageRanges()` and `setPageRanges()` methods, you can get/set the r
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L23-L29" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L21-L27" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -66,7 +66,7 @@ Using the `getPaperSize()` and `setPaperSize()` methods, you can get/set the pap
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L32-L38" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L30-L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -91,7 +91,7 @@ Using the `getPageMargin()` and `setPageMargin()` methods, you can set the margi
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L41-L51" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L40-L49" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -116,7 +116,7 @@ Using `getScale()` and `setScale()` methods, you can get/set the scale of the pa
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L54-L60" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L52-L58" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -141,7 +141,7 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether b
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L63-L69" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L61-L67" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -166,7 +166,7 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether t
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L72-L78" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L70-L76" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/print_page.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/print_page.pt-br.md
@@ -16,7 +16,7 @@ Using the `getOrientation()` and `setOrientation()` methods, you can get/set the
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L14-L20" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L12-L18" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -41,7 +41,7 @@ Using the `getPageRanges()` and `setPageRanges()` methods, you can get/set the r
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L23-L29" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L21-L27" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -66,7 +66,7 @@ Using the `getPaperSize()` and `setPaperSize()` methods, you can get/set the pap
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L32-L38" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L30-L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -91,7 +91,7 @@ Using the `getPageMargin()` and `setPageMargin()` methods, you can set the margi
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L41-L51" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L40-L49" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -116,7 +116,7 @@ Using `getScale()` and `setScale()` methods, you can get/set the scale of the pa
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L54-L60" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L52-L58" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -141,7 +141,7 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether b
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L63-L69" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L61-L67" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -166,7 +166,7 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether t
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L72-L78" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L70-L76" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/print_page.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/print_page.zh-cn.md
@@ -16,7 +16,7 @@ Using the `getOrientation()` and `setOrientation()` methods, you can get/set the
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L14-L20" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L12-L18" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -41,7 +41,7 @@ Using the `getPageRanges()` and `setPageRanges()` methods, you can get/set the r
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L23-L29" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L21-L27" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -66,7 +66,7 @@ Using the `getPaperSize()` and `setPaperSize()` methods, you can get/set the pap
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L32-L38" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L30-L36" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -91,7 +91,7 @@ Using the `getPageMargin()` and `setPageMargin()` methods, you can set the margi
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L41-L51" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L40-L49" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -116,7 +116,7 @@ Using `getScale()` and `setScale()` methods, you can get/set the scale of the pa
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L54-L60" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L52-L58" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -141,7 +141,7 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether b
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L63-L69" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L61-L67" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -166,7 +166,7 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether t
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L72-L78" >}}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java#L70-L76" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}


### PR DESCRIPTION
### **User description**
Seems the PrintOptions page's example were incorrectly lined

### Description
updated example line references

### Motivation and Context
make examples more accurate / readable

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
documentation


___

### **Description**
- Updated Java code example line references across multiple language documentation files.
- Ensured the accuracy of example line numbers for better readability and understanding.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>print_page.en.md</strong><dd><code>Correct Java example line references in English documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/print_page.en.md

<li>Updated line references in Java code examples.<br> <li> Corrected example line numbers for accuracy.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1992/files#diff-ab83295d85363fa0e82b30ca84fb9727d0e73fecc3de7b707767c39343a2459c">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>print_page.ja.md</strong><dd><code>Correct Java example line references in Japanese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/print_page.ja.md

<li>Updated line references in Java code examples.<br> <li> Corrected example line numbers for accuracy.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1992/files#diff-b2a566eb1a7cdfae34aa2dd15f597e4b8fd40fbdaadc1a3db3ce0fe850e7dc92">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>print_page.pt-br.md</strong><dd><code>Correct Java example line references in Portuguese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/print_page.pt-br.md

<li>Updated line references in Java code examples.<br> <li> Corrected example line numbers for accuracy.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1992/files#diff-d4342199d4feb4c990d7fa275bf4912397b428908760f58d26e1326ba4aea21a">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>print_page.zh-cn.md</strong><dd><code>Correct Java example line references in Chinese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/print_page.zh-cn.md

<li>Updated line references in Java code examples.<br> <li> Corrected example line numbers for accuracy.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/1992/files#diff-33cd5d0d8234827d7cacbb49b609e33192310123a67cbe0910f68a66a2b5eb6d">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information