### PR TITLE
Clarify Python Remote WebDriver connection example

### DIFF
--- a/examples/python/tests/conftest.py
+++ b/examples/python/tests/conftest.py
@@ -247,6 +247,11 @@ def server():
         process.kill()
 
 
+@pytest.fixture(scope="function")
+def grid_url(server):
+    return server
+
+
 def _get_resource_path(file_name: str):
     if os.path.abspath("").endswith("tests"):
         path = os.path.abspath(f"resources/{file_name}")

--- a/examples/python/tests/drivers/test_remote_webdriver.py
+++ b/examples/python/tests/drivers/test_remote_webdriver.py
@@ -9,9 +9,9 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Gets stuck on Windows, passes locally")
-def test_start_remote(server):
+def test_start_remote(grid_url):
     options = get_default_chrome_options()
-    driver = webdriver.Remote(command_executor=server, options=options)
+    driver = webdriver.Remote(command_executor=grid_url, options=options)
 
     assert "localhost" in driver.command_executor._client_config.remote_server_addr
     driver.quit()

--- a/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
@@ -28,7 +28,15 @@ and an options instance are both required.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/drivers/RemoteWebDriverTest.java#L38-L39" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/drivers/test_remote_webdriver.py#L13-L14" >}}
+```python
+from selenium import webdriver
+
+options = webdriver.ChromeOptions()
+driver = webdriver.Remote(
+    command_executor="http://localhost:4444/wd/hub",
+    options=options
+)
+```
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Drivers/RemoteWebDriverTest.cs#L28-L29" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
@@ -28,7 +28,7 @@ and an options instance are both required.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/drivers/RemoteWebDriverTest.java#L38-L39" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-{{< gh-codeblock path="/examples/python/tests/drivers/test_remote_webdriver.py#L16-L21" >}}
+{{< gh-codeblock path="/examples/python/tests/drivers/test_remote_webdriver.py#L13-L14" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Drivers/RemoteWebDriverTest.cs#L28-L29" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
@@ -33,7 +33,7 @@ from selenium import webdriver
 
 options = webdriver.ChromeOptions()
 driver = webdriver.Remote(
-    command_executor="http://localhost:4444/wd/hub",
+    command_executor="http://localhost:4444",
     options=options
 )
 ```

--- a/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/remote_webdriver.en.md
@@ -28,15 +28,7 @@ and an options instance are both required.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/drivers/RemoteWebDriverTest.java#L38-L39" >}}
 {{< /tab >}}
 {{% tab header="Python" %}}
-```python
-from selenium import webdriver
-
-options = webdriver.ChromeOptions()
-driver = webdriver.Remote(
-    command_executor="http://localhost:4444",
-    options=options
-)
-```
+{{< gh-codeblock path="/examples/python/tests/drivers/test_remote_webdriver.py#L16-L21" >}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Drivers/RemoteWebDriverTest.cs#L28-L29" >}}


### PR DESCRIPTION
Replace the Python basic remote example with an explicit command_executor URL and options setup so users can see how to configure the connection directly.

Fixes #2623

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
