### PR TITLE
Replace unused variable in lambda expression

### DIFF
--- a/examples/python/tests/waits/test_waits.py
+++ b/examples/python/tests/waits/test_waits.py
@@ -39,7 +39,7 @@ def test_explicit(driver):
     driver.find_element(By.ID, "reveal").click()
 
     wait = WebDriverWait(driver, timeout=2)
-    wait.until(lambda d : revealed.is_displayed())
+    wait.until(lambda _ : revealed.is_displayed())
 
     revealed.send_keys("Displayed")
     assert revealed.get_property("value") == "Displayed"
@@ -52,6 +52,6 @@ def test_explicit_options(driver):
 
     errors = [NoSuchElementException, ElementNotInteractableException]
     wait = WebDriverWait(driver, timeout=2, poll_frequency=.2, ignored_exceptions=errors)
-    wait.until(lambda d : revealed.send_keys("Displayed") or True)
+    wait.until(lambda _ : revealed.send_keys("Displayed") or True)
 
     assert revealed.get_property("value") == "Displayed"


### PR DESCRIPTION
### **User description**
### Description
In Python it is common to indicate unused variables by choosing _ (underscore) as variable name. This pull request replaces some instances of unused variables in lambda expressions to align with Python customs and also other test examples in the repository.

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced unused variables in lambda expressions with `_` for Python convention.

- Improved code readability and consistency with Python customs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_waits.py</strong><dd><code>Update lambda expressions to use `_` for unused variables</code></dd></summary>
<hr>

examples/python/tests/waits/test_waits.py

<li>Replaced <code>d</code> with <code>_</code> in lambda expressions to indicate unused variables.<br> <li> Updated two test cases (<code>test_explicit</code> and <code>test_explicit_options</code>) for <br>better readability.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2160/files#diff-20755900d5228dec3a7c19de8735ac6f45a15c89a25affb88c32a0e556c1c436">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>