### PR TITLE
[java]: docs for set context in firefox

### DIFF
--- a/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java
@@ -15,12 +15,12 @@ import org.junit.jupiter.api.condition.OS;
 import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxDriverLogLevel;
-import org.openqa.selenium.firefox.FirefoxDriverService;
-import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.firefox.GeckoDriverService;
+import org.openqa.selenium.firefox.*;
 import org.openqa.selenium.remote.service.DriverFinder;
+
+
+
+
 
 public class FirefoxTest extends BaseTest {
   private FirefoxDriver driver;
@@ -186,6 +186,22 @@ public class FirefoxTest extends BaseTest {
     // Verify the screenshot file exists
     Assertions.assertTrue(targetFile.exists(), "The full page screenshot file should exist");
     Files.deleteIfExists(targetFile.toPath());
+
+    driver.quit();
+  }
+
+  @Test
+  public void setContext() {
+    driver = startFirefoxDriver();
+
+    ((HasContext) driver).setContext(FirefoxCommandContext.CHROME);
+    driver.executeScript("console.log('Inside Chrome context');");
+
+    // Verify the context is back to "content"
+    Assertions.assertEquals(
+            FirefoxCommandContext.CHROME, ((HasContext) driver).getContext(),
+            "The context should be 'chrome'"
+    );
 
     driver.quit();
   }

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.en.md
@@ -441,7 +441,7 @@ please refer to the
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L197-L198" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L149-L150" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md
@@ -437,7 +437,7 @@ IDはアドオンインストール時の戻り値から取得できます。
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L197-L198" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L149-L150" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md
@@ -446,7 +446,7 @@ please refer to the
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L197-L198" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L149-L150" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md
@@ -443,7 +443,7 @@ please refer to the
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java#L197-L198" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< gh-codeblock path="/examples/python/tests/browsers/test_firefox.py#L149-L150" >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Java docs for set context in firefox

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
documentation, tests


___

### **Description**
- Added a new test method `setContext` in `FirefoxTest.java` to test Firefox context switching using the `HasContext` interface.
- Updated documentation for Firefox browser in multiple languages (English, Japanese, Portuguese, Chinese) to improve Java code example formatting by using `gh-codeblock`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirefoxTest.java</strong><dd><code>Add test for Firefox context switching in Java</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/java/src/test/java/dev/selenium/browsers/FirefoxTest.java

<li>Added a new test method <code>setContext</code> to test Firefox context switching.<br> <li> Used <code>HasContext</code> interface to set and verify the context.<br> <li> Ensured the context is set to 'chrome' and verified.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2068/files#diff-2328b7cf7dd1e3cad6d9a9ccc8def15869503f3b9ba3c4af41be8638b71a4833">+21/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firefox.en.md</strong><dd><code>Update Java code example formatting in English docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/firefox.en.md

<li>Updated Java code example to use <code>gh-codeblock</code> for better clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2068/files#diff-b15295d3d29dd29126510a0f6512397f6bb5ec98c5eb17c33798ef7b532aa4cf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox.ja.md</strong><dd><code>Update Java code example formatting in Japanese docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/firefox.ja.md

<li>Updated Java code example to use <code>gh-codeblock</code> for better clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2068/files#diff-02b45056986e5b04a1d62e9a4d294f0209c87f8937167aa405dcb7eea33f7617">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox.pt-br.md</strong><dd><code>Update Java code example formatting in Portuguese docs</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/firefox.pt-br.md

<li>Updated Java code example to use <code>gh-codeblock</code> for better clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2068/files#diff-a7846d2db0bfab86e7a78f751e043ce8fc58a4abe79a9798efedce6def25ea3b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox.zh-cn.md</strong><dd><code>Update Java code example formatting in Chinese docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/firefox.zh-cn.md

<li>Updated Java code example to use <code>gh-codeblock</code> for better clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2068/files#diff-44bf88c57d3d9f7aa384e74e0f3b5ea1479e7d42eba14f7ba16f3bffb70b27d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information