### PR TITLE
add concurrency for tests and skip mac tests for PRs

### DIFF
--- a/.github/workflows/dotnet-examples.yml
+++ b/.github/workflows/dotnet-examples.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - 'examples/dotnet/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DISPLAY: :99
   GITHUB_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
@@ -25,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, windows, macos ]
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu", "windows", "macos"]') || fromJSON('["ubuntu", "windows"]') }}
         release: [ stable, nightly ]
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:

--- a/.github/workflows/java-examples.yml
+++ b/.github/workflows/java-examples.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, windows, macos ]
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu", "windows", "macos"]') || fromJSON('["ubuntu", "windows"]') }}
         release: [ stable, nightly ]
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:

--- a/.github/workflows/js-examples.yml
+++ b/.github/workflows/js-examples.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - 'examples/javascript/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DISPLAY: :99
   GITHUB_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
@@ -25,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, windows, macos ]
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu", "windows", "macos"]') || fromJSON('["ubuntu", "windows"]') }}
         release: [ stable, nightly ]
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:

--- a/.github/workflows/kotlin-examples.yml
+++ b/.github/workflows/kotlin-examples.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - 'examples/kotlin/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DISPLAY: :99
   GITHUB_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
@@ -25,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, windows, macos ]
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu", "windows", "macos"]') || fromJSON('["ubuntu", "windows"]') }}
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:
     - name: Checkout GitHub repo

--- a/.github/workflows/python-examples.yml
+++ b/.github/workflows/python-examples.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - 'examples/python/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DISPLAY: :99
   GITHUB_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
@@ -25,24 +29,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu", "windows", "macos"]') || fromJSON('["ubuntu", "windows"]') }}
+        release: [ stable, nightly ]
         include:
-        - os: ubuntu
-          release: stable
+        - release: stable
           python: '3.10'
-        - os: ubuntu
-          release: nightly
-          python: '3.14'
-        - os: windows
-          release: stable
-          python: '3.10'
-        - os: windows
-          release: nightly
-          python: '3.14'
-        - os: macos
-          release: stable
-          python: '3.10'
-        - os: macos
-          release: nightly
+        - release: nightly
           python: '3.14'
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:

--- a/.github/workflows/ruby-examples.yml
+++ b/.github/workflows/ruby-examples.yml
@@ -15,6 +15,10 @@ on:
     paths:
       - 'examples/ruby/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DISPLAY: :99
   GITHUB_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
@@ -25,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, windows, macos ]
+        os: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && fromJSON('["ubuntu", "windows", "macos"]') || fromJSON('["ubuntu", "windows"]') }}
         release: [ stable, nightly ]
     runs-on: ${{ format('{0}-latest', matrix.os) }}
     steps:


### PR DESCRIPTION
Our docs are taking all the Mac capacity for our code changes.

All the tests look to have been failing for weeks, anyway?

This PR sets concurrency limits at least so each commit to each PR doesn't run a million tests, and limits mac to only run at night or when jobs are kicked off manually. 