### PR TITLE
Add documentation for SessionNotCreatedException in troubleshooting errors

### DIFF
--- a/website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.en.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.en.md
@@ -145,3 +145,21 @@ like when the last tab/browser has closed (e.g. `driver.close()`)
 
 Check your script for instances of `driver.close()` and `driver.quit()`, and any other possible causes 
 of closed tabs/browsers. It could be that you are locating an element before you should/can.
+
+## SessionNotCreatedException
+
+This exception occurs when the WebDriver is unable to create a new session for the browser. This often happens due to version mismatches, system-level restrictions, or configuration issues.
+
+### Likely Cause
+
+- The browser version and WebDriver version are incompatible (e.g., ChromeDriver v113 with Chrome v115).
+- macOS privacy settings may block the WebDriver from running.
+- The WebDriver binary is missing, inaccessible, or lacks the necessary execution permissions (e.g., on Linux/macOS, the driver file may not be executable).
+
+
+### Possible Solutions
+
+- Ensure the WebDriver version matches the browser version. For Chrome, check the browser version at `chrome://settings/help` and download the matching driver from [ChromeDriver Downloads](https://chromedriver.chromium.org/downloads).
+- On macOS, go to **System Settings > Privacy & Security**, and allow the driver to run if blocked.
+- Verify the driver binary is executable (`chmod +x /path/to/driver` on Linux/macOS).
+

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.ja.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.ja.md
@@ -141,3 +141,20 @@ like when the last tab/browser has closed (e.g. `driver.close()`)
 
 Check your script for instances of `driver.close()` and `driver.quit()`, and any other possible causes of closed 
 tabs/browsers. It could be that you are locating an element before you should/can.
+
+## SessionNotCreatedException
+
+This exception occurs when the WebDriver is unable to create a new session for the browser. This often happens due to version mismatches, system-level restrictions, or configuration issues.
+
+### Likely Cause
+
+- The browser version and WebDriver version are incompatible (e.g., ChromeDriver v113 with Chrome v115).
+- macOS privacy settings may block the WebDriver from running.
+- The WebDriver binary is missing, inaccessible, or lacks the necessary execution permissions (e.g., on Linux/macOS, the driver file may not be executable).
+
+
+### Possible Solutions
+
+- Ensure the WebDriver version matches the browser version. For Chrome, check the browser version at `chrome://settings/help` and download the matching driver from [ChromeDriver Downloads](https://chromedriver.chromium.org/downloads).
+- On macOS, go to **System Settings > Privacy & Security**, and allow the driver to run if blocked.
+- Verify the driver binary is executable (`chmod +x /path/to/driver` on Linux/macOS).

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.pt-br.md
@@ -141,3 +141,21 @@ This usually occurs when the session has been deleted (e.g. `driver.quit()`) or 
 ### Possible Solutions
 
 Check your script for instances of `driver.close()` and `driver.quit()`, and any other possible causes of closed tabs/browsers. It could be that you are locating an element before you should/can.
+
+## SessionNotCreatedException
+
+This exception occurs when the WebDriver is unable to create a new session for the browser. This often happens due to version mismatches, system-level restrictions, or configuration issues.
+
+### Likely Cause
+
+- The browser version and WebDriver version are incompatible (e.g., ChromeDriver v113 with Chrome v115).
+- macOS privacy settings may block the WebDriver from running.
+- The WebDriver binary is missing, inaccessible, or lacks the necessary execution permissions (e.g., on Linux/macOS, the driver file may not be executable).
+
+
+### Possible Solutions
+
+- Ensure the WebDriver version matches the browser version. For Chrome, check the browser version at `chrome://settings/help` and download the matching driver from [ChromeDriver Downloads](https://chromedriver.chromium.org/downloads).
+- On macOS, go to **System Settings > Privacy & Security**, and allow the driver to run if blocked.
+- Verify the driver binary is executable (`chmod +x /path/to/driver` on Linux/macOS).
+

--- a/website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.zh-cn.md
@@ -145,3 +145,19 @@ Actions class with `Actions.moveToElement(element)`.
 
 ### 可能的解决方案
 检查脚本中是否有 `driver.close()` 和 `driver.quit()` 的实例，以及其他可能导致标签页/浏览器关闭的原因。可能是您在应该/能够定位元素之前就尝试定位了该元素。
+
+## SessionNotCreatedException
+
+此异常发生在 WebDriver 无法为浏览器创建新会话时。通常由于版本不匹配、系统级限制或配置问题导致。
+
+### 可能的原因
+
+- 浏览器版本和 WebDriver 版本不兼容（例如 ChromeDriver v113 和 Chrome v115）。
+- macOS 隐私设置可能会阻止 WebDriver 运行。
+- WebDriver 二进制文件丢失、不可访问或没有执行权限。
+
+### 可能的解决方案
+
+- 确保 WebDriver 版本与浏览器版本匹配。对于 Chrome，请在浏览器中访问 `chrome://settings/help` 检查浏览器版本，并从 [ChromeDriver 下载](https://chromedriver.chromium.org/downloads)页面下载匹配的驱动程序。
+- 在 macOS 上，转到 **系统设置 > 隐私与安全性**，并允许驱动程序运行（如果被阻止）。
+- 验证驱动程序二进制文件是否可执行（在 Linux/macOS 上运行 `chmod +x /path/to/driver`）。


### PR DESCRIPTION
### **User description**
**Description**
This PR adds documentation for the `SessionNotCreatedException` under the "Troubleshooting Errors" section of the Selenium site. It includes a concise explanation of the exception, its likely causes, and actionable solutions.

**Motivation and Context**
The `SessionNotCreatedException` is a common error encountered by users, often caused by browser-WebDriver version mismatches, macOS privacy settings, or permission issues on the WebDriver binary. Documenting this will help users quickly understand and resolve the issue, improving their experience with Selenium.

**Types of Changes**
 Documentation improvement (added a new section under "Troubleshooting Errors").

**Checklist**
 I have read the contributing guidelines.
 I have tested the changes locally using [Hugo](https://gohugo.io/).
 I have ensured the documentation renders as expected and the format is consistent with other entries.


___

### **PR Type**
Documentation


___

### **Description**
- Added documentation for `SessionNotCreatedException` under "Troubleshooting Errors".

- Explained common causes of the exception, including version mismatches and system restrictions.

- Provided actionable solutions to resolve the exception, such as matching WebDriver and browser versions.

- Included macOS-specific guidance and Linux/macOS permission fixes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_index.en.md</strong><dd><code>Documented `SessionNotCreatedException` causes and solutions</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/troubleshooting/errors/_index.en.md

<li>Added a new section for <code>SessionNotCreatedException</code>.<br> <li> Described likely causes of the exception.<br> <li> Provided detailed solutions for resolving the issue.<br> <li> Included platform-specific troubleshooting steps.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2119/files#diff-d8713bd094ba75ca3ce0659e13a3158956619dcbb35d5ede1743e90dbee52f9a">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information