### PR TITLE
Added Python Examples for PrintOptions()

### DIFF
--- a/examples/python/tests/interactions/test_print_options.py
+++ b/examples/python/tests/interactions/test_print_options.py
@@ -1,0 +1,58 @@
+import pytest
+from selenium import webdriver
+from selenium.webdriver.common.print_page_options import PrintOptions
+
+@pytest.fixture()
+def driver():
+    driver = webdriver.Chrome()
+    yield driver
+    driver.quit()
+
+def test_orientation(driver):
+    driver.get("https://www.selenium.dev/")
+    print_options = PrintOptions()
+    print_options.orientation = "landscape" ## landscape or portrait
+    assert print_options.orientation == "landscape"
+
+def test_range(driver):
+    driver.get("https://www.selenium.dev/")
+    print_options = PrintOptions()
+    print_options.page_ranges = ["1-3"] ## ["1", "2", "3"] or ["1-3"]
+    assert print_options.page_ranges == ["1", "2", "3"]
+
+def test_size(driver):
+    driver.get("https://www.selenium.dev/")
+    print_options = PrintOptions()
+    print_options.scale = 0.5 ## 0.1 to 2.0``
+    assert print_options.scale == 0.5
+
+def test_margin(driver):
+    driver.get("https://www.selenium.dev/")
+    print_options = PrintOptions()
+    print_options.margin_top = 10
+    print_options.margin_bottom = 10
+    print_options.margin_left = 10
+    print_options.margin_right = 10
+    assert print_options.margin_top == 10
+    assert print_options.margin_bottom == 10
+    assert print_options.margin_left == 10
+    assert print_options.margin_right == 10
+
+def test_scale(driver):
+    driver.get("https://www.selenium.dev/")
+    print_options = PrintOptions()
+    print_options.scale = 0.5 ## 0.1 to 2.0
+    current_scale = print_options.scale
+    assert current_scale == 0.5
+
+def test_background(driver):
+    driver.get("https://www.selenium.dev/")
+    print_options = PrintOptions()
+    print_options.background = True ## True or False
+    assert print_options.background is True
+
+def test_shrink_to_fit(driver):
+    driver.get("https://www.selenium.dev/")
+    print_options = PrintOptions()
+    print_options.shrink_to_fit = True ## True or False
+    assert print_options.shrink_to_fit is True

--- a/examples/python/tests/interactions/test_print_options.py
+++ b/examples/python/tests/interactions/test_print_options.py
@@ -18,7 +18,7 @@ def test_range(driver):
     driver.get("https://www.selenium.dev/")
     print_options = PrintOptions()
     print_options.page_ranges = ["1, 2, 3"] ## ["1", "2", "3"] or ["1-3"]
-    assert print_options.page_ranges == ["1", "2", "3"]
+    assert print_options.page_ranges == ["1, 2, 3"]
 
 def test_size(driver):
     driver.get("https://www.selenium.dev/")

--- a/examples/python/tests/interactions/test_print_options.py
+++ b/examples/python/tests/interactions/test_print_options.py
@@ -17,7 +17,7 @@ def test_orientation(driver):
 def test_range(driver):
     driver.get("https://www.selenium.dev/")
     print_options = PrintOptions()
-    print_options.page_ranges = ["1-3"] ## ["1", "2", "3"] or ["1-3"]
+    print_options.page_ranges = ["1, 2, 3"] ## ["1", "2", "3"] or ["1-3"]
     assert print_options.page_ranges == ["1", "2", "3"]
 
 def test_size(driver):

--- a/website_and_docs/content/documentation/webdriver/interactions/print_page.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/print_page.en.md
@@ -22,16 +22,16 @@ Using the `getOrientation()` and `setOrientation()` methods, you can get/set the
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L12-L19" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L11-L15" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -46,16 +46,16 @@ Using the `getPageRanges()` and `setPageRanges()` methods, you can get/set the r
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L22-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L17-L21" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -70,16 +70,16 @@ Using the `getPaperSize()` and `setPaperSize()` methods, you can get/set the pap
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L32-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L23-L27" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -94,16 +94,16 @@ Using the `getPageMargin()` and `setPageMargin()` methods, you can set the margi
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L51-L57" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L29-L39" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,16 +118,16 @@ Using `getScale()` and `setScale()` methods, you can get/set the scale of the pa
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L61-L68" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L41-L46" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -142,16 +142,16 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether b
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L41-L48" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L48-L52" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -166,15 +166,15 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether t
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L71-L78" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L54-L58" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/print_page.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/print_page.ja.md
@@ -22,16 +22,16 @@ Using the `getOrientation()` and `setOrientation()` methods, you can get/set the
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L12-L19" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L11-L15" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -46,16 +46,16 @@ Using the `getPageRanges()` and `setPageRanges()` methods, you can get/set the r
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L22-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L17-L21" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -70,16 +70,16 @@ Using the `getPaperSize()` and `setPaperSize()` methods, you can get/set the pap
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L32-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L23-L27" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -94,16 +94,16 @@ Using the `getPageMargin()` and `setPageMargin()` methods, you can set the margi
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L51-L57" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L29-L39" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,16 +118,16 @@ Using `getScale()` and `setScale()` methods, you can get/set the scale of the pa
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L61-L68" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L41-L46" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -142,16 +142,16 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether b
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L41-L48" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L48-L52" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -166,15 +166,15 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether t
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L71-L78" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L54-L58" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/print_page.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/print_page.pt-br.md
@@ -22,16 +22,16 @@ Using the `getOrientation()` and `setOrientation()` methods, you can get/set the
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L12-L19" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L11-L15" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -46,16 +46,16 @@ Using the `getPageRanges()` and `setPageRanges()` methods, you can get/set the r
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L22-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L17-L21" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -70,16 +70,16 @@ Using the `getPaperSize()` and `setPaperSize()` methods, you can get/set the pap
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L32-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L23-L27" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -94,16 +94,16 @@ Using the `getPageMargin()` and `setPageMargin()` methods, you can set the margi
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L51-L57" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L29-L39" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,16 +118,16 @@ Using `getScale()` and `setScale()` methods, you can get/set the scale of the pa
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L61-L68" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L41-L46" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -142,16 +142,16 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether b
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L41-L48" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L48-L52" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -166,15 +166,15 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether t
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L71-L78" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L54-L58" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/print_page.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/print_page.zh-cn.md
@@ -22,16 +22,16 @@ Using the `getOrientation()` and `setOrientation()` methods, you can get/set the
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L12-L19" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L11-L15" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -46,16 +46,16 @@ Using the `getPageRanges()` and `setPageRanges()` methods, you can get/set the r
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L22-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L17-L21" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -70,16 +70,16 @@ Using the `getPaperSize()` and `setPaperSize()` methods, you can get/set the pap
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L32-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L23-L27" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -94,16 +94,16 @@ Using the `getPageMargin()` and `setPageMargin()` methods, you can set the margi
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L51-L57" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L29-L39" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,16 +118,16 @@ Using `getScale()` and `setScale()` methods, you can get/set the scale of the pa
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L61-L68" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L41-L46" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -142,16 +142,16 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether b
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L41-L48" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L48-L52" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}
 
@@ -166,15 +166,15 @@ Using `getBackground()` and `setBackground()` methods, you can get/set whether t
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/PrintOptionsTest.cs#L71-L78" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/python/tests/interactions/test_print_options.py#L54-L58" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< badge-implementation >}}
 {{< /tab >}}
 {{< /tabpane >}}


### PR DESCRIPTION
Added python examples to the printoptions sections of the documentation

### Description
added test_print_options.py
added examples to print_options.md in all translations

### Motivation and Context
Issue #1941
Fixed conflicts in previous pr
Hacktober

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
