### PR TITLE
Add Python examples for BiDi network intercept commands

### DIFF
--- a/examples/python/tests/bidi/test_network_commands.py
+++ b/examples/python/tests/bidi/test_network_commands.py
@@ -1,4 +1,5 @@
 import pytest
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.wait import WebDriverWait
 
 
@@ -41,9 +42,10 @@ def test_fail_request(driver):
         request.fail_request()
 
     driver.network.add_request_handler("before_request", fail_request)
-    driver.get("https://www.selenium.dev/selenium/web/bidi/logEntryAdded.html")
-
-    assert blocked_requests
+    driver.set_page_load_timeout(5)
+    with pytest.raises(TimeoutException):
+        driver.get("https://www.selenium.dev/selenium/web/bidi/logEntryAdded.html")
+    WebDriverWait(driver, 5).until(lambda _: blocked_requests)
 
 
 @pytest.mark.driver_type("bidi")

--- a/examples/python/tests/bidi/test_network_commands.py
+++ b/examples/python/tests/bidi/test_network_commands.py
@@ -1,0 +1,65 @@
+import pytest
+from selenium.webdriver.support.wait import WebDriverWait
+
+
+@pytest.mark.driver_type("bidi")
+def test_add_intercept(driver):
+    requests = []
+
+    def capture_request(request):
+        requests.append(request.request_id)
+        request.continue_request()
+
+    callback_id = driver.network.add_request_handler("before_request", capture_request)
+    driver.get("https://www.selenium.dev/selenium/web/bidi/logEntryAdded.html")
+
+    WebDriverWait(driver, 5).until(lambda _: requests)
+    assert callback_id is not None
+
+
+@pytest.mark.driver_type("bidi")
+def test_remove_intercept(driver):
+    requests = []
+
+    def capture_request(request):
+        requests.append(request.request_id)
+        request.continue_request()
+
+    callback_id = driver.network.add_request_handler("before_request", capture_request)
+    driver.network.remove_request_handler("before_request", callback_id)
+
+    driver.get("https://www.selenium.dev/selenium/web/blank.html")
+    assert not requests
+
+
+@pytest.mark.driver_type("bidi")
+def test_fail_request(driver):
+    blocked_requests = []
+
+    def fail_request(request):
+        blocked_requests.append(request.request_id)
+        request.fail_request()
+
+    driver.network.add_request_handler("before_request", fail_request)
+    driver.get("https://www.selenium.dev/selenium/web/bidi/logEntryAdded.html")
+
+    assert blocked_requests
+
+
+@pytest.mark.driver_type("bidi")
+def test_add_and_remove_request_handler(driver):
+    requests = []
+
+    def capture_request(request):
+        requests.append(request.request_id)
+        request.continue_request()
+
+    callback_id = driver.network.add_request_handler("before_request", capture_request)
+    driver.get("https://www.selenium.dev/selenium/web/bidi/logEntryAdded.html")
+    WebDriverWait(driver, 5).until(lambda _: requests)
+
+    requests.clear()
+    driver.network.remove_request_handler("before_request", callback_id)
+
+    driver.get("https://www.selenium.dev/selenium/web/blank.html")
+    assert not requests

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
@@ -17,6 +17,10 @@ This section contains the APIs related to network commands.
 {{< badge-version version="4.18" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L36-L38" >}}
 {{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.41" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L13-L14" >}}
+{{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
 {{< /tab >}}
@@ -35,6 +39,10 @@ This section contains the APIs related to network commands.
 {{< tab header="Java" >}}
 {{< badge-version version="4.18" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L46-L50" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.41" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L28-L30" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -111,6 +119,10 @@ This section contains the APIs related to network commands.
 {{< tab header="Java" >}}
 {{< badge-version version="4.18" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L104-L108" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.41" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L44" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
@@ -19,7 +19,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.41" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L13-L14" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L9-L14" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -42,7 +42,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.41" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L28-L30" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L25-L30" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -122,7 +122,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.41" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L44" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L48" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}


### PR DESCRIPTION
Add Python examples for add/remove intercept and fail request in W3C BiDi Network docs and reference them from the documentation page.

Fixes #2638

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
