### PR TITLE
Fix iframe attribute spacing in Chinese frames documentation

### DIFF
--- a/website_and_docs/content/documentation/webdriver/interactions/frames.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/frames.zh-cn.md
@@ -16,7 +16,7 @@ aliases: [
 
 ```html
 <div id="modal">
-  <iframe id="buttonframe"name="myframe"src="https://seleniumhq.github.io">
+  <iframe id="buttonframe" name="myframe" src="https://seleniumhq.github.io">
    <button>Click here</button>
  </iframe>
 </div>


### PR DESCRIPTION
### **User description**
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes invalid HTML in the Chinese version of the frames documentation by adding
missing spaces between iframe attributes. This makes the example consistent
with the English version and valid HTML.


### Motivation and Context
The iframe example in frames.zh-cn.md had concatenated attributes
(id, name, src) without spaces, which makes the HTML invalid and confusing.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Documentation


___

### **Description**
- Fix spacing in HTML iframe attributes in Chinese documentation

- Adds proper spaces between iframe attributes for readability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chinese frames.zh-cn.md"] -- "Add spaces between attributes" --> B["Properly formatted iframe tag"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frames.zh-cn.md</strong><dd><code>Add spacing between iframe attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

website_and_docs/content/documentation/webdriver/interactions/frames.zh-cn.md

<ul><li>Fixed spacing in iframe HTML element attributes<br> <li> Changed <code>id="buttonframe"name="myframe"src=</code> to <code>id="buttonframe" </code><br><code>name="myframe" src=</code><br> <li> Improves code readability and follows HTML formatting standards</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/seleniumhq.github.io/pull/2563/files#diff-e07bd358cdd1ed4749113c0a901dc91bd8486590aafa14ce221ef6ab1e938cc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

