### PR TITLE
Move Python examples in Windows interactions docs

### DIFF
--- a/examples/python/tests/interactions/test_windows.py
+++ b/examples/python/tests/interactions/test_windows.py
@@ -20,25 +20,39 @@ def test_current_window_handle(driver):
 
 def test_switch_to_window(driver):
     driver.get(url)
-    original_window_handles = set(driver.window_handles)
-    assert len(original_window_handles) == 1
+    wait = WebDriverWait(driver, 10)
+
+    original_window_handle = driver.current_window_handle
+
     driver.find_element(By.LINK_TEXT, "Open new window").click()
-    new_handles = set(driver.window_handles) - original_window_handles
-    assert len(new_handles) == 1
-    new_window_handle = new_handles.pop()
+    wait.until(EC.number_of_windows_to_be(2))
+
+    new_window_handle = (set(driver.window_handles) - {original_window_handle}).pop()
     driver.switch_to.window(new_window_handle)
     assert driver.current_window_handle == new_window_handle
 
 def test_close_window(driver):
     driver.get(url)
-    driver.find_element(By.LINK_TEXT, "Open new window").click()
-    driver.close()
-    current_handles = driver.window_handles
-    assert len(current_handles) == 1
+    wait = WebDriverWait(driver, 10)
 
-def test_new_window(driver):
+    original_window_handle = driver.current_window_handle
+
+    driver.find_element(By.LINK_TEXT, "Open new window").click()
+    wait.until(EC.number_of_windows_to_be(2))
+
+    new_window_handle = (set(driver.window_handles) - {original_window_handle}).pop()
+    driver.switch_to.window(new_window_handle)
+
+    driver.close()
+    driver.switch_to.window(original_window_handle)
+
+    assert driver.current_window_handle == original_window_handle
+    assert len(driver.window_handles) == 1
+
+def test_create_new_window(driver):
     # Opens a new tab and switches to new tab
     driver.switch_to.new_window('tab')
+    assert driver.title == ""
     # Opens a new window and switches to new window
     driver.switch_to.new_window('window')
-    assert len(driver.window_handles) == 3
+    assert driver.title == ""

--- a/examples/python/tests/interactions/test_windows.py
+++ b/examples/python/tests/interactions/test_windows.py
@@ -19,14 +19,26 @@ def test_current_window_handle(driver):
 
 
 def test_switch_to_window(driver):
-    wait = WebDriverWait(driver, 10)
     driver.get(url)
     original_window_handles = set(driver.window_handles)
     assert len(original_window_handles) == 1
     driver.find_element(By.LINK_TEXT, "Open new window").click()
-    wait.until(EC.number_of_windows_to_be(2))
     new_handles = set(driver.window_handles) - original_window_handles
     assert len(new_handles) == 1
     new_window_handle = new_handles.pop()
     driver.switch_to.window(new_window_handle)
     assert driver.current_window_handle == new_window_handle
+
+def test_close_window(driver):
+    driver.get(url)
+    driver.find_element(By.LINK_TEXT, "Open new window").click()
+    driver.close()
+    current_handles = driver.window_handles
+    assert len(current_handles) == 1
+
+def test_new_window(driver):
+    # Opens a new tab and switches to new tab
+    driver.switch_to.new_window('tab')
+    # Opens a new window and switches to new window
+    driver.switch_to.new_window('window')
+    assert len(driver.window_handles) == 3

--- a/examples/python/tests/interactions/test_windows.py
+++ b/examples/python/tests/interactions/test_windows.py
@@ -1,2 +1,32 @@
+import pytest
 from selenium import webdriver
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
 
+url = "https://www.selenium.dev/selenium/web/window_switching_tests/page_with_frame.html"
+
+@pytest.fixture()
+def driver():
+    driver = webdriver.Chrome()
+    yield driver
+    driver.quit()
+
+def test_current_window_handle(driver):
+    driver.get(url)
+    current_handle = driver.current_window_handle
+    assert current_handle is not None
+
+
+def test_switch_to_window(driver):
+    wait = WebDriverWait(driver, 10)
+    driver.get(url)
+    original_window_handles = set(driver.window_handles)
+    assert len(original_window_handles) == 1
+    driver.find_element(By.LINK_TEXT, "Open new window").click()
+    wait.until(EC.number_of_windows_to_be(2))
+    new_handles = set(driver.window_handles) - original_window_handles
+    assert len(new_handles) == 1
+    new_window_handle = new_handles.pop()
+    driver.switch_to.window(new_window_handle)
+    assert driver.current_window_handle == new_window_handle

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
@@ -23,7 +23,7 @@ current window by using:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L16-L20" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L16-L18" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L16-L18" >}}
   {{< /tab >}}
   {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L17-L21" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
@@ -49,7 +49,7 @@ window is launched. So first position will be default browser, and so on.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L32" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L30" >}}
   {{< /tab >}}
   
   {{< tab header="CSharp" text=true >}}
@@ -148,12 +148,8 @@ handle stored in a variable. Put this together and you will get:
  {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L31-L34" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-    #Close the tab or window
-driver.close()
-
-    #Switch back to the old tab or window
-driver.switch_to.window(original_window)
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L35-L35" >}}
   {{< /tab >}}
   
     {{< tab header="CSharp" text=true >}}
@@ -202,12 +198,8 @@ __Note: This feature works with Selenium 4 and later versions.__
    {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L36-L42" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-    # Opens a new tab and switches to new tab
-driver.switch_to.new_window('tab')
-
-    # Opens a new window and switches to new window
-driver.switch_to.new_window('window')
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L40-L43" >}}
   {{< /tab >}}
   
   
@@ -250,7 +242,9 @@ instead of close:
      {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L44-L45" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}driver.quit(){{< /tab >}}
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L13-L13" >}}
+{{< /tab >}}
     
   {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L45-L46" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
@@ -22,7 +22,9 @@ current window by using:
 {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L16-L20" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}driver.current_window_handle{{< /tab >}}
+  {{< tab header="Python" text=true >}}
+  {{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L16-L18" >}}
+  {{< /tab >}}
   {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L17-L21" >}}
   {{< /tab >}}
@@ -46,38 +48,8 @@ window is launched. So first position will be default browser, and so on.
   {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium import webdriver
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-
-with webdriver.Firefox() as driver:
-    # Open URL
-    driver.get("https://seleniumhq.github.io")
-
-    # Setup wait for later
-    wait = WebDriverWait(driver, 10)
-
-    # Store the ID of the original window
-    original_window = driver.current_window_handle
-
-    # Check we don't have other windows open already
-    assert len(driver.window_handles) == 1
-
-    # Click the link which opens in a new window
-    driver.find_element(By.LINK_TEXT, "new window").click()
-
-    # Wait for the new window or tab
-    wait.until(EC.number_of_windows_to_be(2))
-
-    # Loop through until we find a new window handle
-    for window_handle in driver.window_handles:
-        if window_handle != original_window:
-            driver.switch_to.window(window_handle)
-            break
-
-    # Wait for the new tab to finish loading content
-    wait.until(EC.title_is("SeleniumHQ Browser Automation"))
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L32" >}}
   {{< /tab >}}
   
   {{< tab header="CSharp" text=true >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.en.md
@@ -49,7 +49,7 @@ window is launched. So first position will be default browser, and so on.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L30" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L32" >}}
   {{< /tab >}}
   
   {{< tab header="CSharp" text=true >}}
@@ -149,7 +149,7 @@ handle stored in a variable. Put this together and you will get:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L31-L34" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L35-L35" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L46-L46" >}}
   {{< /tab >}}
   
     {{< tab header="CSharp" text=true >}}
@@ -199,7 +199,7 @@ __Note: This feature works with Selenium 4 and later versions.__
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L36-L42" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L40-L43" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L53-L58" >}}
   {{< /tab >}}
   
   

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
@@ -44,7 +44,7 @@ WebDriverは、ウィンドウとタブを区別しません。
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L30" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L32" >}}
   {{< /tab >}}
   
     {{< tab header="CSharp" text=true >}}
@@ -141,7 +141,7 @@ wait.until(titleIs("Selenium documentation"))
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L31-L34" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L35-L35" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L46-L46" >}}
   {{< /tab >}}
 
    {{< tab header="CSharp" text=true >}}
@@ -188,7 +188,7 @@ __注意: この機能は、Selenium 4以降のバージョンで機能します
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L36-L42" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L40-L43" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L53-L58" >}}
   {{< /tab >}}
     
   {{< tab header="CSharp" text=true >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.ja.md
@@ -20,7 +20,9 @@ WebDriverは、ウィンドウとタブを区別しません。
   {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L16-L20" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}driver.current_window_handle{{< /tab >}}
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L16-L18" >}}
+{{< /tab >}}
     {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L17-L21" >}}
   {{< /tab >}}
@@ -41,39 +43,8 @@ WebDriverは、ウィンドウとタブを区別しません。
   {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium import webdriver
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-
-    # Start the driver
-with webdriver.Firefox() as driver:
-    # Open URL
-    driver.get("https://seleniumhq.github.io")
-
-    # Setup wait for later
-    wait = WebDriverWait(driver, 10)
-
-    # Store the ID of the original window
-    original_window = driver.current_window_handle
-
-    # Check we don't have other windows open already
-    assert len(driver.window_handles) == 1
-
-    # Click the link which opens in a new window
-    driver.find_element(By.LINK_TEXT, "new window").click()
-
-    # Wait for the new window or tab
-    wait.until(EC.number_of_windows_to_be(2))
-
-    # Loop through until we find a new window handle
-    for window_handle in driver.window_handles:
-        if window_handle != original_window:
-            driver.switch_to.window(window_handle)
-            break
-
-    # Wait for the new tab to finish loading content
-    wait.until(EC.title_is("SeleniumHQ Browser Automation"))
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L30" >}}
   {{< /tab >}}
   
     {{< tab header="CSharp" text=true >}}
@@ -169,12 +140,8 @@ wait.until(titleIs("Selenium documentation"))
  {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L31-L34" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-    #Close the tab or window
-driver.close()
-
-    #Switch back to the old tab or window
-driver.switch_to.window(original_window)
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L35-L35" >}}
   {{< /tab >}}
 
    {{< tab header="CSharp" text=true >}}
@@ -220,12 +187,8 @@ __注意: この機能は、Selenium 4以降のバージョンで機能します
    {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L36-L42" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-    # Opens a new tab and switches to new tab
-driver.switch_to.new_window('tab')
-
-    # Opens a new window and switches to new window
-driver.switch_to.new_window('window')
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L40-L43" >}}
   {{< /tab >}}
     
   {{< tab header="CSharp" text=true >}}
@@ -268,7 +231,9 @@ driver.switchTo().newWindow(WindowType.WINDOW)
  {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L44-L45" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}driver.quit(){{< /tab >}}
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L13-L13" >}}
+{{< /tab >}}
   {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L45-L46" >}}
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
@@ -50,7 +50,7 @@ que cria uma nova guia (ou) nova janela e muda automaticamente para ela.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L30" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L32" >}}
   {{< /tab >}}
 
     {{< tab header="CSharp" text=true >}}
@@ -150,7 +150,7 @@ anterior armazenado em uma variável. Junte isso e você obterá:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L31-L34" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L35-L35" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L46-L46" >}}
   {{< /tab >}}
 
    {{< tab header="CSharp" text=true >}}
@@ -198,7 +198,7 @@ __Nota: este recurso funciona com Selenium 4 e versões posteriores.__
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L36-L42" >}}
 {{< /tab >}}
   {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L40-L43" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L53-L58" >}}
   {{< /tab >}}
   
   {{< tab header="CSharp" text=true >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.pt-br.md
@@ -20,7 +20,9 @@ persistente em uma única sessão. Você pode pegar o identificador atual usando
     {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L16-L20" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}driver.current_window_handle{{< /tab >}}
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L16-L18" >}}
+{{< /tab >}}
      {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L17-L21" >}}
   {{< /tab >}}
@@ -47,39 +49,8 @@ que cria uma nova guia (ou) nova janela e muda automaticamente para ela.
    {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-from selenium import webdriver
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-
-    # Start the driver
-with webdriver.Firefox() as driver:
-    # Open URL
-    driver.get("https://seleniumhq.github.io")
-
-    # Setup wait for later
-    wait = WebDriverWait(driver, 10)
-
-    # Store the ID of the original window
-    original_window = driver.current_window_handle
-
-    # Check we don't have other windows open already
-    assert len(driver.window_handles) == 1
-
-    # Click the link which opens in a new window
-    driver.find_element(By.LINK_TEXT, "new window").click()
-
-    # Wait for the new window or tab
-    wait.until(EC.number_of_windows_to_be(2))
-
-    # Loop through until we find a new window handle
-    for window_handle in driver.window_handles:
-        if window_handle != original_window:
-            driver.switch_to.window(window_handle)
-            break
-
-    # Wait for the new tab to finish loading content
-    wait.until(EC.title_is("SeleniumHQ Browser Automation"))
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L30" >}}
   {{< /tab >}}
 
     {{< tab header="CSharp" text=true >}}
@@ -178,12 +149,8 @@ anterior armazenado em uma variável. Junte isso e você obterá:
  {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L31-L34" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-    #Close the tab or window
-driver.close()
-
-    #Switch back to the old tab or window
-driver.switch_to.window(original_window)
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L35-L35" >}}
   {{< /tab >}}
 
    {{< tab header="CSharp" text=true >}}
@@ -230,12 +197,8 @@ __Nota: este recurso funciona com Selenium 4 e versões posteriores.__
   {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L36-L42" >}}
 {{< /tab >}}
-  {{< tab header="Python" >}}
-    # Opens a new tab and switches to new tab
-driver.switch_to.new_window('tab')
-
-    # Opens a new window and switches to new window
-driver.switch_to.new_window('window')
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L40-L43" >}}
   {{< /tab >}}
   
   {{< tab header="CSharp" text=true >}}
@@ -279,7 +242,9 @@ em vez de fechar:
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L44-L45" >}}
 {{< /tab >}}
   
-  {{< tab header="Python" >}}driver.quit(){{< /tab >}}
+  {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L13-L13" >}}
+{{< /tab >}}
   {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L45-L46" >}}
   {{< /tab >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
@@ -43,7 +43,7 @@ WebDriver 没有区分窗口和标签页。如果你的站点打开了一个新�
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
  {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L30" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L32" >}}
 {{< /tab >}}
 
  {{< tab header="CSharp" text=true >}}
@@ -135,7 +135,7 @@ wait.until(titleIs("Selenium documentation"))
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L31-L34" >}}
 {{< /tab >}}
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L35-L35" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L46-L46" >}}
 {{< /tab >}}
 
    {{< tab header="CSharp" text=true >}}
@@ -181,7 +181,7 @@ _注意: 该特性适用于 Selenium 4 及其后续版本。_
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L36-L42" >}}
 {{< /tab >}}
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L40-L43" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L53-L58" >}}
 {{< /tab >}}
   
   {{< tab header="CSharp" text=true >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/windows.zh-cn.md
@@ -16,7 +16,9 @@ WebDriver 没有区分窗口和标签页。如果你的站点打开了一个新�
   {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L16-L20" >}}
 {{< /tab >}}
-{{< tab header="Python" >}}driver.current_window_handle{{< /tab >}}
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L16-L18" >}}
+{{< /tab >}}
     {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L17-L21" >}}
   {{< /tab >}}
@@ -40,39 +42,8 @@ WebDriver 没有区分窗口和标签页。如果你的站点打开了一个新�
  {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L22-L29" >}}
 {{< /tab >}}
-{{< tab header="Python" >}}
-from selenium import webdriver
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-
-    # 启动驱动程序
-with webdriver.Firefox() as driver:
-    # 打开网址
-driver.get("https://seleniumhq.github.io")
-
-    # 设置等待
-    wait = WebDriverWait(driver, 10)
-
-    # 存储原始窗口的 ID
-    original_window = driver.current_window_handle
-
-    # 检查一下，我们还没有打开其他的窗口
-    assert len(driver.window_handles) == 1
-
-    # 单击在新窗口中打开的链接
-    driver.find_element(By.LINK_TEXT, "new window").click()
-
-    # 等待新窗口或标签页
-    wait.until(EC.number_of_windows_to_be(2))
-
-    # 循环执行，直到找到一个新的窗口句柄
-    for window_handle in driver.window_handles:
-        if window_handle != original_window:
-            driver.switch_to.window(window_handle)
-            break
-
-    # 等待新标签页完成加载内容
-    wait.until(EC.title_is("SeleniumHQ Browser Automation"))
+ {{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L22-L30" >}}
 {{< /tab >}}
 
  {{< tab header="CSharp" text=true >}}
@@ -163,12 +134,8 @@ wait.until(titleIs("Selenium documentation"))
  {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L31-L34" >}}
 {{< /tab >}}
-{{< tab header="Python" >}}
-    #关闭标签页或窗口
-driver.close()
-
-    #切回到之前的标签页或窗口
-driver.switch_to.window(original_window)
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L35-L35" >}}
 {{< /tab >}}
 
    {{< tab header="CSharp" text=true >}}
@@ -213,12 +180,8 @@ _注意: 该特性适用于 Selenium 4 及其后续版本。_
  {{< tab header="Java" text=true >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L36-L42" >}}
 {{< /tab >}}
-{{< tab header="Python" >}}
-    # 打开新标签页并切换到新标签页
-driver.switch_to.new_window('tab')
-
-    # 打开一个新窗口并切换到新窗口
-driver.switch_to.new_window('window')
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L40-L43" >}}
 {{< /tab >}}
   
   {{< tab header="CSharp" text=true >}}
@@ -261,7 +224,9 @@ driver.switchTo().newWindow(WindowType.WINDOW)
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/WindowsTest.java#L44-L45" >}}
 {{< /tab >}}
 
-{{< tab header="Python" >}}driver.quit(){{< /tab >}}
+{{< tab header="Python" text=true >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_windows.py#L13-L13" >}}
+{{< /tab >}}
   {{< tab header="CSharp" text=true >}}
   {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Interactions/WindowsTest.cs#L45-L46" >}}
   {{< /tab >}}


### PR DESCRIPTION
### Description
Moves the inline python examples for Windows interactions page to `examples/python/tests/interactions/test_windows.py`:

- Get window handle
- Switching windows or tabs
- Closing a window or tab
- Create new window (or) new tab and switch
- Quitting the browser at the end of a session

These are now referenced via the `gh-codeblock` shortcode.

### Motivation and Context
Part of ongoing effort to run all code examples in the CI by moving all inline code examples out of the documentation Markdown, as described in the "Moving examples" section of the contributing guide

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
