### PR TITLE
Add Python examples to W3C BiDi log docs

### DIFF
--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/log.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/log.en.md
@@ -18,6 +18,10 @@ Listen to the `console.log` events and register callbacks to process the event.
 {{< badge-version version="4.8" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L33-L39" >}}
 {{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.41" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L11-L15" >}}
+{{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
 {{< /tab >}}
@@ -37,6 +41,10 @@ and register callbacks to process the exception details.
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/LogTest.java#L73-L78" >}}
+{{< /tab >}}
+{{< tab header="Python" >}}
+{{< badge-version version="4.41" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L35-L39" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/log.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/log.en.md
@@ -20,7 +20,7 @@ Listen to the `console.log` events and register callbacks to process the event.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.41" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L11-L15" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L7-L15" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -44,7 +44,7 @@ and register callbacks to process the exception details.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.41" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L35-L39" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_bidi_logging.py#L31-L39" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}


### PR DESCRIPTION
Add Python tabs for console logs and JavaScript exceptions in W3C BiDi log documentation using existing examples/python/tests/bidi/test_bidi_logging.py snippets.

Fixes #2642

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
