### PR TITLE
add details tag with full example to code snippets

### DIFF
--- a/website_and_docs/layouts/shortcodes/gh-codeblock.html
+++ b/website_and_docs/layouts/shortcodes/gh-codeblock.html
@@ -21,6 +21,7 @@
 
 {{ $fullPath := .Get "path" }}
 {{ $path := index (split $fullPath "#") 0 }}
+{{ $hasFragment := in $fullPath "#" }}
 
 {{ $apiUrl := printf "%s/%s/%s/contents%s?ref=%s" $apiBaseUrl $org $repo $path $branch }}
 {{ $webUrl := printf "%s/%s/%s/blob/%s/%s" $webBaseUrl $org $repo $branch $fullPath }}
@@ -50,6 +51,13 @@
 
   {{ highlight $codeSnippet $language }}
 
+{{ if $hasFragment }}
+<details class="mt-2">
+  <summary>Show full example</summary>
+  <div class="pt-2">{{ highlight $content $language }}</div>
+</details>
+{{ end }}
+
   <div class="text-end pb-2">
     <a href="{{- $webUrl -}}" target="_blank">
       <i class="fas fa-external-link-alt pl-2"></i>
@@ -59,5 +67,3 @@
 {{ else }}
   {{ partial "github-content.html" }}
 {{ end }}
-
-


### PR DESCRIPTION
### **User description**
Demo to show an option for how we might improve things. It overflows the tab, so this isn't what we actually want, but looking for feedback on the concept.


___

### **PR Type**
Enhancement


___

### **Description**
- Added a collapsible `details` tag to display full code examples.

- Improved user experience by showing snippets with an option for full content.

- Enhanced conditional rendering for fragments in code blocks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gh-codeblock.html</strong><dd><code>Added collapsible full example display for code snippets</code>&nbsp; </dd></summary>
<hr>

website_and_docs/layouts/shortcodes/gh-codeblock.html

<li>Added a <code>details</code> tag to display full examples.<br> <li> Introduced a condition to check for URL fragments.<br> <li> Enhanced rendering logic for code snippets and full content.<br> <li> Improved layout with collapsible content for better UX.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2276/files#diff-ec8f0b60495d44a6e5cc53d677af6f660f18a6ff59ebf84ea5777e3835a7e46d">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>