### PR TITLE
Fix Python options snippets for Chrome and Edge

### DIFF
--- a/examples/python/tests/browsers/test_chrome.py
+++ b/examples/python/tests/browsers/test_chrome.py
@@ -6,7 +6,7 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 def test_basic_options():
-    options = get_default_chrome_options()
+    options = webdriver.ChromeOptions()
     driver = webdriver.Chrome(options=options)
 
     driver.quit()

--- a/examples/python/tests/browsers/test_edge.py
+++ b/examples/python/tests/browsers/test_edge.py
@@ -6,7 +6,7 @@ from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 def test_basic_options():
-    options = get_default_edge_options()
+    options = webdriver.EdgeOptions()
 
     driver = webdriver.Edge(options=options)
 

--- a/examples/python/tests/browsers/test_edge.py
+++ b/examples/python/tests/browsers/test_edge.py
@@ -7,7 +7,6 @@ from selenium.webdriver.common.by import By
 
 def test_basic_options():
     options = webdriver.EdgeOptions()
-
     driver = webdriver.Edge(options=options)
 
     driver.quit()


### PR DESCRIPTION
Replace internal helper usage in the Python basic options examples with explicit webdriver.ChromeOptions() and webdriver.EdgeOptions() so generated docs show runnable user-facing code.

Fixes #2621

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
