### PR TITLE
[py]: add firefox context example for python

### DIFF
--- a/examples/python/tests/browsers/test_firefox.py
+++ b/examples/python/tests/browsers/test_firefox.py
@@ -141,3 +141,13 @@ def test_full_page_screenshot(firefox_driver):
     assert os.path.exists("full_page_screenshot.png")
 
     driver.quit()
+
+
+def test_set_context(firefox_driver):
+    driver = firefox_driver
+
+    with driver.context(driver.CONTEXT_CHROME):
+        driver.execute_script("console.log('Inside Chrome context');")
+
+    # Check if the context is back to content
+    assert driver.execute("GET_CONTEXT")["value"] == "content"

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
@@ -443,9 +443,9 @@ please refer to the
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L149-L150" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
@@ -439,9 +439,9 @@ IDはアドオンインストール時の戻り値から取得できます。
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L149-L150" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
@@ -448,9 +448,9 @@ please refer to the
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L149-L150" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
@@ -445,9 +445,9 @@ please refer to the
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L149-L150" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Firefox context example for python

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Tests, Documentation


___

### **Description**
- Added a new test `test_set_context` in the Python test suite for Firefox, which demonstrates context switching to Chrome and back to content.
- Updated documentation across multiple languages (English, Japanese, Portuguese, Chinese) to include a reference to the new Python code example.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_firefox.py</strong><dd><code>Add Firefox context switching test in Python</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/browsers/test_firefox.py

<li>Added a new test <code>test_set_context</code> for Firefox.<br> <li> Utilizes the <code>context</code> method to switch to Chrome context.<br> <li> Verifies the context switch back to content.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2050/files#diff-0c150a20628e9efa5a2d236dd4cd1c861ecbfc8f25f32a2add0958f9155cccf0">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firefox.en.md</strong><dd><code>Update Python code block reference in English docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/firefox.en.md

- Updated Python tab to include a code block reference.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2050/files#diff-b15295d3d29dd29126510a0f6512397f6bb5ec98c5eb17c33798ef7b532aa4cf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox.ja.md</strong><dd><code>Update Python code block reference in Japanese docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md

- Updated Python tab to include a code block reference.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2050/files#diff-02b45056986e5b04a1d62e9a4d294f0209c87f8937167aa405dcb7eea33f7617">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox.pt-br.md</strong><dd><code>Update Python code block reference in Portuguese docs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md

- Updated Python tab to include a code block reference.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2050/files#diff-a7846d2db0bfab86e7a78f751e043ce8fc58a4abe79a9798efedce6def25ea3b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox.zh-cn.md</strong><dd><code>Update Python code block reference in Chinese docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md

- Updated Python tab to include a code block reference.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2050/files#diff-44bf88c57d3d9f7aa384e74e0f3b5ea1479e7d42eba14f7ba16f3bffb70b27d7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information