### PR TITLE
Assertion example and test runner link in portuguese language added.

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/using_selenium.pt-br.md
@@ -93,7 +93,8 @@ que será usado para todos os exemplos nesta página.
   {{% /tab %}}
 
 {{% tab header="Kotlin" %}}
-
+- [Kotest](https://kotest.io/) - Uma estrutura de testes flexível e abrangente, projetada especificamente para Kotlin.
+- [JUnit5](https://junit.org/junit5/) - A estrutura de testes padrão do Java, totalmente compatível com Kotlin.
 {{% /tab %}}
 {{< /tabpane >}}
 
@@ -151,7 +152,7 @@ In your project's `package.json`, adicionar requisito às `dependências`:
 {{< gh-codeblock path="examples/javascript/test/getting_started/runningTests.spec.js#L14-L15" >}}
 {{< /tab >}}
 {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/getting_started/FirstScriptTest.kt#L20-21" >}}
 {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
### User description  
Added a reference to the existing assertion code (`assertEquals("Web form", title)`) and test runner link in `usingselenium.pt-br.md` to improve documentation clarity.  

### Description  
- Linked the assertion line in the Kotlin example section.  
- Added Test Runner Reference in the Kotlin section.
- Ensured consistency in the documentation.  

### Motivation and Context  
- Improves visibility of assertion usage in Selenium’s Kotlin examples.  
- Enhances documentation clarity and consistency.  

### Types of changes  
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)  
- [ ] Code example added (and I also added the example to all translated languages)  
- [ ] Improved translation  
- [ ] Added new translation (and I also added a notice to each document missing translation)  

### Checklist  
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.  
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally, and I am sure it works.  

![image](https://github.com/user-attachments/assets/d2322893-8ad7-4857-874c-a8e38c34894a)

