### PR TITLE
Fix flaky test in examples python

### DIFF
--- a/examples/python/tests/actions_api/test_mouse.py
+++ b/examples/python/tests/actions_api/test_mouse.py
@@ -1,17 +1,19 @@
+import pytest
 from time import sleep
-
 from selenium.webdriver import ActionChains
 from selenium.webdriver.common.actions.action_builder import ActionBuilder
 from selenium.webdriver.common.actions.mouse_button import MouseButton
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 def test_click_and_hold(driver):
     driver.get('https://selenium.dev/selenium/web/mouse_interaction.html')
 
     clickable = driver.find_element(By.ID, "clickable")
-    ActionChains(driver)\
-        .click_and_hold(clickable)\
+    ActionChains(driver) \
+        .click_and_hold(clickable) \
         .perform()
 
     sleep(0.5)
@@ -22,8 +24,8 @@ def test_click_and_release(driver):
     driver.get('https://selenium.dev/selenium/web/mouse_interaction.html')
 
     clickable = driver.find_element(By.ID, "click")
-    ActionChains(driver)\
-        .click(clickable)\
+    ActionChains(driver) \
+        .click(clickable) \
         .perform()
 
     assert "resultPage.html" in driver.current_url
@@ -33,8 +35,8 @@ def test_right_click(driver):
     driver.get('https://selenium.dev/selenium/web/mouse_interaction.html')
 
     clickable = driver.find_element(By.ID, "clickable")
-    ActionChains(driver)\
-        .context_click(clickable)\
+    ActionChains(driver) \
+        .context_click(clickable) \
         .perform()
 
     sleep(0.5)
@@ -72,8 +74,8 @@ def test_double_click(driver):
     driver.get('https://selenium.dev/selenium/web/mouse_interaction.html')
 
     clickable = driver.find_element(By.ID, "clickable")
-    ActionChains(driver)\
-        .double_click(clickable)\
+    ActionChains(driver) \
+        .double_click(clickable) \
         .perform()
 
     assert driver.find_element(By.ID, "click-status").text == "double-clicked"
@@ -83,8 +85,8 @@ def test_hover(driver):
     driver.get('https://selenium.dev/selenium/web/mouse_interaction.html')
 
     hoverable = driver.find_element(By.ID, "hover")
-    ActionChains(driver)\
-        .move_to_element(hoverable)\
+    ActionChains(driver) \
+        .move_to_element(hoverable) \
         .perform()
 
     assert driver.find_element(By.ID, "move-status").text == "hovered"
@@ -94,8 +96,8 @@ def test_move_by_offset_from_element(driver):
     driver.get('https://selenium.dev/selenium/web/mouse_interaction.html')
 
     mouse_tracker = driver.find_element(By.ID, "mouse-tracker")
-    ActionChains(driver)\
-        .move_to_element_with_offset(mouse_tracker, 8, 0)\
+    ActionChains(driver) \
+        .move_to_element_with_offset(mouse_tracker, 8, 0) \
         .perform()
 
     coordinates = driver.find_element(By.ID, "relative-location").text.split(", ")
@@ -104,7 +106,7 @@ def test_move_by_offset_from_element(driver):
 
 def test_move_by_offset_from_viewport_origin_ab(driver):
     driver.get('https://selenium.dev/selenium/web/mouse_interaction.html')
-
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.ID, "absolute-location")))
     action = ActionBuilder(driver)
     action.pointer_action.move_to_location(8, 0)
     action.perform()
@@ -121,8 +123,8 @@ def test_move_by_offset_from_current_pointer_ab(driver):
     action.pointer_action.move_to_location(6, 3)
     action.perform()
 
-    ActionChains(driver)\
-        .move_by_offset( 13, 15)\
+    ActionChains(driver) \
+        .move_by_offset(13, 15) \
         .perform()
 
     coordinates = driver.find_element(By.ID, "absolute-location").text.split(", ")
@@ -136,8 +138,8 @@ def test_drag_and_drop_onto_element(driver):
 
     draggable = driver.find_element(By.ID, "draggable")
     droppable = driver.find_element(By.ID, "droppable")
-    ActionChains(driver)\
-        .drag_and_drop(draggable, droppable)\
+    ActionChains(driver) \
+        .drag_and_drop(draggable, droppable) \
         .perform()
 
     assert driver.find_element(By.ID, "drop-status").text == "dropped"
@@ -149,15 +151,8 @@ def test_drag_and_drop_by_offset(driver):
     draggable = driver.find_element(By.ID, "draggable")
     start = draggable.location
     finish = driver.find_element(By.ID, "droppable").location
-    ActionChains(driver)\
-        .drag_and_drop_by_offset(draggable, finish['x'] - start['x'], finish['y'] - start['y'])\
+    ActionChains(driver) \
+        .drag_and_drop_by_offset(draggable, finish['x'] - start['x'], finish['y'] - start['y']) \
         .perform()
 
     assert driver.find_element(By.ID, "drop-status").text == "dropped"
-
-
-
-
-
-
-

--- a/examples/python/tests/bidi/cdp/test_script.py
+++ b/examples/python/tests/bidi/cdp/test_script.py
@@ -1,6 +1,8 @@
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.log import Log
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 @pytest.mark.trio
@@ -8,6 +10,7 @@ async def test_mutation(driver):
     async with driver.bidi_connection() as session:
         async with Log(driver, session).mutation_events() as event:
             driver.get('https://www.selenium.dev/selenium/web/dynamic.html')
+            WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.ID, "reveal")))
             driver.find_element(By.ID, "reveal").click()
 
     assert event["element"] == driver.find_element(By.ID, "revealed")

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md
@@ -25,7 +25,7 @@ This is useful for focusing a specific element:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L22-L25" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L12-L15" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L14-L17" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L17-L20" >}}
@@ -51,7 +51,7 @@ This is otherwise known as "clicking":
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L34-L37" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L24-L27" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L26-L29" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L30-L33" >}}
@@ -86,7 +86,7 @@ This is otherwise known as "right-clicking":
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L46-L49" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L35-L38" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L37-L40" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L43-L46" >}}
@@ -112,7 +112,7 @@ There is no convenience method for this, it is just pressing and releasing mouse
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.2" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L49-L52" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L51-L54" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.2" >}}
@@ -141,7 +141,7 @@ There is no convenience method for this, it is just pressing and releasing mouse
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.2" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L63-L66" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L65-L68" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.2" >}}
@@ -169,7 +169,7 @@ This method combines moving to the center of an element with pressing and releas
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L93-L96" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L74-L77" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L76-L79" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L91-L94" >}}
@@ -196,7 +196,7 @@ Note that the element must be in the viewport or else the command will error.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L105-L108" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L85-L88" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L87-L90" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L104-L107" >}}
@@ -228,7 +228,7 @@ then moves by the provided offset.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L118-L121" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L98-L101" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L132-L135" >}}
@@ -254,7 +254,7 @@ offset.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L131-L136" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L108-L110" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L110-L112" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L146-L150" >}}
@@ -286,7 +286,7 @@ the current mouse position.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L153-L155" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L124-L126" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L126-L128" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L167-L169" >}}
@@ -312,7 +312,7 @@ moves to the location of the target element and then releases the mouse.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L166-L170" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L137-L141" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L139-L143" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L181-L185" >}}
@@ -337,7 +337,7 @@ This method firstly performs a click-and-hold on the source element, moves to th
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L179-L184" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L149-L154" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L151-L156" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L195-L200" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md
@@ -25,7 +25,7 @@ This is useful for focusing a specific element:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L22-L25" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L12-L15" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L14-L17" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L17-L20" >}}
@@ -51,7 +51,7 @@ This is otherwise known as "clicking":
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L34-L37" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L24-L27" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L26-L29" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L30-L33" >}}
@@ -86,7 +86,7 @@ This is otherwise known as "right-clicking":
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L46-L49" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L35-L38" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L37-L40" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L43-L46" >}}
@@ -112,7 +112,7 @@ There is no convenience method for this, it is just pressing and releasing mouse
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.2" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L49-L52" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L51-L54" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.2" >}}
@@ -141,7 +141,7 @@ There is no convenience method for this, it is just pressing and releasing mouse
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.2" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L63-L66" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L65-L68" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.2" >}}
@@ -169,7 +169,7 @@ This method combines moving to the center of an element with pressing and releas
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L93-L96" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L74-L77" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L76-L79" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L91-L94" >}}
@@ -196,7 +196,7 @@ Note that the element must be in the viewport or else the command will error.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L105-L108" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L85-L88" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L87-L90" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L104-L107" >}}
@@ -228,7 +228,7 @@ then moves by the provided offset.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L118-L121" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L98-L101" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L132-L135" >}}
@@ -254,7 +254,7 @@ offset.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L131-L136" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L108-L110" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L110-L112" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L146-L150" >}}
@@ -286,7 +286,7 @@ the current mouse position.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L153-L155" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L124-L126" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L126-L128" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L167-L169" >}}
@@ -312,7 +312,7 @@ moves to the location of the target element and then releases the mouse.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L166-L170" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L137-L141" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L139-L143" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L181-L185" >}}
@@ -337,7 +337,7 @@ This method firstly performs a click-and-hold on the source element, moves to th
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L179-L184" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L149-L154" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L151-L156" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L195-L200" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md
@@ -22,7 +22,7 @@ Este método combina mover o mouse para o centro de um elemento com a pressão d
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L22-L25" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L12-L15" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L14-L17" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L17-L20" >}}
@@ -47,7 +47,7 @@ Este método combina mover o mouse para o centro de um elemento com a pressão e
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L34-L37" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L24-L27" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L26-L29" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L30-L33" >}}
@@ -82,7 +82,7 @@ Este método combina mover o mouse para o centro de um elemento com a pressão e
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L46-L49" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L35-L38" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L37-L40" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L43-L46" >}}
@@ -108,7 +108,7 @@ Este termo pode se referir a um clique com o botão X1 (botão de voltar) do mou
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.2" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L49-L52" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L51-L54" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.2" >}}
@@ -137,7 +137,7 @@ Este termo se refere a um clique com o botão X2 (botão de avançar) do mouse. 
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.2" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L63-L66" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L65-L68" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.2" >}}
@@ -165,7 +165,7 @@ Este método combina mover o mouse para o centro de um elemento com a pressão e
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L93-L96" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L74-L77" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L76-L79" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L91-L94" >}}
@@ -190,7 +190,7 @@ Este método move o mouse para o ponto central do elemento que está visível na
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L105-L108" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L85-L88" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L87-L90" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L104-L107" >}}
@@ -219,7 +219,7 @@ Este método move o mouse para o ponto central do elemento visível na tela e, e
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L118-L121" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L98-L101" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L132-L135" >}}
@@ -244,7 +244,7 @@ Este método move o mouse a partir do canto superior esquerdo da janela de visua
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L131-L136" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L108-L110" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L110-L112" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L146-L150" >}}
@@ -270,7 +270,7 @@ Observe que o primeiro argumento, X, especifica o movimento para a direita quand
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L153-L155" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L124-L126" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L126-L128" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L167-L169" >}}
@@ -295,7 +295,7 @@ Este método primeiro realiza um clique e mantém pressionado no elemento de ori
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L166-L170" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L137-L141" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L139-L143" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L181-L185" >}}
@@ -320,7 +320,7 @@ Este método primeiro realiza um clique e mantém pressionado no elemento de ori
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L179-L184" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L149-L154" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L151-L156" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L195-L200" >}}

--- a/website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md
@@ -26,7 +26,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L22-L25" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L12-L15" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L14-L17" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L17-L20" >}}
@@ -52,7 +52,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L34-L37" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L24-L27" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L26-L29" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L30-L33" >}}
@@ -87,7 +87,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L46-L49" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L35-L38" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L37-L40" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L43-L46" >}}
@@ -113,7 +113,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.2" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L49-L52" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L51-L54" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.2" >}}
@@ -142,7 +142,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.2" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L63-L66" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L65-L68" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-version version="4.2" >}}
@@ -170,7 +170,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L93-L96" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L74-L77" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L76-L79" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L91-L94" >}}
@@ -197,7 +197,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L105-L108" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L85-L88" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L87-L90" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L104-L107" >}}
@@ -227,7 +227,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L118-L121" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L96-L99" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L98-L101" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L132-L135" >}}
@@ -252,7 +252,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L131-L136" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L108-L110" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L110-L112" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L146-L150" >}}
@@ -281,7 +281,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L153-L155" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L124-L126" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L126-L128" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L167-L169" >}}
@@ -306,7 +306,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L166-L170" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L137-L141" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L139-L143" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L181-L185" >}}
@@ -330,7 +330,7 @@ Selenium组合了常见的操作并提供了方便的方法。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/actions_api/MouseTest.java#L179-L184" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L149-L154" >}}
+{{< gh-codeblock path="/examples/python/tests/actions_api/test_mouse.py#L151-L156" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/ActionsAPI/MouseTest.cs#L195-L200" >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/cdp/script.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/cdp/script.en.md
@@ -42,7 +42,7 @@ methods will eventually be removed when WebDriver BiDi implemented.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidi/cdp/NetworkTest.java#L44" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/bidi/cdp/test_script.py#L8-L9" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/cdp/test_script.py#L10-L11" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/BiDi/CDP/ScriptTest.cs#L39-L46" >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/cdp/script.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/cdp/script.ja.md
@@ -51,7 +51,7 @@ methods will eventually be removed when WebDriver BiDi implemented.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidi/cdp/NetworkTest.java#L44" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/bidi/cdp/test_script.py#L8-L9" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/cdp/test_script.py#L10-L11" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/BiDi/CDP/ScriptTest.cs#L39-L46" >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/cdp/script.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/cdp/script.pt-br.md
@@ -51,7 +51,7 @@ methods will eventually be removed when WebDriver BiDi implemented.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidi/cdp/NetworkTest.java#L44" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/bidi/cdp/test_script.py#L8-L9" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/cdp/test_script.py#L10-L11" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/BiDi/CDP/ScriptTest.cs#L39-L46" >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/cdp/script.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/cdp/script.zh-cn.md
@@ -51,7 +51,7 @@ methods will eventually be removed when WebDriver BiDi implemented.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidi/cdp/NetworkTest.java#L44" >}}
 {{% /tab %}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/bidi/cdp/test_script.py#L8-L9" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/cdp/test_script.py#L10-L11" >}}
 {{% /tab %}}
 {{% tab header="CSharp" %}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/BiDi/CDP/ScriptTest.cs#L39-L46" >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Added lines of code. And updated code-blocks in docs also

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Tests, Documentation


___

### **Description**
- Improved the stability of Python tests by adding explicit waits using `WebDriverWait` and `expected_conditions`.
- Fixed formatting issues in Python test files for better readability and consistency.
- Updated documentation to reflect new line numbers in Python code examples across multiple languages.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_mouse.py</strong><dd><code>Improve stability and formatting of mouse action tests</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/actions_api/test_mouse.py

<li>Added <code>pytest</code> import.<br> <li> Added <code>WebDriverWait</code> and <code>expected_conditions</code> imports.<br> <li> Improved test stability by using <code>WebDriverWait</code>.<br> <li> Fixed formatting issues with <code>ActionChains</code> method chaining.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-ecc1698a7da9e0eb371b8b34dd6ac98dc4b1c3e28c2a83669cf9ad04d944b33d">+22/-27</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_script.py</strong><dd><code>Enhance test stability with explicit waits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/bidi/cdp/test_script.py

<li>Added <code>WebDriverWait</code> and <code>expected_conditions</code> imports.<br> <li> Improved test stability by waiting for element to be clickable.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-ed553fddaef4f87891e1478df5b35324f7192403944770a801b8f6715fe01eb2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>mouse.en.md</strong><dd><code>Update Python code block references in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/actions_api/mouse.en.md

- Updated code block line references for Python examples.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-548a32be19b22d84f6ddfb71ad79ebb6f1d0f6e07f6e41ecbc5a5d32064151fb">+12/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mouse.ja.md</strong><dd><code>Update Python code block references in Japanese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/actions_api/mouse.ja.md

- Updated code block line references for Python examples.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-de689069cca7cb870adff2eaaab23409a3cd2ef806b0115bd25c9e4457b977b7">+12/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mouse.pt-br.md</strong><dd><code>Update Python code block references in Portuguese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/actions_api/mouse.pt-br.md

- Updated code block line references for Python examples.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-fe6dc1be357ffeb0042cebc0090069a4ec2583d7f97c98bd89e73600ecf67430">+12/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mouse.zh-cn.md</strong><dd><code>Update Python code block references in Chinese documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/actions_api/mouse.zh-cn.md

- Updated code block line references for Python examples.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-733c600f7668279d12d14de06dc21a0848d4d1dabd2018e699860fda1529ba65">+12/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>script.en.md</strong><dd><code>Update Python code block references in BiDi script documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/bidi/cdp/script.en.md

- Updated code block line references for Python examples.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-4b761cf11087ef5ea63697dffb0fc236324b121b79a031266012bab613bf6a31">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>script.ja.md</strong><dd><code>Update Python code block references in Japanese BiDi script </code><br><code>documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/bidi/cdp/script.ja.md

- Updated code block line references for Python examples.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-d395c5237051d18c03964d4787c754d059bd38ec99b43aeca1cffa9a63450c13">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>script.pt-br.md</strong><dd><code>Update Python code block references in Portuguese BiDi script </code><br><code>documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/bidi/cdp/script.pt-br.md

- Updated code block line references for Python examples.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-95d1777029f29f38a1fa167fb2ae22bcbf8316509f273d621c6d21441013a081">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>script.zh-cn.md</strong><dd><code>Update Python code block references in Chinese BiDi script </code><br><code>documentation</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/bidi/cdp/script.zh-cn.md

- Updated code block line references for Python examples.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2042/files#diff-760dc1381493edb66eaed9f33fddcc6fb020dede7e77f1f249b074a6a6a8dfb4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information