### PR TITLE
Correct Webdriver HTTP Client in Python examples

### DIFF
--- a/examples/python/tests/drivers/test_http_client.py
+++ b/examples/python/tests/drivers/test_http_client.py
@@ -9,14 +9,14 @@ from selenium.webdriver.remote.client_config import ClientConfig
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Gets stuck on Windows, passes locally")
-@pytest.mark.sanity
 def test_start_remote_with_client_config(grid_server):
     proxy = Proxy({"proxyType": ProxyType.AUTODETECT})
     retries = Retry(connect=2, read=2, redirect=2)
     timeout = Timeout(connect=300, read=3600)
     client_config = ClientConfig(remote_server_addr=grid_server,
                                  proxy=proxy,
-                                 init_args_for_pool_manager={"retries": retries, "timeout": timeout},
+                                 init_args_for_pool_manager={
+                                     "init_args_for_pool_manager": {"retries": retries, "timeout": timeout}},
                                  ca_certs=_get_resource_path("tls.crt"),
                                  username="admin", password="myStrongPassword")
     options = webdriver.ChromeOptions()
@@ -26,7 +26,6 @@ def test_start_remote_with_client_config(grid_server):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Gets stuck on Windows, passes locally")
-@pytest.mark.sanity
 def test_start_remote_ignore_certs(grid_server):
     proxy = Proxy({"proxyType": ProxyType.AUTODETECT})
     client_config = ClientConfig(remote_server_addr=grid_server,


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
tests


___

### **Description**
- Removed the `@pytest.mark.sanity` decorator from the test functions `test_start_remote_with_client_config` and `test_start_remote_ignore_certs`, which may have been used for categorizing tests.
- Corrected the structure of the `init_args_for_pool_manager` dictionary in the `test_start_remote_with_client_config` function to ensure proper initialization of retries and timeout parameters.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_http_client.py</strong><dd><code>Update test configuration and remove sanity mark</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/drivers/test_http_client.py

<li>Removed <code>@pytest.mark.sanity</code> decorator from tests.<br> <li> Corrected the dictionary structure for <code>init_args_for_pool_manager</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2045/files#diff-7ac14943f11a2dae3096a5972797d87fcdcc47674527661731811129772250d5">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information