### PR TITLE
Fix PrintOptions size example to replace setScale with setPageSize for A4 dimensions

### DIFF
--- a/examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java
+++ b/examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java
@@ -3,7 +3,7 @@ package dev.selenium.interactions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.print.PageMargin;
 import org.openqa.selenium.print.PrintOptions;
-
+import org.openqa.selenium.print.PageSize;
 import dev.selenium.BaseChromeTest;
 
 public class PrintOptionsTest extends BaseChromeTest {
@@ -31,8 +31,8 @@ public class PrintOptionsTest extends BaseChromeTest {
     {
         driver.get("https://www.selenium.dev/");
         PrintOptions printOptions = new PrintOptions();
-        printOptions.setScale(.50);
-        double current_scale = printOptions.getScale();
+        printOptions.setPageSize(new PageSize(27.94, 21.59)); // A4 size in cm
+        double currentHeight = printOptions.getPageSize().getHeight(); // use getWidth() to retrieve width
     }
 
     @Test


### PR DESCRIPTION
### **User description**
### Description

This pull request updates the PrintOptions size example in the [Selenium documentation](https://www.selenium.dev/documentation/webdriver/interactions/print_page/) to use the correct API method. The previous example incorrectly demonstrated `setScale`, which is unrelated to setting the page size. The updated example now uses the `setPageSize` method with the `PageSize` class, leveraging its constructor to set dimensions for A4 size (27.94 x 21.59 cm).

This example also demonstrates how to retrieve the page height using `getPageSize().getHeight()`, and a comment has been added to guide users on retrieving the width with `getWidth()` if needed.

### Motivation and Context
This change addresses the issue raised in [#2095](https://github.com/SeleniumHQ/seleniumhq.github.io/issues/2095), where the documentation incorrectly demonstrated the `setScale` method instead of showcasing the correct `setPageSize` functionality for the size example.

The updated example:

Fixes the incorrect API usage (`setScale`) in the documentation.
Aligns with the current Selenium 4.27.0 API, providing users with an accurate and functional reference.
Demonstrates the ability to set and retrieve dimensions for A4 size using the existing `PageSize` class.

### Note:
I have tested the example code locally, and it runs successfully. This commit addresses the fix for the Java example only. I will update the examples for other languages in the same PR once this review is complete.

___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Replace incorrect setScale with proper setPageSize method

- Implement A4 page dimensions using PageSize class

- Add documentation for width/height retrieval methods


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PrintOptionsTest.java</strong><dd><code>Fix PrintOptions size example with correct PageSize implementation</code></dd></summary>
<hr>

examples/java/src/test/java/dev/selenium/interactions/PrintOptionsTest.java

<li>Replaced incorrect <code>setScale</code> method with <code>setPageSize</code> for A4 dimensions<br> <li> Added PageSize constructor with A4 dimensions (27.94 x 21.59 cm)<br> <li> Updated variable to get page height instead of scale<br> <li> Added comment about retrieving width using <code>getWidth()</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2118/files#diff-76575056861bc43694114ff9fc4eeb31ea2343cbd2aee22db99e842de7d7e14f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information