### PR TITLE
Corrected C# "Remote WebDriver / Download a File" example reference

### DIFF
--- a/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
@@ -159,7 +159,7 @@ Selenium looks for the name of the provided file in the list and downloads it to
 {{< gh-codeblock path="examples/python/tests/drivers/test_remote_webdriver.py#L58" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/RemoteWebDriverTest.cs#L78" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/RemoteWebDriverTest.cs#L79" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/remote_webdriver_spec.rb#L57" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.ja.md
@@ -141,7 +141,7 @@ Seleniumは、提供されたファイルの名前をリストの中で探し、
 {{< gh-codeblock path="examples/python/tests/drivers/test_remote_webdriver.py#L58" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/RemoteWebDriverTest.cs#L78" >}}
+{{< gh-codeblock path="examples/dotnet/SeleniumDocs/Drivers/RemoteWebDriverTest.cs#L79" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="examples/ruby/spec/drivers/remote_webdriver_spec.rb#L57" >}}


### PR DESCRIPTION
### **User description**
### Description

Corrected C# "Remote WebDriver / Download a File" example reference.

### Motivation and Context

I've noticed that on page <https://www.selenium.dev/documentation/webdriver/drivers/remote_webdriver/> "Download a File" C# example is empty. It turned out that it references a wrong example line number 78 ([link](https://github.com/SeleniumHQ/seleniumhq.github.io/blob/trunk/examples/dotnet/SeleniumDocs/Drivers/RemoteWebDriverTest.cs#L78)), but it should be 79. Incorrect line number is on `remote_webdriver.en.md` and `remote_webdriver.ja.md` pages, while the correct number is on `remote_webdriver.pt-br.md` and `remote_webdriver.zh-cn.md`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
documentation


___

### **Description**
- Corrected the line number reference for the C# "Remote WebDriver / Download a File" example in the English and Japanese documentation.
- Updated the reference from line 78 to line 79 to ensure the correct example is displayed.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_webdriver.en.md</strong><dd><code>Fix incorrect line number in C# example reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md

<li>Corrected the line number reference for the C# code example.<br> <li> Changed from line 78 to line 79.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2034/files#diff-6479af8ea2d3476a57172c140d8d8004e07166cd433cf250fce86e0b7c604c40">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>remote_webdriver.ja.md</strong><dd><code>Fix incorrect line number in C# example reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.ja.md

<li>Corrected the line number reference for the C# code example.<br> <li> Changed from line 78 to line 79.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2034/files#diff-3a6a9f776ab7392c22a6f274f7bfea45cbe64bf684919073c9772dead7b96222">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information