### PR TITLE
Added Kotlin Code Examples

### DIFF
--- a/examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt
+++ b/examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt
@@ -1,0 +1,65 @@
+package dev.selenium.waits
+
+import dev.selenium.BaseTest
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.openqa.selenium.By
+import org.openqa.selenium.ElementNotInteractableException
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui.FluentWait
+import org.openqa.selenium.support.ui.Wait
+import org.openqa.selenium.support.ui.WebDriverWait
+import java.time.Duration
+
+
+class WaitsTest : BaseTest() {
+
+    @Test
+    fun implicit() {
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(2))
+        driver.get("https://www.selenium.dev/selenium/web/dynamic.html")
+        driver.findElement(By.id("adder")).click()
+
+        val added = driver.findElement(By.id("box0"))
+
+        Assertions.assertEquals("redbox",added.getDomAttribute("class"))
+
+    }
+
+    @Test
+    fun explicit() {
+
+        driver.get("https://www.selenium.dev/selenium/web/dynamic.html")
+        val revealed = driver.findElement(By.id("revealed"))
+        driver.findElement(By.id("reveal")).click()
+
+        val wait =  WebDriverWait(driver, Duration.ofSeconds(2))
+        wait.until { revealed.isDisplayed }
+
+        revealed.sendKeys("Displayed")
+        Assertions.assertEquals("Displayed", revealed.getDomProperty("value"))
+    }
+
+    @Test
+    fun explicitWithOptions() {
+
+        driver.get("https://www.selenium.dev/selenium/web/dynamic.html")
+
+        val revealed = driver.findElement(By.id("revealed"))
+        driver.findElement(By.id("reveal")).click()
+
+        val wait: Wait<WebDriver?> =
+            FluentWait(driver)
+                .withTimeout(Duration.ofSeconds(2))
+                .pollingEvery(Duration.ofMillis(300))
+                .ignoring(ElementNotInteractableException::class.java)
+
+        wait.until {
+            revealed.sendKeys("Displayed")
+            true
+        }
+
+        Assertions.assertEquals("Displayed", revealed.getDomProperty("value"))
+    }
+
+}

--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path= "examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path= "examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path= "examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.en.md
+++ b/website_and_docs/content/documentation/webdriver/waits.en.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= "examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= "examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= "examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.ja.md
+++ b/website_and_docs/content/documentation/webdriver/waits.ja.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/waits.pt-br.md
@@ -82,7 +82,7 @@ Solving our example with an implicit wait looks like this:
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -118,7 +118,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -154,6 +154,6 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -92,7 +92,7 @@ Selenium 内置了一种自动等待元素出现的方式, 称为 _隐式等待_
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -133,7 +133,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -174,7 +174,7 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path="examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -92,7 +92,7 @@ Selenium 内置了一种自动等待元素出现的方式, 称为 _隐式等待_
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -133,7 +133,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -174,7 +174,7 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path= " examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -92,7 +92,7 @@ Selenium 内置了一种自动等待元素出现的方式, 称为 _隐式等待_
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L19" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -133,7 +133,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L36-L37" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -174,7 +174,7 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L51-L60" >}}
+{{< gh-codeblock path= " /examples/kotlin/test/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/waits.zh-cn.md
@@ -92,7 +92,7 @@ Selenium 内置了一种自动等待元素出现的方式, 称为 _隐式等待_
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L39" >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L19" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -133,7 +133,7 @@ JavaScript also supports [Expected Conditions]({{< ref "support_features/expecte
 {{< gh-codeblock path="/examples/javascript/test/waits/waits.spec.js#L52" >}}
   {{% /tab %}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L36-L37" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -174,7 +174,7 @@ The easiest way to customize Waits in Java is to use the `FluentWait` class:
 {{< badge-code >}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-{{< badge-code >}}
+{{< gh-codeblock path= " /examples/kotlin/tests/waits/WaitsTest.kt#L51-L60" >}}
   {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
### **User description**
# Added Kotlin Waits Code Example

### Description
Added Kotlin examples for Selenium waits in the code section. Previously, Kotlin examples were missing, making it harder for Kotlin developers to reference wait implementations directly from the documentation.

### Motivation and Context
Providing Kotlin wait examples ensures that Kotlin developers can quickly find and reference proper Selenium wait usage, improving accessibility and completeness of the documentation.

### Types of changes
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

## PR Type
Enhancement


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Added comprehensive Kotlin code examples for Selenium waits

- Created test file with implicit, explicit, and fluent wait implementations

- Updated documentation to reference Kotlin examples across multiple languages

- Replaced placeholder badges with actual code block references


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New Kotlin Test File"] --> B["Implicit Wait Example"]
  A --> C["Explicit Wait Example"] 
  A --> D["Fluent Wait Example"]
  E["Documentation Files"] --> F["Updated Code References"]
  B --> F
  C --> F
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WaitsTest.kt</strong><dd><code>New Kotlin waits test implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/kotlin/src/test/kotlin/dev/selenium/waits/WaitsTest.kt

<ul><li>Created new Kotlin test class extending <code>BaseTest</code><br> <li> Implemented three wait test methods: implicit, explicit, and fluent<br> <li> Added proper imports for Selenium WebDriver and wait classes<br> <li> Included assertions to verify wait functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2499/files#diff-c691087252fd610da9af9750ee1b30cc483c3b44b1c2c6426e51f7934d1b6697">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>waits.en.md</strong><dd><code>Updated English documentation with Kotlin examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/waits.en.md

<ul><li>Replaced <code>{{< badge-code >}}</code> placeholders with actual Kotlin code <br>references<br> <li> Added links to specific lines in the new Kotlin test file<br> <li> Updated three sections: implicit waits, explicit waits, and fluent <br>waits</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2499/files#diff-0f903beeec94e44f636d84011042a3269fca16724e0f9157750468627d2fbcf1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>waits.ja.md</strong><dd><code>Updated Japanese documentation with Kotlin examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/waits.ja.md

<ul><li>Replaced <code>{{< badge-code >}}</code> placeholders with Kotlin code block <br>references<br> <li> Added same code references as English version for consistency<br> <li> Updated Japanese documentation to include Kotlin examples</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2499/files#diff-f2a1e275d6460bc8bbd76d7286d4aba317fee68f1d67e896e329a083a28a979a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>waits.pt-br.md</strong><dd><code>Updated Portuguese documentation with Kotlin examples</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/waits.pt-br.md

<ul><li>Replaced placeholder badges with actual Kotlin code references<br> <li> Added links to specific test methods and line ranges<br> <li> Updated Portuguese-Brazilian documentation with Kotlin examples</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2499/files#diff-527b5c5c4b7c1eeca060671f7532d5cb791033f313ed8a89d3d9f38291dcb43d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>waits.zh-cn.md</strong><dd><code>Updated Chinese documentation with Kotlin examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/waits.zh-cn.md

<ul><li>Replaced <code>{{< badge-code >}}</code> with proper code block references<br> <li> Added same Kotlin example links as other language versions<br> <li> Updated Chinese documentation to include Kotlin code examples</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2499/files#diff-1425a343085ce58500c63c9673d9c352f76169844cfa3e9110a610ee3b37fc7e">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

