### PR TITLE
allow deploying site manually from github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - trunk
+  workflow_dispatch:
 
 jobs:
   deploy:
-    if: contains(toJson(github.event.commits), '[deploy site]') == true
+    if: contains(toJson(github.event.commits), '[deploy site]') == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo


### PR DESCRIPTION
### **User description**
I keep forgetting to add the deploy site comment, can't we just also do it from GitHub actions manually?


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added manual trigger support for deployment via GitHub Actions.

- Updated deployment condition to include `workflow_dispatch` events.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Add manual deployment trigger to workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml

<li>Added <code>workflow_dispatch</code> to GitHub Actions triggers.<br> <li> Modified deployment condition to check for manual trigger events.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2211/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>