### PR TITLE
feat: add button to show full code example

### DIFF
--- a/website_and_docs/layouts/shortcodes/gh-codeblock.html
+++ b/website_and_docs/layouts/shortcodes/gh-codeblock.html
@@ -6,21 +6,22 @@
 
 {{ $defaultBranchFromEnv := (getenv "SELENIUM_EXAMPLES_BRANCH") }}
 {{ if $defaultBranchFromEnv }}
-  {{ $branch = $defaultBranchFromEnv }}
+{{ $branch = $defaultBranchFromEnv }}
 {{ end }}
 
 {{ $defaultOrgFromEnv := (getenv "SELENIUM_EXAMPLES_ORG") }}
 {{ if $defaultOrgFromEnv }}
-  {{ $org = $defaultOrgFromEnv }}
+{{ $org = $defaultOrgFromEnv }}
 {{ end }}
 
 {{ $defaultRepoFromEnv := (getenv "SELENIUM_EXAMPLES_REPO") }}
 {{ if $defaultRepoFromEnv }}
-  {{ $repo = $defaultRepoFromEnv }}
+{{ $repo = $defaultRepoFromEnv }}
 {{ end }}
 
 {{ $fullPath := .Get "path" }}
 {{ $path := index (split $fullPath "#") 0 }}
+{{ $hasFragment := in $fullPath "#" }}
 
 {{ $apiUrl := printf "%s/%s/%s/contents%s?ref=%s" $apiBaseUrl $org $repo $path $branch }}
 {{ $webUrl := printf "%s/%s/%s/blob/%s/%s" $webBaseUrl $org $repo $branch $fullPath }}
@@ -30,34 +31,130 @@
 
 {{ $githubToken := (getenv "SELENIUM_CI_TOKEN") }}
 {{ if $githubToken }}
-  {{ $toReplace := printf "://%s@" $githubToken }}
-  {{ $tokenInUrl := cond (eq $githubToken "") "://" $toReplace }}
-  {{ $apiUrlWithToken := replace $apiUrl "://" $tokenInUrl }}
+{{ $toReplace := printf "://%s@" $githubToken }}
+{{ $tokenInUrl := cond (eq $githubToken "") "://" $toReplace }}
+{{ $apiUrlWithToken := replace $apiUrl "://" $tokenInUrl }}
 
-  {{ $apiResults := getJSON $apiUrlWithToken  }}
-  {{ $content := base64Decode $apiResults.content }}
-  {{ $codeSnippet := $content }}
+{{ $apiResults := getJSON $apiUrlWithToken  }}
+{{ $content := base64Decode $apiResults.content }}
+{{ $codeSnippet := $content }}
 
-  {{ $parsedApiUrl := urls.Parse $webUrl }}
-  {{ with $parsedApiUrl.Fragment }}
-    {{ $codeLines := split $parsedApiUrl.Fragment "-" }}
-    {{ $fromLine := sub (int (replace (index $codeLines 0) "L" "")) 1 }}
-    {{ $toLine := int (cond (eq (len $codeLines) 1) (replace (index $codeLines 0) "L" "") (replace (index $codeLines 1) "L" "")) }}
-    {{ $numOfLines := cond (eq (sub $toLine $fromLine) 0) 1 (sub $toLine $fromLine) }}
-    {{ $splitContent := split $content "\n" }}
-    {{ $codeSnippet = delimit (first $numOfLines (after $fromLine $splitContent)) "\n" }}
-  {{ end }}
-
-  {{ highlight $codeSnippet $language }}
-
-  <div class="text-end pb-2">
-    <a href="{{- $webUrl -}}" target="_blank">
-      <i class="fas fa-external-link-alt pl-2"></i>
-        <strong>View full example on GitHub</strong>
-    </a>
-  </div>
-{{ else }}
-  {{ partial "github-content.html" }}
+{{ $parsedApiUrl := urls.Parse $webUrl }}
+{{ with $parsedApiUrl.Fragment }}
+{{ $codeLines := split $parsedApiUrl.Fragment "-" }}
+{{ $fromLine := sub (int (replace (index $codeLines 0) "L" "")) 1 }}
+{{ $toLine := int (cond (eq (len $codeLines) 1) (replace (index $codeLines 0) "L" "") (replace (index $codeLines 1) "L" "")) }}
+{{ $numOfLines := cond (eq (sub $toLine $fromLine) 0) 1 (sub $toLine $fromLine) }}
+{{ $splitContent := split $content "\n" }}
+{{ $codeSnippet = delimit (first $numOfLines (after $fromLine $splitContent)) "\n" }}
 {{ end }}
 
+{{ highlight $codeSnippet $language }}
 
+{{ if $hasFragment }}
+{{ $uniqueId := md5 $path }}
+<div class="mt-2">
+    <button class="btn btn-outline-secondary" onclick="showCodeModal('{{ $uniqueId }}')">
+        Show full example
+    </button>
+</div>
+
+<div id="codeModal_{{ $uniqueId }}" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1050;">
+    <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; border-radius: 8px; max-width: 90%; max-height: 90%; overflow: auto; box-shadow: 0 4px 20px rgba(0,0,0,0.3);">
+        <div style="padding: 20px; border-bottom: 1px solid #dee2e6; display: flex; justify-content: space-between; align-items: center;">
+            <h5 style="margin: 0;">{{ $path }}</h5>
+            <div>
+                <button onclick="copyCode('{{ $uniqueId }}')" style="margin-right: 10px; padding: 5px 10px; border: 1px solid #007bff; background: #007bff; color: white; border-radius: 4px; cursor: pointer;">
+                    Copy
+                </button>
+                <button onclick="closeCodeModal('{{ $uniqueId }}')" style="padding: 5px 10px; border: 1px solid #6c757d; background: #6c757d; color: white; border-radius: 4px; cursor: pointer;">
+                    Close
+                </button>
+            </div>
+        </div>
+        <div style="padding: 20px;">
+            <div id="codeContent_{{ $uniqueId }}">{{ highlight $content $language }}</div>
+        </div>
+    </div>
+</div>
+
+<script>
+window.showCodeModal = window.showCodeModal || function(id) {
+    document.getElementById('codeModal_' + id).style.display = 'block';
+    document.body.style.overflow = 'hidden';
+};
+
+window.closeCodeModal = window.closeCodeModal || function(id) {
+    document.getElementById('codeModal_' + id).style.display = 'none';
+    document.body.style.overflow = '';
+};
+
+window.copyCode = window.copyCode || function(id) {
+    const codeElement = document.getElementById('codeContent_' + id);
+    const code = codeElement.textContent;
+    
+    if (navigator.clipboard) {
+        navigator.clipboard.writeText(code).then(() => {
+            const btn = event.target;
+            const originalText = btn.textContent;
+            btn.textContent = 'Copied!';
+            btn.style.background = '#28a745';
+            btn.style.borderColor = '#28a745';
+            setTimeout(() => {
+                btn.textContent = originalText;
+                btn.style.background = '#007bff';
+                btn.style.borderColor = '#007bff';
+            }, 2000);
+        });
+    } else {
+        const textArea = document.createElement('textarea');
+        textArea.value = code;
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textArea);
+        
+        const btn = event.target;
+        const originalText = btn.textContent;
+        btn.textContent = 'Copied!';
+        btn.style.background = '#28a745';
+        btn.style.borderColor = '#28a745';
+        setTimeout(() => {
+            btn.textContent = originalText;
+            btn.style.background = '#007bff';
+            btn.style.borderColor = '#007bff';
+        }, 2000);
+    }
+};
+
+document.addEventListener('click', function(e) {
+    if (e.target.id && e.target.id.startsWith('codeModal_')) {
+        const id = e.target.id.replace('codeModal_', '');
+        closeCodeModal(id);
+    }
+});
+
+document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+        const openModals = document.querySelectorAll('[id^="codeModal_"]');
+        openModals.forEach(modal => {
+            if (modal.style.display === 'block') {
+                const id = modal.id.replace('codeModal_', '');
+                closeCodeModal(id);
+            }
+        });
+    }
+});
+</script>
+{{ end }}
+
+<div class="text-end pb-2">
+    <a href="{{- $webUrl -}}" target="_blank">
+        <i class="fas fa-external-link-alt pl-2"></i>
+        <strong>View full example on GitHub</strong>
+    </a>
+</div>
+
+{{ else }}
+{{ partial "github-content.html" }}
+{{ end }}

--- a/website_and_docs/layouts/shortcodes/gh-codeblock.html
+++ b/website_and_docs/layouts/shortcodes/gh-codeblock.html
@@ -53,10 +53,16 @@
 
 {{ if $hasFragment }}
 {{ $uniqueId := md5 $path }}
-<div class="mt-2">
-    <button class="btn btn-outline-secondary" onclick="showCodeModal('{{ $uniqueId }}')">
-        Show full example
-    </button>
+<div class="mt-4 pb-2">
+    <div style="border: 1px solid #dee2e6; border-radius: 6px; overflow: hidden; display: flex;">
+        <a onclick="showCodeModal('{{ $uniqueId }}')" style="flex: 1; display: flex; align-items: center; justify-content: center; padding: 8px 12px; text-decoration: none; color: #007bff; background: #f8f9fa; font-weight: 500; transition: background-color 0.2s; cursor: pointer; border-right: 1px solid #dee2e6;" onmouseover="this.style.backgroundColor='#e9ecef'" onmouseout="this.style.backgroundColor='#f8f9fa'">
+            View Complete Code
+        </a>
+        <a href="{{- $webUrl -}}" target="_blank" style="flex: 1; display: flex; align-items: center; justify-content: center; padding: 8px 12px; text-decoration: none; color: #007bff; background: #f8f9fa; font-weight: 500; transition: background-color 0.2s;" onmouseover="this.style.backgroundColor='#e9ecef'" onmouseout="this.style.backgroundColor='#f8f9fa'">
+            <i class="fas fa-external-link-alt" style="margin-right: 8px;"></i>
+            View on GitHub
+        </a>
+    </div>
 </div>
 
 <div id="codeModal_{{ $uniqueId }}" style="display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 1050;">
@@ -146,14 +152,14 @@ document.addEventListener('keydown', function(e) {
     }
 });
 </script>
-{{ end }}
-
+{{ else }}
 <div class="text-end pb-2">
     <a href="{{- $webUrl -}}" target="_blank">
         <i class="fas fa-external-link-alt pl-2"></i>
-        <strong>View full example on GitHub</strong>
+        <strong>View on GitHub</strong>
     </a>
 </div>
+{{ end }}
 
 {{ else }}
 {{ partial "github-content.html" }}

--- a/website_and_docs/layouts/shortcodes/gh-codeblock.html
+++ b/website_and_docs/layouts/shortcodes/gh-codeblock.html
@@ -64,7 +64,7 @@
         <div style="padding: 20px; border-bottom: 1px solid #dee2e6; display: flex; justify-content: space-between; align-items: center;">
             <h5 style="margin: 0;">{{ $path }}</h5>
             <div>
-                <button onclick="copyCode('{{ $uniqueId }}')" style="margin-right: 10px; padding: 5px 10px; border: 1px solid #007bff; background: #007bff; color: white; border-radius: 4px; cursor: pointer;">
+                <button onclick="copyCode('{{ $uniqueId }}', event)" style="margin-right: 10px; padding: 5px 10px; border: 1px solid #007bff; background: #007bff; color: white; border-radius: 4px; cursor: pointer;">
                     Copy
                 </button>
                 <button onclick="closeCodeModal('{{ $uniqueId }}')" style="padding: 5px 10px; border: 1px solid #6c757d; background: #6c757d; color: white; border-radius: 4px; cursor: pointer;">
@@ -89,7 +89,7 @@ window.closeCodeModal = window.closeCodeModal || function(id) {
     document.body.style.overflow = '';
 };
 
-window.copyCode = window.copyCode || function(id) {
+window.copyCode = window.copyCode || function(id, event) {
     const codeElement = document.getElementById('codeContent_' + id);
     const code = codeElement.textContent;
     


### PR DESCRIPTION
### **User description**
### Description

add show example, inspired from PR https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2276
<!--- Describe your changes in detail -->
![Screenshot 2025-06-05 at 10 43 18 AM](https://github.com/user-attachments/assets/5cf5cd40-7b1d-439e-b052-db32772f360f)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add "Show full example" button for code snippets with line fragments
  - Opens modal displaying the complete code file
  - Includes copy and close functionality in modal
  - Handles modal display, clipboard copy, and keyboard events

- Improve user experience for viewing and copying full code examples


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gh-codeblock.html</strong><dd><code>Add modal to display and copy full code example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/layouts/shortcodes/gh-codeblock.html

<li>Add logic to detect line fragment in code path<br> <li> Render "Show full example" button and modal for partial code blocks<br> <li> Implement modal with copy and close buttons, styled overlay<br> <li> Add JavaScript for modal control, clipboard copy, and keyboard <br>shortcuts


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2334/files#diff-ec8f0b60495d44a6e5cc53d677af6f660f18a6ff59ebf84ea5777e3835a7e46d">+126/-29</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>