### PR TITLE
added ruby code in document

### DIFF
--- a/examples/ruby/spec/interactions/cookies_spec.rb
+++ b/examples/ruby/spec/interactions/cookies_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe 'Cookies' do
   it 'deletes a cookie by name' do
     driver.navigate.to 'https://www.selenium.dev/selenium/web/blank.html'
     driver.manage.add_cookie(name: 'test1', value: 'cookie1')
-    # Verify cookie exists
-    expect(driver.manage.cookie_named('test1')).not_to be_nil
     # Delete cookie named
     driver.manage.delete_cookie('test1')
     # Verify cookie is deleted
@@ -52,8 +50,6 @@ RSpec.describe 'Cookies' do
     # Add cookies into current browser context
     driver.manage.add_cookie(name: 'test1', value: 'cookie1')
     driver.manage.add_cookie(name: 'test2', value: 'cookie2')
-    # Verify cookies exist
-    expect(driver.manage.all_cookies.size).to eq(2)
     # Delete All cookies
     driver.manage.delete_all_cookies
     # Verify all cookies are deleted

--- a/website_and_docs/content/documentation/webdriver/interactions/cookies.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/cookies.en.md
@@ -36,18 +36,8 @@ e.g. http://example.com/some404page)
 {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L32-L34" >}}
   {{< /tab >}}
-{{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  
-  # Adds the cookie into current browser context
-  driver.manage.add_cookie(name: "key", value: "value")
-ensure
-  driver.quit
-end
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L9-L11" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L18">}}
@@ -85,19 +75,8 @@ It returns the serialized cookie data matching with the cookie name among all as
   {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L40-L44" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "foo", value: "bar")
-
-  # Get cookie details with named cookie 'foo'
-  puts driver.manage.cookie_named('foo')
-ensure
-  driver.quit
-end
+  {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L17-L21" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L35-L38">}}
@@ -138,20 +117,8 @@ If browser is no longer available it returns error.
     {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L51-L64" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # Get all available cookies
-  puts driver.manage.all_cookies
-ensure
-  driver.quit
-end
+   {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L26-L31" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L49-L51">}}
@@ -193,20 +160,8 @@ It deletes the cookie data matching with the provided cookie name.
           {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L70-L73" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # delete a cookie with name 'test1'
-  driver.manage.delete_cookie('test1')
-ensure
-  driver.quit
-end
+    {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L40-L43" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L61-L62">}}
@@ -251,20 +206,8 @@ It deletes all the cookies of the current browsing context.
 {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L92-L97" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # deletes all cookies
-  driver.manage.delete_all_cookies
-ensure
-  driver.quit
-end
+     {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L49-L54" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L77-L78">}}

--- a/website_and_docs/content/documentation/webdriver/interactions/cookies.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/cookies.ja.md
@@ -33,18 +33,8 @@ Cookieの追加では、一連の定義済みのシリアル化可能なJSONオ�
 {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L32-L34" >}}
   {{< /tab >}}
-{{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  
-  # Adds the cookie into current browser context
-  driver.manage.add_cookie(name: "key", value: "value")
-ensure
-  driver.quit
-end
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L9-L11" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L18">}}
@@ -81,19 +71,8 @@ fun main() {
     {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L40-L44" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "foo", value: "bar")
-
-  # Get cookie details with named cookie 'foo'
-  puts driver.manage.cookie_named('foo')
-ensure
-  driver.quit
-end
+   {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L17-L21" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L35-L38">}}
@@ -133,20 +112,8 @@ fun main() {
       {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L51-L64" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # Get all available cookies
-  puts driver.manage.all_cookies
-ensure
-  driver.quit
-end
+   {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L26-L31" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L49-L51">}}
@@ -187,20 +154,8 @@ fun main() {
             {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L70-L73" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # delete a cookie with name 'test1'
-  driver.manage.delete_cookie('test1')
-ensure
-  driver.quit
-end
+     {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L40-L43" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L61-L62">}}
@@ -244,20 +199,8 @@ fun main() {
  {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L92-L97" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # deletes all cookies
-  driver.manage.delete_all_cookies
-ensure
-  driver.quit
-end
+   {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L49-L54" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L77-L78">}}

--- a/website_and_docs/content/documentation/webdriver/interactions/cookies.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/cookies.pt-br.md
@@ -35,18 +35,8 @@ por exemplo http://example.com/some404page)
 {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L32-L34" >}}
   {{< /tab >}}
-{{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  
-  # Adds the cookie into current browser context
-  driver.manage.add_cookie(name: "key", value: "value")
-ensure
-  driver.quit
-end
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L9-L11" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L18">}}
@@ -83,19 +73,8 @@ Retorna os dados do cookie serializado correspondentes ao nome do cookie entre t
       {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L40-L44" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "foo", value: "bar")
-
-  # Get cookie details with named cookie 'foo'
-  puts driver.manage.cookie_named('foo')
-ensure
-  driver.quit
-end
+     {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L17-L21" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L35-L38">}}
@@ -135,20 +114,8 @@ Se o navegador não estiver mais disponível, ele retornará um erro.
         {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L51-L64" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # Get all available cookies
-  puts driver.manage.all_cookies
-ensure
-  driver.quit
-end
+    {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L26-L31" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L49-L51">}}
@@ -189,20 +156,8 @@ Exclui os dados do cookie que correspondem ao nome do cookie fornecido.
               {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L70-L73" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # delete a cookie with name 'test1'
-  driver.manage.delete_cookie('test1')
-ensure
-  driver.quit
-end
+      {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L40-L43" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L61-L62">}}
@@ -246,20 +201,8 @@ Exclui todos os cookies do contexto de navegação atual.
    {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L92-L97" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # deletes all cookies
-  driver.manage.delete_all_cookies
-ensure
-  driver.quit
-end
+   {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L49-L54" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L77-L78">}}

--- a/website_and_docs/content/documentation/webdriver/interactions/cookies.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/cookies.zh-cn.md
@@ -31,18 +31,8 @@ WebDriver API提供了一种使用内置的方法与Cookie进行交互:
   {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L32-L34" >}}
   {{< /tab >}}
-{{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  
-  # Adds the cookie into current browser context
-  driver.manage.add_cookie(name: "key", value: "value")
-ensure
-  driver.quit
-end
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L9-L11" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
   {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L18">}}
@@ -79,20 +69,11 @@ fun main() {
         {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L40-L44" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "foo", value: "bar")
-
-  # Get cookie details with named cookie 'foo'
-  puts driver.manage.cookie_named('foo')
-ensure
-  driver.quit
-end
+  
+      {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L17-L21" >}}
   {{< /tab >}}
+
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L35-L38">}}
   {{< /tab >}}
@@ -130,21 +111,11 @@ fun main() {
          {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L51-L64" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
 
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L26-L31" >}}
+{{< /tab >}}
 
-  # Get all available cookies
-  puts driver.manage.all_cookies
-ensure
-  driver.quit
-end
-  {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L49-L51">}}
   {{< /tab >}}
@@ -184,21 +155,11 @@ fun main() {
                 {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L70-L73" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
 
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
+{{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L40-L43" >}}
+{{< /tab >}}
 
-  # delete a cookie with name 'test1'
-  driver.manage.delete_cookie('test1')
-ensure
-  driver.quit
-end
-  {{< /tab >}}
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L61-L62">}}
   {{< /tab >}}
@@ -241,21 +202,11 @@ fun main() {
      {{< tab header="CSharp" text=true >}}
 {{< gh-codeblock path="examples/dotnet/SeleniumDocs/Interactions/CookiesTest.cs#L92-L97" >}}
   {{< /tab >}}
-  {{< tab header="Ruby" >}}
-require 'selenium-webdriver'
-driver = Selenium::WebDriver.for :chrome
-
-begin
-  driver.get 'https://www.example.com'
-  driver.manage.add_cookie(name: "test1", value: "cookie1")
-  driver.manage.add_cookie(name: "test2", value: "cookie2")
-
-  # deletes all cookies
-  driver.manage.delete_all_cookies
-ensure
-  driver.quit
-end
+  
+   {{< tab header="Ruby" text=true >}}
+{{< gh-codeblock path="examples/ruby/spec/interactions/cookies_spec.rb#L49-L54" >}}
   {{< /tab >}}
+
   {{< tab header="JavaScript" text=true >}}
 {{< gh-codeblock path="/examples/javascript/test/interactions/cookies.spec.js#L77-L78">}}
   {{< /tab >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->
added ruby code in document
### Description
<!--- Describe your changes in detail -->
added ruby code in document
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
added ruby code in document
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
documentation


___

### **Description**
- Updated documentation to use Ruby code from test files
  - Replaced inline Ruby code with references to tested code blocks
  - Applied changes across English, Japanese, Portuguese, and Chinese docs

- Minor cleanup in Ruby cookie spec tests
  - Removed redundant cookie existence assertions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cookies.en.md</strong><dd><code>Use Ruby spec code blocks for documentation examples (EN)</code></dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/cookies.en.md

<li>Replaced inline Ruby code with references to Ruby spec code blocks<br> <li> Ensured Ruby examples are consistent and up-to-date<br> <li> Improved maintainability by linking to tested code


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2306/files#diff-de012bb51fd45347f0d28ed564143367a25e13bb81952c94bee5fa2bf9c2c8dc">+10/-67</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cookies.ja.md</strong><dd><code>Reference Ruby spec code in documentation (JA)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/cookies.ja.md

<li>Updated Ruby code examples to reference Ruby spec code blocks<br> <li> Removed inline Ruby code for consistency<br> <li> Ensured Japanese docs use tested Ruby code


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2306/files#diff-9223d83b53098c84bdd6b9af7ebf4b4808eaf3b690ca5878014857cf98299444">+10/-67</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cookies.pt-br.md</strong><dd><code>Reference Ruby spec code in documentation (PT-BR)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/cookies.pt-br.md

<li>Switched Ruby code examples to use Ruby spec code blocks<br> <li> Removed outdated inline Ruby code<br> <li> Improved consistency in Portuguese docs


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2306/files#diff-a5ad525f824c1ea7dcd5ae2b7f32373d89df041ea1475e18a315fa14bfc57371">+10/-67</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cookies.zh-cn.md</strong><dd><code>Reference Ruby spec code in documentation (ZH-CN)</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/cookies.zh-cn.md

<li>Updated Ruby code examples to reference Ruby spec code blocks<br> <li> Removed inline Ruby code for Chinese docs<br> <li> Ensured all Ruby examples are maintained in one place


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2306/files#diff-fae40b43d0b18aeea875789b554789d0e976a50aa9c1689d398b78212a32e055">+16/-65</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cookies_spec.rb</strong><dd><code>Cleanup and streamline Ruby cookie spec tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/ruby/spec/interactions/cookies_spec.rb

<li>Removed redundant assertions for cookie existence in tests<br> <li> Minor cleanup for clarity and maintainability


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2306/files#diff-30e3beaef784ae556b6f2d16b30ed5a6650e78be7c0bf31b95ea846a01f5ada4">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>