### PR TITLE
Add VirtualAuthenticator tests to Ruby examples

### DIFF
--- a/examples/ruby/spec/virtual_authenticator/virtual_authenticator_options_spec.rb
+++ b/examples/ruby/spec/virtual_authenticator/virtual_authenticator_options_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'VirtualAuthenticatorOptions' do
+  let(:options) { Selenium::WebDriver::VirtualAuthenticatorOptions.new }
+
+  it "can set the various options" do
+    options.user_verified = true
+    options.user_verification = true
+    options.user_consenting = true
+    options.transport = :usb
+    options.protocol = :u2f
+    options.resident_key = false
+
+    expect(options.user_verified).to eq(true)
+    expect(options.user_verification).to eq(true)
+    expect(options.transport).to eq(:usb)
+    expect(options.protocol).to eq(:u2f)
+    expect(options.resident_key).to eq(false)
+  end
+
+  it "sets isUserVerified correctly in as part of as_json" do
+    options.user_verified = true
+    expect(options.as_json["isUserVerified"]).to eq(true)
+  end
+end

--- a/examples/ruby/spec/virtual_authenticator/virtual_authenticator_spec.rb
+++ b/examples/ruby/spec/virtual_authenticator/virtual_authenticator_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'VirtualAuthenticator' do
+  let(:driver) { start_session }
+
+  let(:private_key) {
+    Base64.strict_encode64(OpenSSL::PKey::RSA.generate(2048).private_to_der)
+  }
+
+  let(:options) { Selenium::WebDriver::VirtualAuthenticatorOptions.new }
+
+  it "Registers a new virtual authenticator" do
+    options.protocol = :u2f
+    options.resident_key = false
+
+    authenticator = driver.add_virtual_authenticator(options)
+    credential_list = authenticator.credentials
+
+    expect(credential_list).to be_empty
+  end
+
+  it "Removes a virtual authenticator" do
+    authenticator = driver.add_virtual_authenticator(options)
+
+    authenticator.remove!
+
+    expect {
+      authenticator.credentials
+    }.to raise_error(Selenium::WebDriver::Error::InvalidArgumentError)
+  end
+
+  it "Creates and adds a resident_key" do
+    options.protocol = :ctap2
+    options.resident_key = true
+    options.user_verification = true
+    options.user_verified = true
+
+    authenticator = driver.add_virtual_authenticator(options)
+
+    credential_id = [1,2,3,4] # byte array
+    user_handle = [1] # byte array
+    # decode from Base64, then turn into a byte array
+    decoded_private_key = Base64.strict_decode64(private_key).bytes
+
+    resident_credential = Selenium::WebDriver::Credential.resident(
+      id: credential_id,
+      private_key: decoded_private_key,
+      rp_id: "localhost",
+      user_handle: user_handle
+    )
+
+    authenticator.add_credential(resident_credential)
+
+    credential_list = authenticator.credentials
+
+    expect(credential_list.size).to eq(1)
+
+    expect(credential_id).to eq(credential_list[0].id)
+  end
+
+  it "adding resident keys is not supported when the authenticator uses the U2F protocol" do
+    options.protocol = :u2f
+    options.resident_key = true
+
+    authenticator = driver.add_virtual_authenticator(options)
+
+    credential_id = [1,2,3,4] # byte array
+    user_handle = [1] # byte array
+    # decode from Base64, then turn into a byte array
+    decoded_private_key = Base64.strict_decode64(private_key).bytes
+
+    resident_credential = Selenium::WebDriver::Credential.resident(
+      id: credential_id,
+      private_key: decoded_private_key,
+      rp_id: "localhost",
+      user_handle: user_handle
+    )
+
+    expect {
+      authenticator.add_credential(resident_credential)
+    }.to raise_error(Selenium::WebDriver::Error::InvalidArgumentError)
+  end
+
+  it "Creates and adds a non-resident key" do
+    options.protocol = :u2f
+    options.resident_key = false
+
+    authenticator = driver.add_virtual_authenticator(options)
+
+    credential_id = [1,2,3,4] # byte array
+    # decode from Base64, then turn into a byte array
+    decoded_private_key = Base64.strict_decode64(private_key).bytes
+
+    resident_credential = Selenium::WebDriver::Credential.non_resident(
+      id: credential_id,
+      private_key: decoded_private_key,
+      rp_id: "localhost"
+    )
+
+    authenticator.add_credential(resident_credential)
+
+    credential_list = authenticator.credentials
+
+    expect(credential_list.size).to eq(1)
+
+    expect(credential_id).to eq(credential_list[0].id)
+  end
+
+  it "Can get a credential" do
+    options.protocol = :ctap2
+    options.resident_key = true
+    options.user_verification = true
+    options.user_verified = true
+
+    authenticator = driver.add_virtual_authenticator(options)
+
+    credential_id = [1,2,3,4] # byte array
+    user_handle = [1] # byte array
+    # decode from Base64, then turn into a byte array
+    decoded_private_key = Base64.strict_decode64(private_key).bytes
+
+    resident_credential = Selenium::WebDriver::Credential.resident(
+      id: credential_id,
+      private_key: decoded_private_key,
+      rp_id: "localhost",
+      user_handle: user_handle
+    )
+
+    authenticator.add_credential(resident_credential)
+
+    credential_list = authenticator.credentials
+
+    expect(credential_list.size).to eq(1)
+
+    expect(credential_id).to eq(credential_list[0].id)
+    expect(private_key).to eq(credential_list[0].private_key)
+  end
+
+  it "Removes all credentials" do
+    authenticator = driver.add_virtual_authenticator(options)
+
+    credential_id = [1,2,3,4] # byte array
+    # decode from Base64, then turn into a byte array
+    decoded_private_key = Base64.strict_decode64(private_key).bytes
+
+    resident_credential = Selenium::WebDriver::Credential.non_resident(
+      id: credential_id,
+      private_key: decoded_private_key,
+      rp_id: "localhost"
+    )
+
+    authenticator.add_credential(resident_credential)
+    authenticator.remove_all_credentials
+
+    credential_list = authenticator.credentials
+
+    expect(credential_list.size).to eq(0)
+  end
+end


### PR DESCRIPTION
### **User description**
### Description
* Added tests for the Ruby example project that verify & document the VirtualAuthenticator API
* Note that one test is failing; I wasn't able to figure out what incantation of Base64 decoding/encoding was necessary

### Motivation and Context
* Adding these tests helps document how the Selenium library can be used with virtual authenticators

### Types of changes
- [x] Code example added (and I also added the example to all translated languages)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

_This is a new attempt of #1536, using the latest trunk_


___

### **PR Type**
Tests


___

### **Description**
- Add comprehensive VirtualAuthenticator test suite for Ruby

- Test authenticator options configuration and JSON serialization

- Test credential management (resident/non-resident keys)

- Test protocol-specific behaviors (U2F vs CTAP2)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VirtualAuthenticatorOptions"] --> B["Configuration Tests"]
  C["VirtualAuthenticator"] --> D["Authenticator Management"]
  C --> E["Credential Operations"]
  E --> F["Resident Keys"]
  E --> G["Non-Resident Keys"]
  D --> H["Protocol Validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>virtual_authenticator_options_spec.rb</strong><dd><code>VirtualAuthenticatorOptions configuration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/ruby/spec/virtual_authenticator/virtual_authenticator_options_spec.rb

<ul><li>Test VirtualAuthenticatorOptions configuration methods<br> <li> Verify property setters and getters functionality<br> <li> Test JSON serialization with <code>as_json</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2429/files#diff-af91709f3f903b9c708462d407b88243fd789803716de6b2af5e7cb397cc5e8f">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>virtual_authenticator_spec.rb</strong><dd><code>VirtualAuthenticator API comprehensive tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/ruby/spec/virtual_authenticator/virtual_authenticator_spec.rb

<ul><li>Test virtual authenticator registration and removal<br> <li> Test resident and non-resident credential creation<br> <li> Test protocol-specific behaviors (U2F vs CTAP2)<br> <li> Test credential management operations</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2429/files#diff-1f72918787793946e14e3361508ba4e98591af71d92ae96d82b637fe87002238">+161/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

