### PR TITLE
[py]: add example and docs for casting in edge and chrome

### DIFF
--- a/examples/python/tests/browsers/test_chrome.py
+++ b/examples/python/tests/browsers/test_chrome.py
@@ -1,7 +1,7 @@
 import os
 import re
 import subprocess
-
+import pytest
 from selenium import webdriver
 
 
@@ -161,3 +161,18 @@ def get_permission_state(driver, name):
     });
     """
     return driver.execute_async_script(script, name)
+
+
+def test_cast_features():
+    driver = webdriver.Chrome()
+
+    try:
+        sinks = driver.get_sinks()
+        if sinks:
+            sink_name = sinks[0]['name']
+            driver.start_tab_mirroring(sink_name)
+            driver.stop_casting(sink_name)
+        else:
+            pytest.skip("No available Cast sinks to test with.")
+    finally:
+        driver.quit()

--- a/examples/python/tests/browsers/test_edge.py
+++ b/examples/python/tests/browsers/test_edge.py
@@ -1,7 +1,7 @@
 import os
 import re
 import subprocess
-
+import pytest
 from selenium import webdriver
 
 
@@ -161,3 +161,18 @@ def get_permission_state(driver, name):
     });
     """
     return driver.execute_async_script(script, name)
+
+
+def test_cast_features():
+    driver = webdriver.Edge()
+
+    try:
+        sinks = driver.get_sinks()
+        if sinks:
+            sink_name = sinks[0]['name']
+            driver.start_tab_mirroring(sink_name)
+            driver.stop_casting(sink_name)
+        else:
+            pytest.skip("No available Cast sinks to test with.")
+    finally:
+        driver.quit()

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.en.md
@@ -372,9 +372,9 @@ You can drive Chrome Cast devices, including sharing tabs
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L170-L174" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md
@@ -365,9 +365,9 @@ Chrome Castデバイスを操作することができ、タブの共有も含ま
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L170-L174" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md
@@ -372,9 +372,9 @@ Pode comandar dispositivos Chrome Cast, incluindo partilhar abas
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L170-L174" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md
@@ -373,10 +373,9 @@ Chromedriver 和 Chrome 浏览器版本应该匹配, 如果它们不匹配, 驱�
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
-{{< tab header="CSharp" >}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_chrome.py#L170-L174" >}}
+{{< /tab >}}{{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.en.md
@@ -374,9 +374,9 @@ You can drive Chrome Cast devices with Edge, including sharing tabs
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L170-L174" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.ja.md
@@ -360,9 +360,9 @@ Edge を使用して Chrome Cast デバイスを操作し、タブを共有す�
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L170-L174" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md
@@ -376,9 +376,9 @@ You can drive Chrome Cast devices with Edge, including sharing tabs
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L170-L174" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md
@@ -376,9 +376,9 @@ You can drive Chrome Cast devices with Edge, including sharing tabs
 {{< tab header="Java" >}}
 {{< badge-code >}}
 {{< /tab >}}
-{{% tab header="Python" %}}
-{{< badge-code >}}
-{{% /tab %}}
+{{< tab header="Python" >}}
+{{< gh-codeblock path="/examples/python/tests/browsers/test_edge.py#L170-L174" >}}
+{{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
 {{< /tab >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Added example for casting in edge and chrome

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Tests, Documentation


___

### **Description**
- Added new tests for casting features in both Chrome and Edge browsers using Selenium WebDriver.
- Updated documentation to include Python code examples for casting in multiple languages (English, Japanese, Portuguese, Chinese).
- Utilized `pytest` to handle scenarios where no Cast sinks are available.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_chrome.py</strong><dd><code>Add casting feature test for Chrome browser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/browsers/test_chrome.py

<li>Added a new test <code>test_cast_features</code> for Chrome.<br> <li> Utilized <code>webdriver.Chrome()</code> to test casting features.<br> <li> Implemented logic to handle no available Cast sinks.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-47561b87e40e35009b0ce3e88512579da1f96ffb911e86fd8dc9dee6708e7ba0">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_edge.py</strong><dd><code>Add casting feature test for Edge browser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/browsers/test_edge.py

<li>Added a new test <code>test_cast_features</code> for Edge.<br> <li> Utilized <code>webdriver.Edge()</code> to test casting features.<br> <li> Implemented logic to handle no available Cast sinks.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-503affe7beda841e0a1233e41de7b930960f073ce60ef7843e1044adc4968eac">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome.en.md</strong><dd><code>Update Chrome documentation with Python casting example</code>&nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/chrome.en.md

- Updated Python tab with a code example for casting.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-eccc7d2ca21e26be42c8c903fa062012754d5ea90f001a432f4f9961e87b078c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome.ja.md</strong><dd><code>Update Chrome documentation with Python casting example in Japanese</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/chrome.ja.md

- Updated Python tab with a code example for casting.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-85cef9cb445defdf9de42ecc0dbd533e2ef2b0b47bcd8fb2aecc09f2114b3238">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome.pt-br.md</strong><dd><code>Update Chrome documentation with Python casting example in Portuguese</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/chrome.pt-br.md

- Updated Python tab with a code example for casting.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-4d648f7aea25c7e23a591cdb153ae6a6857d909ab673354eafdf3c5a3b4c4aa7">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome.zh-cn.md</strong><dd><code>Update Chrome documentation with Python casting example in Chinese</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/chrome.zh-cn.md

- Updated Python tab with a code example for casting.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-1aff253f48970f96fb108fece2476c5e0d815aec68c4275a2746b2bad32a377f">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge.en.md</strong><dd><code>Update Edge documentation with Python casting example</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/edge.en.md

- Updated Python tab with a code example for casting.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-eba585ea4c9d1d71d09ee69558012785b4310856fd2b562e49433c4157766b36">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge.ja.md</strong><dd><code>Update Edge documentation with Python casting example in Japanese</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/edge.ja.md

- Updated Python tab with a code example for casting.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-3e852f27c226e1c9c7225112069d43d93dea6a09b6257647d8aaea9cd20e984b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge.pt-br.md</strong><dd><code>Update Edge documentation with Python casting example in Portuguese</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/edge.pt-br.md

- Updated Python tab with a code example for casting.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-6ff8b3969797826d7ffa95108a6aa14cd83e2bfe5839f931ab1136bbea61409c">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge.zh-cn.md</strong><dd><code>Update Edge documentation with Python casting example in Chinese</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/edge.zh-cn.md

- Updated Python tab with a code example for casting.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2072/files#diff-7909b00888234283f45940e23c22d33a7ce74bef4b4ae8385b034429c9a4aec8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information