### PR TITLE
fixed frame code error in java, csharp and python

### DIFF
--- a/examples/dotnet/SeleniumDocs/Interactions/FramesTest.cs
+++ b/examples/dotnet/SeleniumDocs/Interactions/FramesTest.cs
@@ -48,9 +48,9 @@ namespace SeleniumDocs.Interactions
 
 
             //switch To IFrame using name or id
-            driver.FindElement(By.Name("iframe1-name"));
+            IWebElement iframe1=driver.FindElement(By.Name("iframe1-name"));
             //Switch to the frame
-            driver.SwitchTo().Frame(iframe);
+            driver.SwitchTo().Frame(iframe1);
             Assert.AreEqual(true, driver.PageSource.Contains("We Leave From Here"));
             IWebElement email = driver.FindElement(By.Id("email"));
             //Now we can type text into email field

--- a/examples/java/src/test/java/dev/selenium/interactions/FramesTest.java
+++ b/examples/java/src/test/java/dev/selenium/interactions/FramesTest.java
@@ -48,9 +48,9 @@ public class FramesTest{
        
          
          //switch To IFrame using name or id
-         driver.findElement(By.name("iframe1-name"));
+         WebElement iframe1=driver.findElement(By.name("iframe1-name"));
          //Switch to the frame
-         driver.switchTo().frame(iframe);
+         driver.switchTo().frame(iframe1);
          assertEquals(true, driver.getPageSource().contains("We Leave From Here"));
          WebElement email = driver.findElement(By.id("email"));
          //Now we can type text into email field

--- a/examples/python/tests/interactions/test_frames.py
+++ b/examples/python/tests/interactions/test_frames.py
@@ -33,7 +33,7 @@ driver.switch_to.default_content()
 
 # --- Switch to iframe using name or ID ---
 iframe1=driver.find_element(By.NAME, "iframe1-name")  # (This line doesn't switch, just locates)
-driver.switch_to.frame(iframe)
+driver.switch_to.frame(iframe1)
 assert "We Leave From Here" in driver.page_source
 
 email = driver.find_element(By.ID, "email")


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
fixed frame code error in java, csharp and python
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
fixed frame code error in java, csharp and python
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
bug_fix


___

### **Description**
- Fixed incorrect frame switching code in Java, C#, and Python examples

- Updated variable usage to correctly reference located iframe elements

- Ensured frame switch uses the correct WebElement in all languages


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FramesTest.java</strong><dd><code>Corrected frame switching logic in Java frame test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/java/src/test/java/dev/selenium/interactions/FramesTest.java

<li>Assigned the found iframe element to a variable (<code>iframe1</code>)<br> <li> Updated frame switch to use the correct variable (<code>iframe1</code>)<br> <li> Removed incorrect usage of previous iframe variable


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2338/files#diff-c32bcc5edb4bcccf7c3694e3a6103af9a1bb389f8a7b6afee1821662f87df0ba">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FramesTest.cs</strong><dd><code>Fixed frame switching error in C# frame test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/dotnet/SeleniumDocs/Interactions/FramesTest.cs

<li>Assigned the found iframe element to a variable (<code>iframe1</code>)<br> <li> Updated frame switch to use the correct variable (<code>iframe1</code>)<br> <li> Removed incorrect usage of previous iframe variable


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2338/files#diff-e9fd2773b4a583c666654de1c300bb5d50dc92a5159fac8e2c41cb25555086cb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_frames.py</strong><dd><code>Fixed frame switching bug in Python frame test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/python/tests/interactions/test_frames.py

<li>Assigned the found iframe element to a variable (<code>iframe1</code>)<br> <li> Updated frame switch to use the correct variable (<code>iframe1</code>)<br> <li> Removed incorrect usage of previous iframe variable


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2338/files#diff-0b0da9aa5037728889ee1a1c27ee1da0659d4f0147f395beef93aaacf0e0e39f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>