### PR TITLE
Add Firefox BiDi test example to demonstrate session establishment using webSocketUrl capability

### DIFF
--- a/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/FirefoxBiDiTest.java
+++ b/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/FirefoxBiDiTest.java
@@ -1,0 +1,29 @@
+package dev.selenium.bidirectional.webdriver_bidi;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.bidi.BiDi;
+import org.openqa.selenium.bidi.HasBiDi;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+
+public class FirefoxBiDiTest {
+    @Test
+    public void testFirefoxBiDi() {
+        // Configure Firefox options with webSocketUrl capability
+        FirefoxOptions options = new FirefoxOptions();
+        options.setCapability("moz:debuggerAddress", true); // Enables WebSocket-based debugging
+        options.setCapability("webSocketUrl", true); // Explicitly request WebSocket URL
+
+        WebDriver driver = new FirefoxDriver(options);
+
+        try {
+            // Establish a BiDi session
+            BiDi biDi = ((HasBiDi) driver).getBiDi();
+            System.out.println("BiDi session established for Firefox.");
+        } finally {
+            // Quit the driver
+            driver.quit();
+        }
+    }
+}


### PR DESCRIPTION
### **User description**
This pull request adds a new test example, FirefoxBiDiTest.java, to the Java examples repository. The example demonstrates how to establish a BiDi (Bidirectional) session using the FirefoxDriver. It explicitly highlights the use of the webSocketUrl capability, which is necessary for enabling BiDi connections in Firefox.

### **Key Details about the Test**
**Browser Compatibility:**
The example is designed for Firefox with GeckoDriver (tested with Firefox 113+ and GeckoDriver 0.33+).
**Selenium Version:**
The example works with Selenium 4.27.0.
**Local Testing:**
The example has been successfully tested locally using Maven.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduces a new example test demonstrating Firefox BiDi (Bidirectional) session establishment
- Shows proper configuration of Firefox-specific capabilities:
  - `webSocketUrl` for WebSocket URL request
  - `moz:debuggerAddress` for WebSocket-based debugging
- Implements proper WebDriver session management with cleanup
- Serves as a reference implementation for Firefox BiDi testing setup



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FirefoxBiDiTest.java</strong><dd><code>Firefox BiDi Session Setup Test Implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/FirefoxBiDiTest.java

<li>Adds new test class demonstrating Firefox BiDi session establishment<br> <li> Configures Firefox options with <code>webSocketUrl</code> and <code>moz:debuggerAddress</code> <br>capabilities<br> <li> Creates and manages WebDriver session with BiDi support<br> <li> Includes proper driver cleanup in finally block<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2113/files#diff-922bf87e589e7202f27430aa81230d4b9c6901e50a81d86942b0301f5363966a">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information