### PR TITLE
[ci] Add range of python version 3.8 to 3.13 for example tests

### DIFF
--- a/.github/workflows/python-examples.yml
+++ b/.github/workflows/python-examples.yml
@@ -25,8 +25,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, windows, macos ]
-        release: [ stable, nightly ]
+        include:
+        - os: ubuntu
+          release: stable
+          python: '3.8'
+        - os: ubuntu
+          release: nightly
+          python: '3.11'
+        - os: windows
+          release: stable
+          python: '3.9'
+        - os: windows
+          release: nightly
+          python: '3.12'
+        - os: macos
+          release: stable
+          python: '3.10'
+        - os: macos
+          release: nightly
+          python: '3.13'
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
     - name: Checkout GitHub repo
@@ -47,7 +64,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python }}
     - name: Install dependencies nightly non-Windows
       if: matrix.release == 'nightly' && matrix.os != 'windows'
       run: |
@@ -80,8 +97,8 @@ jobs:
     - name: Run tests
       uses: nick-invision/retry@v3.0.0
       with:
-        timeout_minutes: 40
+        timeout_minutes: 60
         max_attempts: 3
         command: |
           cd examples/python
-          pytest
+          pytest --reruns 3

--- a/examples/python/requirements.txt
+++ b/examples/python/requirements.txt
@@ -2,5 +2,6 @@ selenium==4.26.1
 pytest
 trio
 pytest-trio
+pytest-rerunfailures
 flake8
 requests


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Range of support python versions will be tested in example tests
- Stable version of [windows, macos, ubuntu] will be run with python 3.8, 3.9, 3.10
- Nightly version of [windows, macos, ubuntu] will be run with python 3.11, 3.12, 3.13

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the CI workflow to test a range of Python versions (3.8 to 3.13) across different operating systems and release types.
- Increased the test timeout duration from 40 to 60 minutes to accommodate longer test runs.
- Modified the test command to include pytest reruns for improved test reliability.
- Added `pytest-rerunfailures` to the Python requirements to support test reruns.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python-examples.yml</strong><dd><code>Update CI workflow to test multiple Python versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python-examples.yml

<li>Expanded the matrix strategy to include specific Python versions for <br>different OS and release types.<br> <li> Updated the Python setup to use the matrix-defined Python version.<br> <li> Increased the test timeout from 40 to 60 minutes.<br> <li> Added pytest reruns to the test command.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2065/files#diff-07dbf750b5157264e70b95d1bef08a2a4d039fb2674a772d798e374273694337">+22/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Add pytest-rerunfailures to Python requirements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/requirements.txt

- Added `pytest-rerunfailures` to the requirements.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2065/files#diff-c233c301c314607d2dfcee9a9ec0d5a7b78a67d2c8927808fd4c9d382bbb4a8e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information