### PR TITLE
Add Python tab references to BiDi W3C log docs

### DIFF
--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/log.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/log.en.md
@@ -6,17 +6,17 @@ aliases: [
   "/documentation/en/webdriver/bidirectional/bidirectional_w3c/log",
 ]
 ---
-
-This section contains the APIs related to logging. 
-
+This section contains the APIs related to logging.
 ## Console logs
-
 Listen to the `console.log` events and register callbacks to process the event.
-
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L33-L39" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L7-L15" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -28,15 +28,16 @@ Listen to the `console.log` events and register callbacks to process the event.
 {{< badge-code >}}
 {{< /tab >}}
 {{< /tabpane >}}
-
 ## JavaScript exceptions
-
 Listen to the JS Exceptions
 and register callbacks to process the exception details.
-
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L73-L78" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L31-L39" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -48,15 +49,15 @@ and register callbacks to process the exception details.
 {{< badge-code >}}
 {{< /tab >}}
 {{< /tabpane >}}
-
 ## Listen to JS Logs
-
 Listen to all JS logs at all levels and register callbacks to process the log.
-
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L55-L60" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/log.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/log.ja.md
@@ -24,6 +24,10 @@ Listen to the `console.log` events and register callbacks to process the event.
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L33-L39" >}}
 {{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L7-L15" >}}
+{{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
 {{< /tab >}}
@@ -44,6 +48,10 @@ and register callbacks to process the exception details.
 {{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L73-L78" >}}
 {{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L31-L39" >}}
+{{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
 {{< /tab >}}
@@ -63,6 +71,9 @@ Listen to all JS logs at all levels and register callbacks to process the log.
 {{< tab header="Java" >}}
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L55-L60" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/log.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/log.pt-br.md
@@ -24,6 +24,10 @@ Listen to the `console.log` events and register callbacks to process the event.
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L33-L39" >}}
 {{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L7-L15" >}}
+{{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
 {{< /tab >}}
@@ -44,6 +48,10 @@ and register callbacks to process the exception details.
 {{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L73-L78" >}}
 {{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L31-L39" >}}
+{{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
 {{< /tab >}}
@@ -63,6 +71,9 @@ Listen to all JS logs at all levels and register callbacks to process the log.
 {{< tab header="Java" >}}
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L55-L60" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/log.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/log.zh-cn.md
@@ -25,6 +25,10 @@ Listen to the `console.log` events and register callbacks to process the event.
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L33-L39" >}}
 {{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L7-L15" >}}
+{{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
 {{< /tab >}}
@@ -45,6 +49,10 @@ and register callbacks to process the exception details.
 {{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L73-L78" >}}
 {{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L31-L39" >}}
+{{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
 {{< /tab >}}
@@ -64,6 +72,9 @@ Listen to all JS logs at all levels and register callbacks to process the log.
 {{< tab header="Java" >}}
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L55-L60" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/layouts/shortcodes/gh-codeblock.html
+++ b/website_and_docs/layouts/shortcodes/gh-codeblock.html
@@ -60,7 +60,7 @@ div.code-toolbar > .toolbar {
 </style>
 
 {{ if $hasFragment }}
-{{ $uniqueId := md5 $path }}
+{{ $uniqueId := md5 $fullPath }}
 <div class="mt-4 pb-2">
     <div style="border: 1px solid #dee2e6; border-radius: 6px; overflow: hidden; display: flex;">
         <a onclick="showCodeModal('{{ $uniqueId }}')" style="flex: 1; display: flex; align-items: center; justify-content: center; padding: 8px 12px; text-decoration: none; color: #007bff; background: #f8f9fa; font-weight: 500; transition: background-color 0.2s; cursor: pointer; border-right: 1px solid #dee2e6;" onmouseover="this.style.backgroundColor='#e9ecef'" onmouseout="this.style.backgroundColor='#f8f9fa'">


### PR DESCRIPTION
Closes #2642

## What this PR does
Adds Python tab references to the W3C BiDi Log documentation page.

Four files changed:
- `website_and_docs/content/documentation/webdriver/bidi/w3c/log.en.md`
- `website_and_docs/content/documentation/webdriver/bidi/w3c/log.zh-cn.md`
- `website_and_docs/content/documentation/webdriver/bidi/w3c/log.pt-br.md`
- `website_and_docs/content/documentation/webdriver/bidi/w3c/log.ja.md`

## Motivation and Context
The W3C BiDi Log page had no Python tab in any section. Python examples 
already exist in `examples/python/tests/bidi/test_bidi_logging.py` — 
this PR simply references them in the correct documentation page.

## Types of changes
- [x] Code example added
- [x] Code example added to all translated languages (zh-cn, pt-br, ja updated)
- [ ] Change to the site
- [ ] Improved translation

## Checklist
- [x] Follows existing file and naming conventions
- [x] References existing tested Python code
- [x] badge-code placeholder used honestly where no Python test exists
- [x] badge-version version="4.15" matches when driver.script API was introduced
- [x] Issue #2642 raised before this PR