### PR TITLE
Fixing Java tests

### DIFF
--- a/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.bidi.webextension.ExtensionPath;
+import org.openqa.selenium.bidi.webextension.InstallExtensionParameters;
+import org.openqa.selenium.bidi.webextension.WebExtension;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -58,13 +61,17 @@ public class ChromeTest extends BaseTest {
   @Test
   public void extensionOptions() {
     ChromeOptions options = getDefaultChromeOptions();
-    Path path = Paths.get("src/test/resources/extensions/webextensions-selenium-example.crx");
-    File extensionFilePath = new File(path.toUri());
-
-    options.addExtensions(extensionFilePath);
-    options.addArguments("--disable-features=DisableLoadExtensionCommandLineSwitch");
-
+    options.enableBiDi();
+    options.addArguments("--remote-debugging-pipe");
+    options.addArguments("--enable-unsafe-extension-debugging");
     driver = new ChromeDriver(options);
+
+    Path path = Paths.get("src/test/resources/extensions/selenium-example");
+    WebExtension extension = new WebExtension(driver);
+    ExtensionPath extensionPath = new ExtensionPath(path.toString());
+    InstallExtensionParameters parameters = new InstallExtensionParameters(extensionPath);
+    extension.install(parameters);
+
     driver.get("https://www.selenium.dev/selenium/web/blank.html");
     WebElement injected = driver.findElement(By.id("webextensions-selenium-example"));
     Assertions.assertEquals(

--- a/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java
@@ -14,6 +14,8 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.bidi.webextension.ExtensionPath;
@@ -59,6 +61,7 @@ public class ChromeTest extends BaseTest {
   }
 
   @Test
+  @DisabledOnOs(OS.WINDOWS)
   public void extensionOptions() {
     ChromeOptions options = getDefaultChromeOptions();
     options.enableBiDi();

--- a/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java
+++ b/examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java
@@ -21,7 +21,10 @@ import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.edge.EdgeDriverService;
 import org.openqa.selenium.edge.EdgeOptions;
-import org.openqa.selenium.logging.*;
+import org.openqa.selenium.logging.LogEntries;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.remote.service.DriverFinder;
 
 
@@ -116,7 +119,7 @@ public class EdgeTest extends BaseTest {
     driver = new EdgeDriver(service);
 
     String fileContent = new String(Files.readAllBytes(logLocation.toPath()));
-    Assertions.assertTrue(fileContent.contains("Starting Microsoft Edge WebDriver"));
+    Assertions.assertTrue(fileContent.contains("Starting msedgedriver"));
   }
 
   @Test


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Updated Chrome extension testing to use BiDi WebExtension API
  - Replaced deprecated `.crx` file-based extension loading
  - Implemented new `WebExtension`, `ExtensionPath`, and `InstallExtensionParameters` classes
  - Added BiDi and remote debugging pipe configuration

- Fixed Edge driver log assertion to match actual output
  - Changed expected log message from "Starting Microsoft Edge WebDriver" to "Starting msedgedriver"

- Cleaned up wildcard imports in EdgeTest for better code clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chrome Extension Test"] -->|Replace deprecated| B["BiDi WebExtension API"]
  B -->|Use new classes| C["ExtensionPath & InstallExtensionParameters"]
  D["Edge Driver Logs"] -->|Fix assertion| E["Updated log message"]
  F["Import statements"] -->|Expand wildcards| G["Explicit imports"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChromeTest.java</strong><dd><code>Migrate Chrome extension test to BiDi WebExtension API</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/java/src/test/java/dev/selenium/browsers/ChromeTest.java

<ul><li>Added imports for BiDi WebExtension API classes (<code>ExtensionPath</code>, <br><code>InstallExtensionParameters</code>, <code>WebExtension</code>)<br> <li> Refactored <code>extensionOptions()</code> test to use BiDi WebExtension API <br>instead of deprecated <code>.crx</code> file loading<br> <li> Enabled BiDi and added remote debugging pipe arguments to <br>ChromeOptions<br> <li> Changed extension path from <code>.crx</code> file to directory-based path<br> <li> Instantiated <code>WebExtension</code> object and used new parameter-based <br>installation method</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2542/files#diff-3e1487953fb44b38aa25c92c75e04fa0c5a35403f9f2d1a88a242bde99cb20bb">+12/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>EdgeTest.java</strong><dd><code>Fix Edge log assertion and expand wildcard imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/java/src/test/java/dev/selenium/browsers/EdgeTest.java

<ul><li>Expanded wildcard import <code>org.openqa.selenium.logging.*</code> into explicit <br>individual imports<br> <li> Updated log assertion in <code>logsToConsole()</code> test to expect "Starting <br>msedgedriver" instead of "Starting Microsoft Edge WebDriver"</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2542/files#diff-d53fa141aaeea093c4b50ad4e34574f6dd0bc7981bb13637cda1be4ee54b06e7">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

