### PR TITLE
Fix waits link text in Japanese first script docs

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
@@ -102,7 +102,7 @@ Seleniumを使用して、それをうまく行うことは高度なトピック
 暗黙的な待機が最善の解決策になることはめったにありませんが、ここで示すのが最も簡単なので、
 プレースホルダーとして使用します。
 
-[待機戦略] についてさらに読む({{< ref "/documentation/webdriver/waits.md" >}}).
+[待機戦略]({{< ref "/documentation/webdriver/waits.md" >}})についてさらに読む。
 
 {{< tabpane text=true >}}
 {{< tab header="Java" >}}


### PR DESCRIPTION
  ### Description

  Fixes the Japanese sentence that links to the WebDriver waits documentation in the “First script” page.

  The link markdown was malformed, so this updates it to correctly wrap the “待機戦略” text and adjusts the sentence punctuation to natural Japanese.

  ### Motivation and Context

  The previous Japanese text did not render the waits documentation link correctly. This change makes the link usable and improves the readability of the translated
  sentence.

  ### Types of changes

  - [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
  - [ ] Code example added (and I also added the example to all translated languages)
  - [x] Improved translation
  - [ ] Added new translation (and I also added a notice to each document missing translation)

  ### Checklist

  - [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
  - [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.