### PR TITLE
chore: fix typos

### DIFF
--- a/website_and_docs/content/documentation/legacy/desired_capabilities.en.md
+++ b/website_and_docs/content/documentation/legacy/desired_capabilities.en.md
@@ -14,7 +14,7 @@ See [JSON Wire Protocol]({{< ref "json_wire_protocol.md#capabilities-json-object
 ## Remote Driver Specific
 <table><thead><th> <b>Key</b> </th><th> <b>Type</b> </th><th> <b>Description</b> </th></thead><tbody>
 <tr><td> webdriver.remote.sessionid </td><td> string     </td><td> WebDriver session ID for the session. Readonly and only returned if the server implements a server-side webdriver-backed selenium. </td></tr>
-<tr><td> webdriver.remote.quietExceptions </td><td> boolean      </td><td> Disable automatic screnshot capture on exceptions. This is False by default. </td></tr></tbody></table>
+<tr><td> webdriver.remote.quietExceptions </td><td> boolean      </td><td> Disable automatic screenshot capture on exceptions. This is False by default. </td></tr></tbody></table>
 
 ## Grid Specific
 <table><thead><th> <b>Key</b> </th><th> <b>Type</b> </th><th> <b>Description</b> </th></thead><tbody>
@@ -78,7 +78,7 @@ Preferences accepted by the FirefoxProfile with special meaning, in the WebDrive
 ## Safari specific
 | Key                      | Type              | Description                                                                                                                   |
 |:-----|:-------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| honorSystemProxy | boolean | Whether to honour the sysem proxy.                                                                                                                                                                                           |
+| honorSystemProxy | boolean | Whether to honour the system proxy.                                                                                                                                                                                          |
 | ensureCleanSession | boolean | Whether to make sure the session has no cookies, cache entries. And that any registry and proxy settings are restored after the session.                                                                                     |
 
 

--- a/website_and_docs/content/documentation/legacy/json_wire_protocol.en.md
+++ b/website_and_docs/content/documentation/legacy/json_wire_protocol.en.md
@@ -904,7 +904,7 @@ Arguments may be any JSON-primitive, array, or JSON object.  JSON objects that d
 <dt><b>Potential Errors:</b></dt>
 <dd><code>NoSuchWindow</code> - If the currently selected window has been closed.</dd>
 <dd><code>StaleElementReference</code> - If one of the script arguments is a WebElement that is not attached to the page's DOM.</dd>
-<dd><code>Timeout</code> - If the script callback is not invoked before the timout expires. Timeouts are controlled by the <code>/session/:sessionId/timeout/async_script</code> command.</dd>
+<dd><code>Timeout</code> - If the script callback is not invoked before the timeout expires. Timeouts are controlled by the <code>/session/:sessionId/timeout/async_script</code> command.</dd>
 <dd><code>JavaScriptError</code> - If the script throws an Error or if an <code>unload</code> event is fired while waiting for the script to finish.</dd>
 </dl>
 </dd>

--- a/website_and_docs/content/documentation/selenium_manager.en.md
+++ b/website_and_docs/content/documentation/selenium_manager.en.md
@@ -158,7 +158,7 @@ The cache in Selenium Manager is a local folder (`~/.cache/selenium` by default)
 In addition to the downloaded drivers and browsers, two additional files live in the cache's root:
 
 - Configuration file (`se-config.toml`). This file is optional and, as explained in the previous section, allows to store custom configuration values for Selenium Manager. This file is maintained by the end-user and read by Selenium Manager.
-- Metadata file (`se-metadata.json`). This file contains versions discovered by Selenium Manger making network requests (e.g., using the [CfT JSON endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints)) and the time-to-live (TTL) in which they are valid. Selenium Manager automatically maintains this file.
+- Metadata file (`se-metadata.json`). This file contains versions discovered by Selenium Manager making network requests (e.g., using the [CfT JSON endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints)) and the time-to-live (TTL) in which they are valid. Selenium Manager automatically maintains this file.
 
 The TTL in Selenium Manager is inspired by the TTL for DNS, a well-known mechanism that refers to how long some values are cached before they are automatically refreshed. In the case of Selenium Manager, these values are the versions found by making network requests for driver and browser version discovery. By default, the TTL is `3600` seconds (i.e., 1 hour) and can be tuned using configuration values or disabled by setting this configuration value to `0`.
 

--- a/website_and_docs/content/documentation/selenium_manager.ja.md
+++ b/website_and_docs/content/documentation/selenium_manager.ja.md
@@ -158,7 +158,7 @@ The cache in Selenium Manager is a local folder (`~/.cache/selenium` by default)
 In addition to the downloaded drivers and browsers, two additional files live in the cache's root:
 
 - Configuration file (`se-config.toml`). This file is optional and, as explained in the previous section, allows to store custom configuration values for Selenium Manager. This file is maintained by the end-user and read by Selenium Manager.
-- Metadata file (`se-metadata.json`). This file contains versions discovered by Selenium Manger making network requests (e.g., using the [CfT JSON endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints)) and the time-to-live (TTL) in which they are valid. Selenium Manager automatically maintains this file.
+- Metadata file (`se-metadata.json`). This file contains versions discovered by Selenium Manager making network requests (e.g., using the [CfT JSON endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints)) and the time-to-live (TTL) in which they are valid. Selenium Manager automatically maintains this file.
 
 The TTL in Selenium Manager is inspired by the TTL for DNS, a well-known mechanism that refers to how long some values are cached before they are automatically refreshed. In the case of Selenium Manager, these values are the versions found by making network requests for driver and browser version discovery. By default, the TTL is `3600` seconds (i.e., 1 hour) and can be tuned using configuration values or disabled by setting this configuration value to `0`.
 

--- a/website_and_docs/content/documentation/selenium_manager.pt-br.md
+++ b/website_and_docs/content/documentation/selenium_manager.pt-br.md
@@ -158,7 +158,7 @@ The cache in Selenium Manager is a local folder (`~/.cache/selenium` by default)
 In addition to the downloaded drivers and browsers, two additional files live in the cache's root:
 
 - Configuration file (`se-config.toml`). This file is optional and, as explained in the previous section, allows to store custom configuration values for Selenium Manager. This file is maintained by the end-user and read by Selenium Manager.
-- Metadata file (`se-metadata.json`). This file contains versions discovered by Selenium Manger making network requests (e.g., using the [CfT JSON endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints)) and the time-to-live (TTL) in which they are valid. Selenium Manager automatically maintains this file.
+- Metadata file (`se-metadata.json`). This file contains versions discovered by Selenium Manager making network requests (e.g., using the [CfT JSON endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints)) and the time-to-live (TTL) in which they are valid. Selenium Manager automatically maintains this file.
 
 The TTL in Selenium Manager is inspired by the TTL for DNS, a well-known mechanism that refers to how long some values are cached before they are automatically refreshed. In the case of Selenium Manager, these values are the versions found by making network requests for driver and browser version discovery. By default, the TTL is `3600` seconds (i.e., 1 hour) and can be tuned using configuration values or disabled by setting this configuration value to `0`.
 


### PR DESCRIPTION
### **User description**
### Description
fix typos

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Documentation


___

### **Description**
- Fix spelling errors in documentation files

- Correct typos in legacy capabilities and protocol docs

- Update Selenium Manager documentation across multiple languages


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>desired_capabilities.en.md</strong><dd><code>Correct spelling errors in capabilities documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/legacy/desired_capabilities.en.md

<ul><li>Fix typo "screnshot" to "screenshot" in remote driver capabilities<br> <li> Fix typo "sysem" to "system" in Safari proxy configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2428/files#diff-087ab7d70cb9c632231b5af32e18cb10a6b9a3e5ab87a2bfdc0f4050f0af610a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>json_wire_protocol.en.md</strong><dd><code>Fix timeout spelling in protocol documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/legacy/json_wire_protocol.en.md

- Fix typo "timout" to "timeout" in error description


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2428/files#diff-6aa3e033963950095304e213397797054fc8e09210d159d1180e9b569396bf02">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.en.md</strong><dd><code>Correct Selenium Manager spelling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/selenium_manager.en.md

- Fix typo "Manger" to "Manager" in metadata file description


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2428/files#diff-abfd3399fa93ee23ed8a6b8637b566cf12c67d477fda705ed877a10f013047b7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.ja.md</strong><dd><code>Correct Selenium Manager spelling in Japanese docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/selenium_manager.ja.md

- Fix typo "Manger" to "Manager" in metadata file description


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2428/files#diff-a84369b32708be4deb5da8f23f5b2c0adecb18e5eee5d30601e96f5d75e999f0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>selenium_manager.pt-br.md</strong><dd><code>Correct Selenium Manager spelling in Portuguese docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/selenium_manager.pt-br.md

- Fix typo "Manger" to "Manager" in metadata file description


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2428/files#diff-d8c0fd932e504044c81c242c7e255cb4533a7ea66e2b12d142c1cbb1680f6213">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

