### PR TITLE
Incorrect Hugo syntax fixed, for driver.quit()

### DIFF
--- a/website_and_docs/content/documentation/webdriver/drivers/_index.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/_index.en.md
@@ -14,7 +14,8 @@ The session is created automatically by initializing a new Driver class object.
 
 Each language allows a session to be created with arguments from one of these classes (or equivalent):
 
-* [Options]({{< ref "options.md" >}}) to describe the kind of session you want; default values are used for local, but this is required for remote
+* [Options]({{< ref "options.md" >}}) to describe the kind of session you want; default values are used for local, but
+  this is required for remote
 * Some form of [HTTP Client configuration]({{< ref "http_client.md" >}}) (the implementation varies between languages)
 * [Listeners]({{< ref "listeners.md" >}})
 
@@ -23,7 +24,8 @@ Each language allows a session to be created with arguments from one of these cl
 The primary unique argument for starting a local driver includes information about starting the required driver service
 on the local machine.
 
-* [Service]({{< ref "service.md" >}}) object applies only to local drivers and provides information about the browser driver
+* [Service]({{< ref "service.md" >}}) object applies only to local drivers and provides information about the browser
+  driver
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
@@ -51,31 +53,30 @@ on the local machine.
 The primary unique argument for starting a remote driver includes information about where to execute the code.
 Read the details in the [Remote Driver Section]({{< ref "remote_webdriver.md" >}})
 
-
 ## Quitting Sessions
 
 Quitting a session corresponds to W3C command for [Deleting a Session](https://w3c.github.io/webdriver/#delete-session).
 
-Important note: the `quit` method is different from the `close` method, 
+Important note: the `quit` method is different from the `close` method,
 and it is recommended to always use `quit` to end the session
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
 {{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L13" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{< gh-codeblock path="examples/dotnet/HelloSelenium.cs#L13" >}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L28" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/options_spec.rb#L16" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L28" >}
+{{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L28" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L35" >}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L35" >}}
 {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/_index.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/_index.ja.md
@@ -14,14 +14,13 @@ weight: 3
 
 各言語では、次のいずれかのクラス (または同等のもの) の引数を使用してセッションを作成することができます。
 
-* [オプション]({{< ref "options.md" >}}) 作成を希望するセッションの種類 ;  ローカルにはデフォルト値を使用しますが、リモートには必須です。
+* [オプション]({{< ref "options.md" >}}) 作成を希望するセッションの種類 ; ローカルにはデフォルト値を使用しますが、リモートには必須です。
 * 何らかの形の[HTTP Client configuration]({{< ref "http_client.md" >}})  (実装は言語によって異なります)
 * [リスナー]({{< ref "listeners.md" >}})
-  
+
 ### ローカルドライバー
 
 ローカルドライバーを起動するための主な一意の引数には、ローカルコンピューターで必要なドライバーサービスを起動するための情報が含まれます。
-
 
 * [Service]({{< ref "service.md" >}})オブジェクトはローカルドライバーにのみ適用され、ブラウザーのドライバーに関する情報を提供します。
 
@@ -60,21 +59,21 @@ weight: 3
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
 {{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L13" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{< gh-codeblock path="examples/dotnet/HelloSelenium.cs#L13" >}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L28" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/options_spec.rb#L16" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L28" >}
+{{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L28" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L35" >}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L35" >}}
 {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/_index.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/_index.pt-br.md
@@ -14,7 +14,8 @@ The session is created automatically by initializing a new Driver class object.
 
 Each language allows a session to be created with arguments from one of these classes (or equivalent):
 
-* [Options]({{< ref "options.md" >}}) to describe the kind of session you want; default values are used for local, but this is required for remote
+* [Options]({{< ref "options.md" >}}) to describe the kind of session you want; default values are used for local, but
+  this is required for remote
 * Some form of [Http Client Configuration]({{< ref "http_client.md" >}}) (the implementation varies between languages)
 * [Listeners]({{< ref "listeners.md" >}})
 
@@ -23,7 +24,8 @@ Each language allows a session to be created with arguments from one of these cl
 The primary unique argument for starting a local driver includes information about starting the required driver service
 on the local machine.
 
-* [Service]({{< ref "service.md" >}}) object applies only to local drivers and provides information about the browser driver
+* [Service]({{< ref "service.md" >}}) object applies only to local drivers and provides information about the browser
+  driver
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
@@ -51,31 +53,30 @@ on the local machine.
 The primary unique argument for starting a remote driver includes information about where to execute the code.
 Read the details in the [Remote Driver Section]({{< ref "remote_webdriver.md" >}})
 
-
 ## Quitting Sessions
 
 Quitting a session corresponds to W3C command for [Deleting a Session](https://w3c.github.io/webdriver/#delete-session).
 
-Important note: the `quit` method is different from the `close` method, 
+Important note: the `quit` method is different from the `close` method,
 and it is recommended to always use `quit` to end the session
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
 {{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L13" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{< gh-codeblock path="examples/dotnet/HelloSelenium.cs#L13" >}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L28" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/options_spec.rb#L16" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L28" >}
+{{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L28" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L35" >}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L35" >}}
 {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/_index.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/_index.zh-cn.md
@@ -8,7 +8,7 @@ weight: 3
 
 ## 创建会话
 
-创建会话对应于W3C的命令 [新建会话](https://w3c.github.io/webdriver/#new-session) 
+创建会话对应于W3C的命令 [新建会话](https://w3c.github.io/webdriver/#new-session)
 
 会话是通过初始化新的驱动类对象自动创建的.
 
@@ -51,7 +51,6 @@ weight: 3
 用于启动远程驱动的首要唯一参数包括有关在何处执行代码的信息.
 请浏览 [远程驱动章节]({{< ref "remote_webdriver.md" >}})中的详细信息
 
-
 ## 退出会话
 
 退出会话对应于W3C的命令 [删除会话](https://w3c.github.io/webdriver/#delete-session).
@@ -61,21 +60,21 @@ weight: 3
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}
+{{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
 {{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L13" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{< gh-codeblock path="examples/dotnet/HelloSelenium.cs#L13" >}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L28" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/options_spec.rb#L16" >}}
 {{< /tab >}}
 {{< tab header="JavaScript" >}}
-{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L28" >}
+{{< gh-codeblock path="examples/javascript/test/getting_started/firstScript.spec.js#L28" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L35" >}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L35" >}}
 {{< /tab >}}
 {{< /tabpane >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
In Quitting session section, on [drivers](https://www.selenium.dev/documentation/webdriver/drivers/) page, due to incorrect hugo syntax the driver.quit() was not being displayed for Java, Dotnet, JS and Kotlin. Fixed this issue, made the changes in all the supported language files, local verification done after the fixes. Fixes #2002. Video attached showing the fixes -

https://github.com/user-attachments/assets/c67bcab3-a14c-4598-87ed-99f38404f4d8



### Motivation and Context
This change was required, because it shows how can we use driver.quit() in various language bindings.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed incorrect Hugo syntax in the "Quitting Sessions" section for Java, CSharp, JavaScript, and Kotlin, ensuring proper rendering of the `driver.quit()` command.
- Updated the CSharp code reference to point to the correct file `examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs`.
- Improved formatting for better readability across multiple language documentation files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_index.en.md</strong><dd><code>Correct Hugo syntax and update CSharp code reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/drivers/_index.en.md

<li>Fixed incorrect Hugo syntax for code blocks in multiple languages.<br> <li> Updated CSharp code reference path to the correct file.<br> <li> Improved formatting for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2003/files#diff-10ff84d69cea7383c29ebfd0e4934cda8a3d6111bfc937897b1f446c4f4781b5">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_index.ja.md</strong><dd><code>Correct Hugo syntax and update CSharp code reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/drivers/_index.ja.md

<li>Fixed incorrect Hugo syntax for code blocks in multiple languages.<br> <li> Updated CSharp code reference path to the correct file.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2003/files#diff-bfbaccc3ea80f5b819613809c7324862ee335c163d6e474b07a0d3aa7e48740e">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_index.pt-br.md</strong><dd><code>Correct Hugo syntax and update CSharp code reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/drivers/_index.pt-br.md

<li>Fixed incorrect Hugo syntax for code blocks in multiple languages.<br> <li> Updated CSharp code reference path to the correct file.<br> <li> Improved formatting for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2003/files#diff-86b91e7aed382ec5c668cf7a26e77cc125d1b983696d9fa5962ce8c47c598fc9">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_index.zh-cn.md</strong><dd><code>Correct Hugo syntax and update CSharp code reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/drivers/_index.zh-cn.md

<li>Fixed incorrect Hugo syntax for code blocks in multiple languages.<br> <li> Updated CSharp code reference path to the correct file.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2003/files#diff-271afe3b24802a1c6427f915a6ded1b3f370a63eda9ee97b38820971149f4563">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information