### PR TITLE
[ci] Get latest Nightly from TestPyPi sort by upload_time

### DIFF
--- a/scripts/latest-python-nightly-version.py
+++ b/scripts/latest-python-nightly-version.py
@@ -1,12 +1,12 @@
 import requests
 import json
-import re
 
 response = requests.get("https://test.pypi.org/pypi/selenium/json")
 data = response.json()
 
-versions = data['releases'].keys()
-sorted_versions = sorted(versions, key=lambda s: [int(part) if part.isdigit() else part for part in re.split(r'(\d+)', s)])
-latest_version = sorted_versions[-1]
+# Extract versions and their upload times
+versions = data['releases']
+sorted_versions = sorted(versions.items(), key=lambda item: item[1][0]['upload_time'], reverse=True)
+latest_version = sorted_versions[0][0]
 
 print(latest_version)


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
In case latest release is not on the first index of release history
![image](https://github.com/user-attachments/assets/229db34a-2306-4b8a-b9c9-4daab583081c)

Get latest Nightly from TestPyPi via JSON attr upload_time instead of release name

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced the script to fetch the latest nightly version from TestPyPi by sorting based on the `upload_time` attribute instead of the version name.
- Removed the use of regex for sorting version names, simplifying the logic.
- Improved accuracy in determining the latest version by directly using the upload time.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>latest-python-nightly-version.py</strong><dd><code>Sort and retrieve latest version by upload time</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/latest-python-nightly-version.py

<li>Removed sorting by version name using regex.<br> <li> Added sorting by upload time using JSON attribute.<br> <li> Extracted versions and their upload times from JSON data.<br> <li> Updated logic to determine the latest version.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2064/files#diff-b44da1dbeed561609b77e152988a12029e34390ca03e4b0ee4b07184ef106704">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information