### PR TITLE
Assertion example in japanese language added.

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.ja.md
@@ -144,7 +144,8 @@ Seleniumコードの使用方法に関係なく、優れた統合開発環境が
 {{< gh-codeblock path="examples/javascript/test/getting_started/runningTests.spec.js#L14-L15" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L20-21" >}}
+
 {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
### User description  
Added a reference to the existing assertion code (`assertEquals("Web form", title)`) in `usingselenium.ja.md` to improve documentation clarity.  

### Description  
- Linked the assertion line in the Kotlin example section.  
- Ensured consistency in the documentation.  

### Motivation and Context  
- Improves visibility of assertion usage in Selenium’s Kotlin examples.  
- Enhances documentation clarity and consistency.  

### Types of changes  
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)  
- [ ] Code example added (and I also added the example to all translated languages)  
- [ ] Improved translation  
- [ ] Added new translation (and I also added a notice to each document missing translation)  

### Checklist  
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.  
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally, and I am sure it works.  

![Screenshot 2025-02-15 192958](https://github.com/user-attachments/assets/932c9cea-33f4-4bb3-b47a-7b43ef546185)
