### PR TITLE
Translate Japanese homepage read-more links

### DIFF
--- a/website_and_docs/content/_index.ja.html
+++ b/website_and_docs/content/_index.ja.html
@@ -20,17 +20,17 @@ linkTitle = "Selenium"
 
 {{< getting-started color="100" height="auto" title="入門" >}}
 
-{{% getting-started-item icon="icons/webdriver.svg" title="Selenium WebDriver" color="selenium-webdriver" url="/ja/documentation/webdriver/" url_text="Read more" %}}
+{{% getting-started-item icon="icons/webdriver.svg" title="Selenium WebDriver" color="selenium-webdriver" url="/ja/documentation/webdriver/" url_text="続きを読む" %}}
 堅牢なブラウザーベースの回帰自動化スイートとテストを作成し、スクリプトをスケーリングして多くの環境に分散する場合は、
 言語固有のバインディングのコレクションであるSeleniumWebDriverを使用して意図した操作でブラウザーを駆動します。
 {{% /getting-started-item %}}
 
-{{% getting-started-item icon="icons/ide.svg" title="Selenium IDE" color="selenium-ide" url="https://selenium.dev/selenium-ide/" url_text="Read more" %}}
+{{% getting-started-item icon="icons/ide.svg" title="Selenium IDE" color="selenium-ide" url="https://selenium.dev/selenium-ide/" url_text="続きを読む" %}}
 迅速なバグ再現スクリプトを作成したい場合、自動化支援の探索的テストを支援するスクリプトを作成したい場合は、SeleniumIDEを使用します。
 Chrome、Firefox、Edgeのアドオンがブラウザとの対話の簡単な記録と再生を行います。
 {{% /getting-started-item %}}
 
-{{% getting-started-item icon="icons/grid.svg" title="Selenium Grid" color="selenium-grid" url="/ja/documentation/grid/" url_text="Read more" %}}
+{{% getting-started-item icon="icons/grid.svg" title="Selenium Grid" color="selenium-grid" url="/ja/documentation/grid/" url_text="続きを読む" %}}
 複数のマシンでテストを分散して実行し、複数の環境を中央から管理して、
 ブラウザーとOSの膨大な組み合わせに対してテストを簡単に実行できるようにすることでスケーリングしたい場合は、
 SeleniumGridを使用します。


### PR DESCRIPTION
 ### Description

  This PR updates the Japanese homepage to translate the "Read more" link text to "続きを読む" for the WebDriver, IDE, and Grid sections.

  ### Motivation and Context

  The Japanese homepage still had English link text in the getting started section. This improves consistency for Japanese readers.

  ### Types of changes

  - [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
  - [ ] Code example added (and I also added the example to all translated languages)
  - [x] Improved translation
  - [ ] Added new translation (and I also added a notice to each document missing translation)

  ### Checklist

  - [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
  - [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.