### PR TITLE
[dotnet] Blog post about strong naming

### DIFF
--- a/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
+++ b/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
@@ -33,9 +33,10 @@ If you reference the `StrongNamed` packages, migrate as follows:
 
 1. Replace `Selenium.WebDriver.StrongNamed` → `Selenium.WebDriver`
 2. Replace `Selenium.Support.StrongNamed` → `Selenium.Support`
-3. Update assembly references from `WebDriver.StrongNamed` → `WebDriver`
+3. Update assembly references: `WebDriver.StrongNamed` → `WebDriver`, `WebDriver.Support.StrongNamed` → `WebDriver.Support`
 
-If you use the regular packages — nothing changes.
+If you use the regular packages — the assemblies are now signed but the API and assembly names
+are unchanged, so no code changes are required.
 
 ## Related Issues
 

--- a/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
+++ b/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
@@ -23,7 +23,7 @@ all of which caused friction, especially in enterprise environments.
 ## What Changed
 
 - `Selenium.WebDriver` and `Selenium.Support` are now strongly signed.
-  Assembly names change: `WebDriver` → `Selenium.WebDriver`, `WebDriver.Support` → `Selenium.WebDriver.Support`.
+  Assembly names change: `WebDriver` → `Selenium.WebDriver`, `WebDriver.Support` → `Selenium.Support`.
 - `AssemblyVersion` stays at `4.0.0.0` (major-only) — no binding redirects needed between `4.x` releases.
 - `Selenium.WebDriver.StrongNamed` and `Selenium.Support.StrongNamed` are **retired**.
 
@@ -33,10 +33,10 @@ If you reference the `StrongNamed` packages, migrate as follows:
 
 1. Replace `Selenium.WebDriver.StrongNamed` → `Selenium.WebDriver`
 2. Replace `Selenium.Support.StrongNamed` → `Selenium.Support`
-3. Update assembly references: `WebDriver.StrongNamed` → `Selenium.WebDriver`, `WebDriver.Support.StrongNamed` → `Selenium.WebDriver.Support`
+3. Update assembly references: `WebDriver.StrongNamed` → `Selenium.WebDriver`, `WebDriver.Support.StrongNamed` → `Selenium.Support`
 
 If you use the regular packages — the assemblies are now signed but the assembly names change
-(`WebDriver.dll` → `Selenium.WebDriver.dll`, `WebDriver.Support.dll` → `Selenium.WebDriver.Support.dll`),
+(`WebDriver.dll` → `Selenium.WebDriver.dll`, `WebDriver.Support.dll` → `Selenium.Support.dll`),
 so update any explicit assembly references accordingly. The public API is unchanged.
 
 ## Related Issues

--- a/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
+++ b/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
@@ -22,7 +22,7 @@ all of which caused friction, especially in enterprise environments.
 
 ## What Changed
 
-- `Selenium.WebDriver` and `Selenium.Support` are signed with the project's `Selenium.snk` key.
+- `Selenium.WebDriver` and `Selenium.Support` are now strongly signed.
   Assembly names (`WebDriver` / `WebDriver.Support`) are **unchanged**.
 - `AssemblyVersion` stays at `4.0.0.0` (major-only) — no binding redirects needed between `4.x` releases.
 - `Selenium.WebDriver.StrongNamed` and `Selenium.Support.StrongNamed` are **retired**.

--- a/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
+++ b/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
@@ -23,7 +23,7 @@ all of which caused friction, especially in enterprise environments.
 ## What Changed
 
 - `Selenium.WebDriver` and `Selenium.Support` are now strongly signed.
-  Assembly names (`WebDriver` / `WebDriver.Support`) are **unchanged**.
+  Assembly names change: `WebDriver` → `Selenium.WebDriver`, `WebDriver.Support` → `Selenium.WebDriver.Support`.
 - `AssemblyVersion` stays at `4.0.0.0` (major-only) — no binding redirects needed between `4.x` releases.
 - `Selenium.WebDriver.StrongNamed` and `Selenium.Support.StrongNamed` are **retired**.
 
@@ -33,10 +33,11 @@ If you reference the `StrongNamed` packages, migrate as follows:
 
 1. Replace `Selenium.WebDriver.StrongNamed` → `Selenium.WebDriver`
 2. Replace `Selenium.Support.StrongNamed` → `Selenium.Support`
-3. Update assembly references: `WebDriver.StrongNamed` → `WebDriver`, `WebDriver.Support.StrongNamed` → `WebDriver.Support`
+3. Update assembly references: `WebDriver.StrongNamed` → `Selenium.WebDriver`, `WebDriver.Support.StrongNamed` → `Selenium.WebDriver.Support`
 
-If you use the regular packages — the assemblies are now signed but the API and assembly names
-are unchanged, so no code changes are required.
+If you use the regular packages — the assemblies are now signed but the assembly names change
+(`WebDriver.dll` → `Selenium.WebDriver.dll`, `WebDriver.Support.dll` → `Selenium.WebDriver.Support.dll`),
+so update any explicit assembly references accordingly. The public API is unchanged.
 
 ## Related Issues
 

--- a/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
+++ b/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
@@ -9,16 +9,11 @@ description: >
   Starting with Selenium 4.44, the main NuGet packages ship strongly signed assemblies. The separate StrongNamed packages are retired.
 ---
 
-Starting with **Selenium 4.44**, the `Selenium.WebDriver` and `Selenium.Support` NuGet packages
-ship **strongly signed assemblies**. The separate `Selenium.WebDriver.StrongNamed` and
-`Selenium.Support.StrongNamed` packages are discontinued.
+Starting with **Selenium 4.44**, the `Selenium.WebDriver` and `Selenium.Support` NuGet packages ship **strongly signed assemblies**. The separate `Selenium.WebDriver.StrongNamed` and `Selenium.Support.StrongNamed` packages are discontinued.
 
 ## Why This Matters
 
-Without strong naming on the official packages, any project that itself needed to be strongly signed
-could not reference Selenium from NuGet. Teams were forced to either forgo strong naming, bundle
-out-of-band downloads, or use the separate `StrongNamed` packages with a different assembly name —
-all of which caused friction, especially in enterprise environments.
+Without strong naming on the official packages, any project that itself needed to be strongly signed could not reference Selenium from NuGet. Teams were forced to either forgo strong naming, bundle out-of-band downloads, or use the separate `StrongNamed` packages with a different assembly name — all of which caused friction, especially in enterprise environments.
 
 ## What Changed
 
@@ -35,9 +30,7 @@ If you reference the `StrongNamed` packages, migrate as follows:
 2. Replace `Selenium.Support.StrongNamed` → `Selenium.Support`
 3. Update assembly references: `WebDriver.StrongNamed` → `Selenium.WebDriver`, `WebDriver.Support.StrongNamed` → `Selenium.Support`
 
-If you use the regular packages — the assemblies are now signed but the assembly names change
-(`WebDriver.dll` → `Selenium.WebDriver.dll`, `WebDriver.Support.dll` → `Selenium.Support.dll`),
-so update any explicit assembly references accordingly. The public API is unchanged.
+If you use the regular packages — the assemblies are now signed but the assembly names change (`WebDriver.dll` → `Selenium.WebDriver.dll`, `WebDriver.Support.dll` → `Selenium.Support.dll`), so update any explicit assembly references accordingly. The public API is unchanged.
 
 ## Related Issues
 

--- a/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
+++ b/website_and_docs/content/blog/2026/dotnet-strong-name-signing.md
@@ -1,0 +1,46 @@
+---
+title: ".NET Assemblies Are Now Strongly Signed"
+linkTitle: ".NET Assemblies Are Now Strongly Signed"
+date: 2026-04-27
+tags: ["selenium", "dotnet"]
+categories: ["general"]
+author: Nikolay Borisenko [@nvborisenko](https://github.com/nvborisenko)
+description: >
+  Starting with Selenium 4.44, the main NuGet packages ship strongly signed assemblies. The separate StrongNamed packages are retired.
+---
+
+Starting with **Selenium 4.44**, the `Selenium.WebDriver` and `Selenium.Support` NuGet packages
+ship **strongly signed assemblies**. The separate `Selenium.WebDriver.StrongNamed` and
+`Selenium.Support.StrongNamed` packages are discontinued.
+
+## Why This Matters
+
+Without strong naming on the official packages, any project that itself needed to be strongly signed
+could not reference Selenium from NuGet. Teams were forced to either forgo strong naming, bundle
+out-of-band downloads, or use the separate `StrongNamed` packages with a different assembly name —
+all of which caused friction, especially in enterprise environments.
+
+## What Changed
+
+- `Selenium.WebDriver` and `Selenium.Support` are signed with the project's `Selenium.snk` key.
+  Assembly names (`WebDriver` / `WebDriver.Support`) are **unchanged**.
+- `AssemblyVersion` stays at `4.0.0.0` (major-only) — no binding redirects needed between `4.x` releases.
+- `Selenium.WebDriver.StrongNamed` and `Selenium.Support.StrongNamed` are **retired**.
+
+## Breaking Changes
+
+If you reference the `StrongNamed` packages, migrate as follows:
+
+1. Replace `Selenium.WebDriver.StrongNamed` → `Selenium.WebDriver`
+2. Replace `Selenium.Support.StrongNamed` → `Selenium.Support`
+3. Update assembly references from `WebDriver.StrongNamed` → `WebDriver`
+
+If you use the regular packages — nothing changes.
+
+## Related Issues
+
+- [#12315](https://github.com/SeleniumHQ/selenium/issues/12315) — Publish StrongNamed builds to NuGet feed
+- [#10845](https://github.com/SeleniumHQ/selenium/issues/10845) — Revisiting strong-named assemblies for NuGet
+- [#14115](https://github.com/SeleniumHQ/selenium/issues/14115) — Strong Name Key
+
+Implementation: [#17397](https://github.com/SeleniumHQ/selenium/pull/17397)


### PR DESCRIPTION
To be loud for 1% of users.

### Description
This pull request adds a new blog post announcing that, starting with Selenium 4.44, the main .NET NuGet packages (`Selenium.WebDriver` and `Selenium.Support`) are now strongly signed. The separate StrongNamed packages are discontinued, simplifying package usage for teams requiring strong naming.

Key updates:

**.NET Strong Name Signing Announcement:**

* Added a new blog post, `dotnet-strong-name-signing.md`, detailing that `Selenium.WebDriver` and `Selenium.Support` NuGet packages are now strongly signed with the project's key, and the separate `StrongNamed` packages are retired.
* The post explains migration steps for users of the old `StrongNamed` packages and provides context on why this change matters for enterprise and strongly signed projects.
* Related issues and implementation pull request are referenced for further information.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
