### PR TITLE
Remove duplicate front matter keys from Japanese legacy docs

### DIFF
--- a/website_and_docs/content/documentation/legacy/selenium_2/upgrading.ja.md
+++ b/website_and_docs/content/documentation/legacy/selenium_2/upgrading.ja.md
@@ -6,8 +6,6 @@ aliases: [
 "/documentation/ja/legacy_docs/migrating_from_rc_to_webdriver/",
 "/ja/documentation/legacy/migrating_from_rc_to_webdriver/"
 ]
-
-aliases: []
 ---
 
 

--- a/website_and_docs/content/documentation/legacy/selenium_3/_index.ja.md
+++ b/website_and_docs/content/documentation/legacy/selenium_3/_index.ja.md
@@ -3,7 +3,6 @@ title: "Selenium 3"
 linkTitle: "Selenium 3"
 weight: 6
 description: >
-description: >
   Selenium 3 was the implementation of WebDriver without the Selenium RC Code.
   It has since been replaced with Selenium 4, which implements the W3C WebDriver specification.
 ---


### PR DESCRIPTION
  ### Description

  Removes duplicate front matter keys from two Japanese legacy documentation pages:

  - `aliases` in the Selenium 2 upgrading page
  - `description` in the Selenium 3 index page

  ### Motivation and Context

  These duplicated front matter keys can make the page metadata ambiguous and may cause Hugo to warn or behave unexpectedly when rendering the documentation. This
  keeps the Japanese legacy docs front matter valid and consistent.

  ### Types of changes

  - [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
  - [ ] Code example added (and I also added the example to all translated languages)
  - [ ] Improved translation
  - [ ] Added new translation (and I also added a notice to each document missing translation)

  ### Checklist

  - [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
  - [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.