### PR TITLE
Update examples test Chrome/Edge run on Ubuntu 24.04 hosted runners

### DIFF
--- a/examples/java/src/test/java/dev/selenium/BaseTest.java
+++ b/examples/java/src/test/java/dev/selenium/BaseTest.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.grid.Main;
@@ -55,6 +56,18 @@ public class BaseTest {
   protected ChromeDriver startChromeDriver(ChromeOptions options) {
     driver = new ChromeDriver(options);
     return (ChromeDriver) driver;
+  }
+
+  protected static ChromeOptions getDefaultChromeOptions() {
+    ChromeOptions options = new ChromeOptions();
+    options.addArguments("--no-sandbox");
+    return options;
+  }
+
+  protected static EdgeOptions getDefaultEdgeOptions() {
+    EdgeOptions options = new EdgeOptions();
+    options.addArguments("--no-sandbox");
+    return options;
   }
 
   protected File getTempDirectory(String prefix) {

--- a/examples/java/src/test/java/dev/selenium/bidi/cdp/CdpApiTest.java
+++ b/examples/java/src/test/java/dev/selenium/bidi/cdp/CdpApiTest.java
@@ -26,7 +26,7 @@ public class CdpApiTest extends BaseTest {
 
   @BeforeEach
   public void createSession() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     options.setBrowserVersion("131");
     driver = new ChromeDriver(options);
     wait = new WebDriverWait(driver, Duration.ofSeconds(10));

--- a/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
@@ -34,13 +34,13 @@ public class ChromeTest extends BaseTest {
 
   @Test
   public void basicOptions() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     driver = new ChromeDriver(options);
   }
 
   @Test
   public void arguments() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
 
     options.addArguments("--start-maximized");
 
@@ -49,7 +49,7 @@ public class ChromeTest extends BaseTest {
 
   @Test
   public void setBrowserLocation() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
 
     options.setBinary(getChromeLocation());
 
@@ -58,7 +58,7 @@ public class ChromeTest extends BaseTest {
 
   @Test
   public void extensionOptions() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     Path path = Paths.get("src/test/resources/extensions/webextensions-selenium-example.crx");
     File extensionFilePath = new File(path.toUri());
 
@@ -73,7 +73,7 @@ public class ChromeTest extends BaseTest {
 
   @Test
   public void excludeSwitches() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
 
     options.setExperimentalOption("excludeSwitches", List.of("disable-popup-blocking"));
 
@@ -82,7 +82,7 @@ public class ChromeTest extends BaseTest {
 
   @Test
   public void loggingPreferences() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     LoggingPreferences logPrefs = new LoggingPreferences();
     logPrefs.enable(LogType.PERFORMANCE, Level.ALL);
     options.setCapability(ChromeOptions.LOGGING_PREFS, logPrefs);
@@ -175,7 +175,7 @@ public class ChromeTest extends BaseTest {
   }
 
   private File getChromeLocation() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     options.setBrowserVersion("stable");
     DriverFinder finder = new DriverFinder(ChromeDriverService.createDefaultService(), options);
     return new File(finder.getBrowserPath());

--- a/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java
@@ -35,13 +35,13 @@ public class EdgeTest extends BaseTest {
 
   @Test
   public void basicOptions() {
-    EdgeOptions options = new EdgeOptions();
+    EdgeOptions options = getDefaultEdgeOptions();
     driver = new EdgeDriver(options);
   }
 
   @Test
   public void arguments() {
-    EdgeOptions options = new EdgeOptions();
+    EdgeOptions options = getDefaultEdgeOptions();
 
     options.addArguments("--start-maximized");
 
@@ -50,7 +50,7 @@ public class EdgeTest extends BaseTest {
 
   @Test
   public void setBrowserLocation() {
-    EdgeOptions options = new EdgeOptions();
+    EdgeOptions options = getDefaultEdgeOptions();
 
     options.setBinary(getEdgeLocation());
 
@@ -59,7 +59,7 @@ public class EdgeTest extends BaseTest {
 
   @Test
   public void extensionOptions() {
-    EdgeOptions options = new EdgeOptions();
+    EdgeOptions options = getDefaultEdgeOptions();
     Path path = Paths.get("src/test/resources/extensions/webextensions-selenium-example.crx");
     File extensionFilePath = new File(path.toUri());
 
@@ -74,7 +74,7 @@ public class EdgeTest extends BaseTest {
 
   @Test
   public void excludeSwitches() {
-    EdgeOptions options = new EdgeOptions();
+    EdgeOptions options = getDefaultEdgeOptions();
 
     options.setExperimentalOption("excludeSwitches", List.of("disable-popup-blocking"));
 
@@ -83,7 +83,7 @@ public class EdgeTest extends BaseTest {
 
   @Test
   public void loggingPreferences() {
-    EdgeOptions options = new EdgeOptions();
+    EdgeOptions options = getDefaultEdgeOptions();
     LoggingPreferences logPrefs = new LoggingPreferences();
     logPrefs.enable(LogType.PERFORMANCE, Level.ALL);
     options.setCapability(EdgeOptions.LOGGING_PREFS, logPrefs);
@@ -170,7 +170,7 @@ public class EdgeTest extends BaseTest {
   }
 
   private File getEdgeLocation() {
-    EdgeOptions options = new EdgeOptions();
+    EdgeOptions options = getDefaultEdgeOptions();
     options.setBrowserVersion("stable");
     DriverFinder finder = new DriverFinder(EdgeDriverService.createDefaultService(), options);
     return new File(finder.getBrowserPath());

--- a/examples/java/src/test/java/dev/selenium/drivers/HttpClientTest.java
+++ b/examples/java/src/test/java/dev/selenium/drivers/HttpClientTest.java
@@ -41,7 +41,7 @@ public class HttpClientTest extends BaseTest {
                 .readTimeout(Duration.ofSeconds(3600))
                 .authenticateAs(new UsernameAndPassword("admin", "myStrongPassword"))
                 .version(HTTP_1_1.toString());
-        ChromeOptions options = new ChromeOptions();
+        ChromeOptions options = getDefaultChromeOptions();
         options.setEnableDownloads(true);
         driver = RemoteWebDriver.builder()
                 .oneOf(options)
@@ -60,7 +60,7 @@ public class HttpClientTest extends BaseTest {
                 .readTimeout(Duration.ofSeconds(3600))
                 .authenticateAs(new UsernameAndPassword("admin", "myStrongPassword"))
                 .version(HTTP_1_1.toString());
-        ChromeOptions options = new ChromeOptions();
+        ChromeOptions options = getDefaultChromeOptions();
         options.setEnableDownloads(true);
         driver = RemoteWebDriver.builder()
                 .oneOf(options)
@@ -78,7 +78,7 @@ public class HttpClientTest extends BaseTest {
                 .connectionTimeout(Duration.ofSeconds(300))
                 .readTimeout(Duration.ofSeconds(3600))
                 .version(HTTP_1_1.toString());
-        ChromeOptions options = new ChromeOptions();
+        ChromeOptions options = getDefaultChromeOptions();
         options.setEnableDownloads(true);
         driver = RemoteWebDriver.builder()
                 .oneOf(options)

--- a/examples/java/src/test/java/dev/selenium/drivers/OptionsTest.java
+++ b/examples/java/src/test/java/dev/selenium/drivers/OptionsTest.java
@@ -18,7 +18,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setPageLoadStrategyNormal() {
-    ChromeOptions chromeOptions = new ChromeOptions();
+    ChromeOptions chromeOptions = getDefaultChromeOptions();
     chromeOptions.setPageLoadStrategy(PageLoadStrategy.NORMAL);
     WebDriver driver = new ChromeDriver(chromeOptions);
     try {
@@ -31,7 +31,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setPageLoadStrategyEager() {
-    ChromeOptions chromeOptions = new ChromeOptions();
+    ChromeOptions chromeOptions = getDefaultChromeOptions();
     chromeOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
     WebDriver driver = new ChromeDriver(chromeOptions);
     try {
@@ -44,7 +44,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setPageLoadStrategyNone() {
-    ChromeOptions chromeOptions = new ChromeOptions();
+    ChromeOptions chromeOptions = getDefaultChromeOptions();
     chromeOptions.setPageLoadStrategy(PageLoadStrategy.NONE);
     WebDriver driver = new ChromeDriver(chromeOptions);
     try {
@@ -57,7 +57,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setAcceptInsecureCerts() {
-    ChromeOptions chromeOptions = new ChromeOptions();
+    ChromeOptions chromeOptions = getDefaultChromeOptions();
     chromeOptions.setAcceptInsecureCerts(true);
     WebDriver driver = new ChromeDriver(chromeOptions);
     try {
@@ -70,14 +70,14 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void getBrowserName() {
-	ChromeOptions chromeOptions = new ChromeOptions();
+	ChromeOptions chromeOptions = getDefaultChromeOptions();
 	String name = chromeOptions.getBrowserName();
 	Assertions.assertFalse(name.isEmpty(), "Browser name should not be empty");
   }
 
   @Test
   public void setBrowserVersion() {
-	ChromeOptions chromeOptions = new ChromeOptions();
+	ChromeOptions chromeOptions = getDefaultChromeOptions();
 	String version = "latest";
 	chromeOptions.setBrowserVersion(version);
 	Assertions.assertEquals(version, chromeOptions.getBrowserVersion());
@@ -85,7 +85,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setPlatformName() {
-	ChromeOptions chromeOptions = new ChromeOptions();
+	ChromeOptions chromeOptions = getDefaultChromeOptions();
 	String platform = "OS X 10.6";
 	chromeOptions.setPlatformName(platform);
 	Assertions.assertEquals(platform, chromeOptions.getPlatformName().toString());
@@ -93,7 +93,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setScriptTimeout() {
-	ChromeOptions chromeOptions = new ChromeOptions();
+	ChromeOptions chromeOptions = getDefaultChromeOptions();
 	Duration duration = Duration.of(5, ChronoUnit.SECONDS);
 	chromeOptions.setScriptTimeout(duration);
 
@@ -108,7 +108,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setPageLoadTimeout() {
-	ChromeOptions chromeOptions = new ChromeOptions();
+	ChromeOptions chromeOptions = getDefaultChromeOptions();
 	Duration duration = Duration.of(5, ChronoUnit.SECONDS);
 	chromeOptions.setPageLoadTimeout(duration);
 
@@ -123,7 +123,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setImplicitWaitTimeout() {
-	ChromeOptions chromeOptions = new ChromeOptions();
+	ChromeOptions chromeOptions = getDefaultChromeOptions();
 	Duration duration = Duration.of(5, ChronoUnit.SECONDS);
 	chromeOptions.setImplicitWaitTimeout(duration);
 
@@ -138,7 +138,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setUnhandledPromptBehaviour() {
-	ChromeOptions chromeOptions = new ChromeOptions();
+	ChromeOptions chromeOptions = getDefaultChromeOptions();
 	chromeOptions.setUnhandledPromptBehaviour(UnexpectedAlertBehaviour.DISMISS_AND_NOTIFY);
 	//verify the capability object is not null
 	Object capabilityObject = chromeOptions.getCapability(CapabilityType.UNHANDLED_PROMPT_BEHAVIOUR);
@@ -148,7 +148,7 @@ public class OptionsTest extends BaseTest {
 
   @Test
   public void setWindowRect() {
-   	ChromeOptions chromeOptions = new ChromeOptions();
+   	ChromeOptions chromeOptions = getDefaultChromeOptions();
    	chromeOptions.setCapability(CapabilityType.SET_WINDOW_RECT, true);
    	//verify the capability object is not null
    	Object capabilityObject = chromeOptions.getCapability(CapabilityType.SET_WINDOW_RECT);
@@ -160,7 +160,7 @@ public class OptionsTest extends BaseTest {
 	
   @Test
   public void setStrictFileInteractability() {
-    ChromeOptions chromeOptions = new ChromeOptions();
+    ChromeOptions chromeOptions = getDefaultChromeOptions();
     chromeOptions.setCapability(CapabilityType.STRICT_FILE_INTERACTABILITY, true);
 	//verify the capability object is not null
     Object capabilityObject = chromeOptions.getCapability(CapabilityType.STRICT_FILE_INTERACTABILITY);

--- a/examples/java/src/test/java/dev/selenium/drivers/RemoteWebDriverTest.java
+++ b/examples/java/src/test/java/dev/selenium/drivers/RemoteWebDriverTest.java
@@ -35,13 +35,13 @@ public class RemoteWebDriverTest extends BaseTest {
 
   @Test
   public void runRemote() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     driver = new RemoteWebDriver(gridUrl, options);
   }
 
   @Test
   public void uploads() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     driver = new RemoteWebDriver(gridUrl, options);
     driver.get("https://the-internet.herokuapp.com/upload");
     File uploadFile = new File("src/test/resources/selenium-snapshot.png");
@@ -57,7 +57,7 @@ public class RemoteWebDriverTest extends BaseTest {
 
   @Test
   public void downloads() throws IOException {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     options.setEnableDownloads(true);
     driver = new RemoteWebDriver(gridUrl, options);
 
@@ -92,7 +92,7 @@ public class RemoteWebDriverTest extends BaseTest {
 
   @Test
   public void augment() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     driver = new RemoteWebDriver(gridUrl, options);
 
     driver = new Augmenter().augment(driver);
@@ -105,7 +105,7 @@ public class RemoteWebDriverTest extends BaseTest {
     driver =
         RemoteWebDriver.builder()
             .address(gridUrl)
-            .oneOf(new ChromeOptions())
+            .oneOf(getDefaultChromeOptions())
             .setCapability("ext:options", Map.of("key", "value"))
             .config(ClientConfig.defaultConfig())
             .build();

--- a/examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java
+++ b/examples/java/src/test/java/dev/selenium/drivers/ServiceTest.java
@@ -19,7 +19,7 @@ public class ServiceTest extends BaseTest {
   @Test
   public void setDriverLocation() {
     setBinaryPaths();
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     options.setBinary(browserPath);
 
     ChromeDriverService service =
@@ -36,7 +36,7 @@ public class ServiceTest extends BaseTest {
   }
 
   private void setBinaryPaths() {
-    ChromeOptions options = new ChromeOptions();
+    ChromeOptions options = getDefaultChromeOptions();
     options.setBrowserVersion("stable");
     DriverFinder finder = new DriverFinder(ChromeDriverService.createDefaultService(), options);
     driverPath = new File(finder.getDriverPath());

--- a/examples/java/src/test/java/dev/selenium/interactions/AlertsTest.java
+++ b/examples/java/src/test/java/dev/selenium/interactions/AlertsTest.java
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import dev.selenium.BaseTest;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -26,12 +27,12 @@ import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AlertsTest {
+public class AlertsTest extends BaseTest {
 
     @Test
     public void testForAlerts() throws Exception {
 
-        ChromeOptions chromeOptions = new ChromeOptions();
+        ChromeOptions chromeOptions = getDefaultChromeOptions();
         chromeOptions.addArguments("disable-search-engine-choice-screen");
         WebDriver driver = new ChromeDriver(chromeOptions);
 

--- a/examples/java/src/test/java/dev/selenium/interactions/PrintsPageTest.java
+++ b/examples/java/src/test/java/dev/selenium/interactions/PrintsPageTest.java
@@ -16,7 +16,7 @@ public class PrintsPageTest extends BaseTest{
 
     @BeforeEach
     public void setup() {
-        ChromeOptions options = new ChromeOptions();
+        ChromeOptions options = getDefaultChromeOptions();
         options.setCapability("webSocketUrl", true);
         driver = new ChromeDriver(options);
     }

--- a/examples/python/tests/browsers/test_chrome.py
+++ b/examples/python/tests/browsers/test_chrome.py
@@ -6,14 +6,14 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 def test_basic_options():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     driver = webdriver.Chrome(options=options)
 
     driver.quit()
 
 
 def test_args():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
 
     options.add_argument("--start-maximized")
 
@@ -24,7 +24,7 @@ def test_args():
 
 
 def test_set_browser_location(chrome_bin):
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
 
     options.binary_location = chrome_bin
 
@@ -34,7 +34,7 @@ def test_set_browser_location(chrome_bin):
 
 
 def test_add_extension():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     extension_file_path = os.path.abspath("tests/extensions/webextensions-selenium-example.crx")
 
     options.add_extension(extension_file_path)
@@ -46,7 +46,7 @@ def test_add_extension():
 
 
 def test_keep_browser_open():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
 
     options.add_experimental_option("detach", True)
 
@@ -57,7 +57,7 @@ def test_keep_browser_open():
 
 
 def test_exclude_switches():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
 
     options.add_experimental_option('excludeSwitches', ['disable-popup-blocking'])
 
@@ -188,3 +188,8 @@ def test_get_browser_logs():
     # Assert that at least one log contains the expected message
     assert any("I am console error" in log['message'] for log in logs), "No matching log message found."
     driver.quit()
+
+def get_default_chrome_options():
+    options = webdriver.ChromeOptions()
+    options.add_argument("--no-sandbox")
+    return options

--- a/examples/python/tests/browsers/test_edge.py
+++ b/examples/python/tests/browsers/test_edge.py
@@ -6,14 +6,14 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 def test_basic_options():
-    options = webdriver.EdgeOptions()
+    options = get_default_edge_options()
     driver = webdriver.Edge(options=options)
 
     driver.quit()
 
 
 def test_args():
-    options = webdriver.EdgeOptions()
+    options = get_default_edge_options()
 
     options.add_argument("--start-maximized")
 
@@ -24,7 +24,7 @@ def test_args():
 
 
 def test_set_browser_location(edge_bin):
-    options = webdriver.EdgeOptions()
+    options = get_default_edge_options()
 
     options.binary_location = edge_bin
 
@@ -34,7 +34,7 @@ def test_set_browser_location(edge_bin):
 
 
 def test_add_extension():
-    options = webdriver.EdgeOptions()
+    options = get_default_edge_options()
     extension_file_path = os.path.abspath("tests/extensions/webextensions-selenium-example.crx")
 
     options.add_extension(extension_file_path)
@@ -46,7 +46,7 @@ def test_add_extension():
 
 
 def test_keep_browser_open():
-    options = webdriver.EdgeOptions()
+    options = get_default_edge_options()
 
     options.add_experimental_option("detach", True)
 
@@ -57,7 +57,7 @@ def test_keep_browser_open():
 
 
 def test_exclude_switches():
-    options = webdriver.EdgeOptions()
+    options = get_default_edge_options()
 
     options.add_experimental_option('excludeSwitches', ['disable-popup-blocking'])
 
@@ -188,3 +188,8 @@ def test_get_browser_logs():
     # Assert that at least one log contains the expected message
     assert any("I am console error" in log['message'] for log in logs), "No matching log message found."
     driver.quit()
+
+def get_default_edge_options():
+    options = webdriver.EdgeOptions()
+    options.add_argument("--no-sandbox")
+    return options

--- a/examples/python/tests/conftest.py
+++ b/examples/python/tests/conftest.py
@@ -20,7 +20,7 @@ def driver(request):
     driver_type = marker.args[0] if marker else None
 
     if driver_type == "bidi":
-        options = webdriver.ChromeOptions()
+        options = get_default_chrome_options()
         options.enable_bidi = True
         driver = webdriver.Chrome(options=options)
     elif driver_type == "firefox":
@@ -36,7 +36,7 @@ def driver(request):
 @pytest.fixture(scope='function')
 def chromedriver_bin():
     service = webdriver.ChromeService()
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.browser_version = 'stable'
     yield webdriver.common.driver_finder.DriverFinder(service=service, options=options).get_driver_path()
 
@@ -44,7 +44,7 @@ def chromedriver_bin():
 @pytest.fixture(scope='function')
 def chrome_bin():
     service = webdriver.ChromeService()
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.browser_version = 'stable'
     yield webdriver.common.driver_finder.DriverFinder(service=service, options=options).get_browser_path()
 
@@ -52,7 +52,7 @@ def chrome_bin():
 @pytest.fixture(scope='function')
 def edge_bin():
     service = webdriver.EdgeService()
-    options = webdriver.EdgeOptions()
+    options = get_default_edge_options()
     options.browser_version = 'stable'
     yield webdriver.common.driver_finder.DriverFinder(service=service, options=options).get_browser_path()
 
@@ -323,3 +323,13 @@ def grid_server():
         process.wait(timeout=10)
     except subprocess.TimeoutExpired:
         process.kill()
+
+def get_default_chrome_options():
+    options = webdriver.ChromeOptions()
+    options.add_argument("--no-sandbox")
+    return options
+
+def get_default_edge_options():
+    options = webdriver.EdgeOptions()
+    options.add_argument("--no-sandbox")
+    return options

--- a/examples/python/tests/drivers/test_http_client.py
+++ b/examples/python/tests/drivers/test_http_client.py
@@ -19,7 +19,7 @@ def test_start_remote_with_client_config(grid_server):
                                      "init_args_for_pool_manager": {"retries": retries, "timeout": timeout}},
                                  ca_certs=_get_resource_path("tls.crt"),
                                  username="admin", password="myStrongPassword")
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     driver = webdriver.Remote(command_executor=grid_server, options=options, client_config=client_config)
     driver.get("https://www.selenium.dev")
     driver.quit()
@@ -33,7 +33,7 @@ def test_start_remote_ignore_certs(grid_server):
                                  timeout=3600,
                                  ignore_certificates=True,
                                  username="admin", password="myStrongPassword")
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     driver = webdriver.Remote(command_executor=grid_server, options=options, client_config=client_config)
     driver.get("https://www.selenium.dev")
     driver.quit()
@@ -45,3 +45,8 @@ def _get_resource_path(file_name: str):
     else:
         path = os.path.abspath(f"tests/resources/{file_name}")
     return path
+
+def get_default_chrome_options():
+    options = webdriver.ChromeOptions()
+    options.add_argument("--no-sandbox")
+    return options

--- a/examples/python/tests/drivers/test_options.py
+++ b/examples/python/tests/drivers/test_options.py
@@ -4,7 +4,7 @@ from selenium.webdriver.common.proxy import ProxyType
 
 
 def test_page_load_strategy_normal():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.page_load_strategy = 'normal'
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
@@ -12,7 +12,7 @@ def test_page_load_strategy_normal():
 
 
 def test_page_load_strategy_eager():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.page_load_strategy = 'eager'
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
@@ -20,35 +20,35 @@ def test_page_load_strategy_eager():
 
 
 def test_page_load_strategy_none():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.page_load_strategy = 'none'
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
 
 def test_timeouts_script():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.timeouts = { 'script': 5000 }
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
 
 def test_timeouts_page_load():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.timeouts = { 'pageLoad': 5000 }
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
 
 def test_timeouts_implicit_wait():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.timeouts = { 'implicit': 5000 }
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
 
 def test_unhandled_prompt():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.unhandled_prompt_behavior = 'accept'
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
@@ -62,28 +62,28 @@ def test_set_window_rect():
     driver.quit()
 
 def test_strict_file_interactability():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.strict_file_interactability = True
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
 
 def test_proxy():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.proxy = Proxy({ 'proxyType': ProxyType.MANUAL, 'httpProxy' : 'http.proxy:1234'})
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
     
 def test_set_browser_name():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     assert options.capabilities['browserName'] == 'chrome'
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
     
 def test_set_browser_version():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.browser_version = 'stable'
     assert options.capabilities['browserVersion'] == 'stable'
     driver = webdriver.Chrome(options=options)
@@ -91,15 +91,20 @@ def test_set_browser_version():
     driver.quit()
     
 def test_platform_name():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.platform_name = 'any'
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
     
 def test_accept_insecure_certs():
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.accept_insecure_certs = True
     driver = webdriver.Chrome(options=options)
     driver.get("https://www.selenium.dev/")
     driver.quit()
+
+def get_default_chrome_options():
+    options = webdriver.ChromeOptions()
+    options.add_argument("--no-sandbox")
+    return options

--- a/examples/python/tests/drivers/test_remote_webdriver.py
+++ b/examples/python/tests/drivers/test_remote_webdriver.py
@@ -10,7 +10,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Gets stuck on Windows, passes locally")
 def test_start_remote(server):
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     driver = webdriver.Remote(command_executor=server, options=options)
 
     assert "localhost" in driver.command_executor._client_config.remote_server_addr
@@ -19,7 +19,7 @@ def test_start_remote(server):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Gets stuck on Windows, passes locally")
 def test_uploads(server):
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     driver = webdriver.Remote(command_executor=server, options=options)
 
     driver.get("https://the-internet.herokuapp.com/upload")
@@ -39,7 +39,7 @@ def test_uploads(server):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Gets stuck on Windows, passes locally")
 def test_downloads(server, temp_dir):
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.enable_downloads = True
     driver = webdriver.Remote(command_executor=server, options=options)
 
@@ -64,3 +64,8 @@ def test_downloads(server, temp_dir):
     driver.delete_downloadable_files()
 
     assert not driver.get_downloadable_files()
+
+def get_default_chrome_options():
+    options = webdriver.ChromeOptions()
+    options.add_argument("--no-sandbox")
+    return options

--- a/examples/python/tests/drivers/test_service.py
+++ b/examples/python/tests/drivers/test_service.py
@@ -9,7 +9,7 @@ def test_basic_service():
 
 
 def test_driver_location(chromedriver_bin, chrome_bin):
-    options = webdriver.ChromeOptions()
+    options = get_default_chrome_options()
     options.binary_location = chrome_bin
 
     service = webdriver.ChromeService(executable_path=chromedriver_bin)
@@ -25,3 +25,8 @@ def test_driver_port():
     driver = webdriver.Chrome(service=service)
 
     driver.quit()
+
+def get_default_chrome_options():
+    options = webdriver.ChromeOptions()
+    options.add_argument("--no-sandbox")
+    return options


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Recently, GitHub updated ubuntu-latest from 22.04 to 24.04.
In this update, it looks like Chrome/Edge didn't wrap with `--no-sandbox` by default anymore.
Which causes the error 
> selenium.common.exceptions.InvalidArgumentException: Message: invalid argument: user data directory is already in use, please specify a unique value for --user-data-dir argument, or don't use --user-data-dir

Refer to an explanation https://stackoverflow.com/questions/70385737/selenium-common-exceptions-invalidargumentexception-message-invalid-argument

Update ChromeOptions/EdgeOptions always append argument `--no-sandbox` when creating WebDriver looks like a solution till now. It makes CI is green back.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added `--no-sandbox` argument to Chrome and Edge options to resolve browser initialization issues on Ubuntu 24.04.

- Introduced `get_default_options` utility functions for Chrome and Edge in Python and Java tests.

- Updated all relevant test cases to use the new default options functions.

- Enhanced test reliability and compatibility with updated GitHub Actions runners.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>test_chrome.py</strong><dd><code>Refactored Chrome tests to use `get_default_options`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-47561b87e40e35009b0ce3e88512579da1f96ffb911e86fd8dc9dee6708e7ba0">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_edge.py</strong><dd><code>Refactored Edge tests to use `get_default_options`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-503affe7beda841e0a1233e41de7b930960f073ce60ef7843e1044adc4968eac">+11/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>conftest.py</strong><dd><code>Added `--no-sandbox` to Chrome options in fixtures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-046cf5671a09c47700a1903ecec9669341fe3c0602c91beb6bb529053e7af113">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_http_client.py</strong><dd><code>Refactored HTTP client tests to use `get_default_options`</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-7ac14943f11a2dae3096a5972797d87fcdcc47674527661731811129772250d5">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_options.py</strong><dd><code>Refactored options tests to use `get_default_options`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-2634464e892392fa3ffdf1940368c555053d49f5d1491886253b739676ea7730">+18/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_remote_webdriver.py</strong><dd><code>Refactored remote WebDriver tests to use `get_default_options`</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-f8b2686eb6f40431029c9b1d3058099b2de2cd6af2dca17433160bf7984d7a99">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_service.py</strong><dd><code>Refactored service tests to use `get_default_options`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-4b8109066a0c3a4a52edea07f2d43e3623a5a7c79c506c52416fc94b25f55235">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CdpApiTest.java</strong><dd><code>Updated CDP API test to use default Chrome options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-5cd825093751d3f5baf30fd0add50b739c5c2066aab449e3856af11b791fb237">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ChromeTest.java</strong><dd><code>Refactored Chrome browser tests to use default options</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-3e1487953fb44b38aa25c92c75e04fa0c5a35403f9f2d1a88a242bde99cb20bb">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>EdgeTest.java</strong><dd><code>Refactored Edge browser tests to use default options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-d53fa141aaeea093c4b50ad4e34574f6dd0bc7981bb13637cda1be4ee54b06e7">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HttpClientTest.java</strong><dd><code>Updated HTTP client tests to use default Chrome options</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-4541278cb4ccb7ecac27217c254d0159062bcd86553568e117d834ff105b92eb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OptionsTest.java</strong><dd><code>Refactored options tests to use default Chrome options</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-3eb3ff6008510d0d30b7f1d43c8857bdf29fda42534f08399bccfe1cd323eab5">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RemoteWebDriverTest.java</strong><dd><code>Updated remote WebDriver tests to use default Chrome options</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-fe7f480b0c1f0e0afdd144427f700ba1ff9485fd484001ddacd53a177aa6cbce">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ServiceTest.java</strong><dd><code>Refactored service tests to use default Chrome options</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-0b468150f1145ee6a02f171ea4326bc423b366e7f0a43308b5069fadf321e388">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AlertsTest.java</strong><dd><code>Updated alerts test to use default Chrome options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-2ec5c2e3450ee03308bd3c130e9b33f0b8696c49c90334028c8e11e8ff6ce356">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrintsPageTest.java</strong><dd><code>Updated prints page test to use default Chrome options</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-2ba4957f9ab1f581acdc5c3f723e1acb4e14a305b04592175703e95bd8531812">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>BaseTest.java</strong><dd><code>Added utility methods for default Chrome and Edge options</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2139/files#diff-7c3da1e3098bcd60a7bd093118736565883b70ee8706191ffdf0f966f9e40ce7">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>