### PR TITLE
[py] use `enable_logging` for Safari logging

### DIFF
--- a/examples/python/tests/browsers/test_safari.py
+++ b/examples/python/tests/browsers/test_safari.py
@@ -14,7 +14,7 @@ def test_basic_options():
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="requires Mac")
 def test_enable_logging():
-    service = webdriver.SafariService(service_args=["--diagnose"])
+    service = webdriver.SafariService(enable_logging=True)
 
     driver = webdriver.Safari(service=service)
 

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.en.md
@@ -69,6 +69,7 @@ Property key: `SafariDriverService.SAFARI_DRIVER_LOGGING`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
+{{< badge-version version="4.26" >}}
 {{< gh-codeblock path="examples/python/tests/browsers/test_safari.py#L17" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.ja.md
@@ -68,6 +68,7 @@ Property key: `SafariDriverService.SAFARI_DRIVER_LOGGING`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
+{{< badge-version version="4.26" >}}
 {{< gh-codeblock path="examples/python/tests/browsers/test_safari.py#L17" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md
@@ -68,6 +68,7 @@ Property key: `SafariDriverService.SAFARI_DRIVER_LOGGING`\
 Property value: `"true"` or `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
+{{< badge-version version="4.26" >}}
 {{< gh-codeblock path="examples/python/tests/browsers/test_safari.py#L17" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md
@@ -71,6 +71,7 @@ Safari 浏览器不允许您选择日志的输出位置或更改级别.
 属性值: `"true"` 或 `"false"`
 {{% /tab %}}
 {{< tab header="Python" >}}
+{{< badge-version version="4.26" >}}
 {{< gh-codeblock path="examples/python/tests/browsers/test_safari.py#L17" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Uses `enable_logging` for Safari service as a parameter with the latest version 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Documentation, Tests


___

### **Description**
- Updated Safari WebDriver to use `enable_logging` parameter.

- Added Python test for `enable_logging` in Safari service.

- Updated documentation for Safari WebDriver across multiple languages.

- Added version badge for `enable_logging` feature in documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_safari.py</strong><dd><code>Add test for Safari `enable_logging` parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/browsers/test_safari.py

<li>Replaced <code>service_args</code> with <code>enable_logging</code> in Safari service.<br> <li> Added a test case for <code>enable_logging</code> parameter.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2123/files#diff-f983ddc390b967d5b05a4318f70f27802784099e585ebee5702a7f482964e67d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>safari.en.md</strong><dd><code>Update English documentation for Safari `enable_logging`</code>&nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/safari.en.md

<li>Added version badge for <code>enable_logging</code> feature.<br> <li> Linked Python example for <code>enable_logging</code> usage.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2123/files#diff-634ecb7644504a2d7735debd2017c7d9091a4d042dd336cea63c521ffb9d9737">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>safari.ja.md</strong><dd><code>Update Japanese documentation for Safari `enable_logging`</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/safari.ja.md

<li>Added version badge for <code>enable_logging</code> feature.<br> <li> Linked Python example for <code>enable_logging</code> usage.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2123/files#diff-3843e74951875d9f02381b4a032de51b438b32a454e95d14a195a2f161646aee">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>safari.pt-br.md</strong><dd><code>Update Portuguese documentation for Safari `enable_logging`</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/safari.pt-br.md

<li>Added version badge for <code>enable_logging</code> feature.<br> <li> Linked Python example for <code>enable_logging</code> usage.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2123/files#diff-5bef1737606138f9714d746b1385f5a2b3de0002ed856fabf3e3e4c57ffe8bc7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>safari.zh-cn.md</strong><dd><code>Update Chinese documentation for Safari `enable_logging`</code>&nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/browsers/safari.zh-cn.md

<li>Added version badge for <code>enable_logging</code> feature.<br> <li> Linked Python example for <code>enable_logging</code> usage.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2123/files#diff-a7937d029700732a1a80db8aaab9b545b2a5e14015ff3875aedc43f4a239aca8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information