### PR TITLE
fix: gh-codeblock pointing to an incorrect line

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md
@@ -233,7 +233,7 @@ See [Quitting Sessions]({{< ref "../drivers/#quitting-sessions" >}}).
 {{< gh-codeblock path="/examples/java/README.md#L60" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/README.md#L35" >}}
+{{< gh-codeblock path="/examples/python/README.md#L58" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/README.md#L55" >}}


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
In https://www.selenium.dev/documentation/webdriver/getting_started/first_script/, the Python tab for the "Running Selenium File" section shows only three backticks:

````
```
````

because the `{{< gh-codeblock >}}` for `{{< tab header="Python" >}}` is pointing to the wrong line in /examples/python/README.md. Someone probably modified the README.md, without also updating the `gh-codeblock` path here.

(Perhaps we should think of a more foolproof way of linking to specific parts of a file?)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect line reference in Python code block

- Updated gh-codeblock path from L35 to L58 in examples/python/README.md

- Resolves empty Python tab display in first_script documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gh-codeblock<br/>L35 incorrect"] -- "update line number" --> B["gh-codeblock<br/>L58 correct"]
  B --> C["Python tab<br/>displays properly"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>first_script.en.md</strong><dd><code>Correct Python code block line reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/getting_started/first_script.en.md

<ul><li>Updated gh-codeblock path reference for Python tab from line 35 to <br>line 58<br> <li> Fixes empty code block display in "Running Selenium File" section<br> <li> Aligns with current structure of examples/python/README.md</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2552/files#diff-0757312e3d52b8201ca35b35c4bdad191db3e0978681a45c0cad1bebeb49fd3c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

