### PR TITLE
Fix 'separately' typo in locator docs

### DIFF
--- a/website_and_docs/content/documentation/webdriver/elements/locators.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.en.md
@@ -382,7 +382,7 @@ and then a child element of that parent, you can instead combine those two `Find
 
 The `ByAll` class enables you to utilize two By locators at once, finding elements that mach _either_ of your By locators. 
 For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields 
-seperately, you can instead find them together in one clean `FindElements()`
+separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.en.md
@@ -380,7 +380,7 @@ and then a child element of that parent, you can instead combine those two `Find
 
 ### ByAll
 
-The `ByAll` class enables you to utilize two By locators at once, finding elements that mach _either_ of your By locators. 
+The `ByAll` class enables you to utilize two By locators at once, finding elements that match _either_ of your By locators. 
 For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields 
 separately, you can instead find them together in one clean `FindElements()`
 

--- a/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
@@ -371,7 +371,7 @@ functions into one.
 
 ### ByAll
 
-The `ByAll` class enables you to utilize two By locators at once, finding elements that mach _either_ of your By locators. 
+The `ByAll` class enables you to utilize two By locators at once, finding elements that match _either_ of your By locators. 
 For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields separately, 
 you can instead find them together in one clean `FindElements()`
 

--- a/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
@@ -372,7 +372,7 @@ functions into one.
 ### ByAll
 
 The `ByAll` class enables you to utilize two By locators at once, finding elements that mach _either_ of your By locators. 
-For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields seperately, 
+For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields separately, 
 you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
@@ -376,7 +376,7 @@ combine those two `FindElement` functions into one.
 
 The `ByAll` class enables you to utilize two By locators at once, finding elements that mach _either_ of your By locators. 
 For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields 
-seperately, you can instead find them together in one clean `FindElements()`
+separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
@@ -374,7 +374,7 @@ combine those two `FindElement` functions into one.
 
 ### ByAll
 
-The `ByAll` class enables you to utilize two By locators at once, finding elements that mach _either_ of your By locators. 
+The `ByAll` class enables you to utilize two By locators at once, finding elements that match _either_ of your By locators. 
 For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields 
 separately, you can instead find them together in one clean `FindElements()`
 

--- a/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
@@ -374,7 +374,7 @@ you can instead combine those two `FindElement` functions into one.
 
 ### ByAll
 
-The `ByAll` class enables you to utilize two By locators at once, finding elements that mach _either_ of your By locators. 
+The `ByAll` class enables you to utilize two By locators at once, finding elements that match _either_ of your By locators. 
 For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields 
 separately, you can instead find them together in one clean `FindElements()`
 

--- a/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
@@ -376,7 +376,7 @@ you can instead combine those two `FindElement` functions into one.
 
 The `ByAll` class enables you to utilize two By locators at once, finding elements that mach _either_ of your By locators. 
 For example, instead of having to utilize two `FindElement()` functions to find the username and password input fields 
-seperately, you can instead find them together in one clean `FindElements()`
+separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}


### PR DESCRIPTION
Correct misspelling of 'separately' in WebDriver locators documentation across English, Japanese, Portuguese, and Chinese files for consistency.

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
