### PR TITLE
fix: correct typo in "Downloading a file" section across multiple language documentation files

### DIFF
--- a/website_and_docs/content/documentation/grid/configuration/cli_options.en.md
+++ b/website_and_docs/content/documentation/grid/configuration/cli_options.en.md
@@ -456,7 +456,7 @@ options.setCapability("se:downloadsEnabled", true);
 In the response the list of file names appear under the key `names`.
 
 
-##### Dowloading a file:
+##### Downloading a file:
 
 * The endpoint to `POST` from is `/session/<sessionId>/se/files` with a payload of the form `{"name": "fileNameGoesHere}`
 * The session needs to be active in order for the command to work.

--- a/website_and_docs/content/documentation/grid/configuration/cli_options.ja.md
+++ b/website_and_docs/content/documentation/grid/configuration/cli_options.ja.md
@@ -416,7 +416,7 @@ options.setCapability("se:downloadsEnabled", true);
 In the response the list of file names appear under the key `names`.
 
 
-##### Dowloading a file:
+##### Downloading a file:
 
 * The endpoint to `POST` from is `/session/<sessionId>/se/files` with a payload of the form `{"name": "fileNameGoesHere}`
 * The session needs to be active in order for the command to work.

--- a/website_and_docs/content/documentation/grid/configuration/cli_options.pt-br.md
+++ b/website_and_docs/content/documentation/grid/configuration/cli_options.pt-br.md
@@ -419,7 +419,7 @@ options.setCapability("se:downloadsEnabled", true);
 In the response the list of file names appear under the key `names`.
 
 
-##### Dowloading a file:
+##### Downloading a file:
 
 * The endpoint to `POST` from is `/session/<sessionId>/se/files` with a payload of the form `{"name": "fileNameGoesHere}`
 * The session needs to be active in order for the command to work.

--- a/website_and_docs/content/documentation/grid/configuration/cli_options.zh-cn.md
+++ b/website_and_docs/content/documentation/grid/configuration/cli_options.zh-cn.md
@@ -425,7 +425,7 @@ options.setCapability("se:downloadsEnabled", true);
 In the response the list of file names appear under the key `names`.
 
 
-##### Dowloading a file:
+##### Downloading a file:
 
 * The endpoint to `POST` from is `/session/<sessionId>/se/files` with a payload of the form `{"name": "fileNameGoesHere}`
 * The session needs to be active in order for the command to work.


### PR DESCRIPTION
### Description
  Corrected a typo in the "Downloading a file" heading in the Grid CLI options documentation.

  Updated the same typo from `Dowloading` to `Downloading` across the English, Japanese, Portuguese (Brazil), and Chinese documentation files.

  ### Motivation and Context
  This fixes a small spelling error in the documentation heading and keeps the translated documentation files consistent with the English version.

  ### Types of changes
  - [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
  - [ ] Code example added (and I also added the example to all translated languages)
  - [x] Improved translation
  - [ ] Added new translation (and I also added a notice to each document missing translation)

  ### Checklist
  - [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
  - [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.