### PR TITLE
py: fix line number of driver quit

### DIFF
--- a/website_and_docs/content/documentation/webdriver/drivers/_index.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/_index.en.md
@@ -65,7 +65,7 @@ and it is recommended to always use `quit` to end the session
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L13" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L11" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L28" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/_index.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/_index.ja.md
@@ -62,7 +62,7 @@ weight: 3
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L13" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L11" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L28" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/_index.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/_index.pt-br.md
@@ -65,7 +65,7 @@ and it is recommended to always use `quit` to end the session
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L13" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L11" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L28" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/_index.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/_index.zh-cn.md
@@ -63,7 +63,7 @@ weight: 3
 {{< gh-codeblock path="examples/java/src/test/java/dev/selenium/getting_started/FirstScript.java#L29" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L13" >}}
+{{< gh-codeblock path="examples/python/tests/drivers/test_options.py#L11" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/GettingStarted/FirstScript.cs#L28" >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Fixes line number for `driver.quit()`. Currently it is a blank line.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Adds the method instead of the blank line which is useless.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
documentation


___

### **Description**
- Corrected the line number for the Python `driver.quit()` example in the documentation.
- Ensures the documentation accurately reflects the code example, improving clarity for users.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_index.en.md</strong><dd><code>Correct line number for Python `driver.quit()` example</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/drivers/_index.en.md

<li>Updated the line number for the Python <code>driver.quit()</code> example.<br> <li> Changed from line 13 to line 11 in the code block reference.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2033/files#diff-10ff84d69cea7383c29ebfd0e4934cda8a3d6111bfc937897b1f446c4f4781b5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information