### PR TITLE
Fix typos in IE driver server docs

### DIFF
--- a/website_and_docs/content/documentation/ie_driver_server/_index.en.md
+++ b/website_and_docs/content/documentation/ie_driver_server/_index.en.md
@@ -154,7 +154,7 @@ There are 2 solutions for problem with cookies (and another session items) share
 multiple instances of InternetExplorer.
 
 The first is to start your InternetExplorer in private mode. After that InternetExplorer will be 
-started with clean session data and will not save changed session data at quiting. To do so you 
+started with clean session data and will not save changed session data at quitting. To do so you 
 need to pass 2 specific capabilities to driver: `ie.forceCreateProcessApi` with `true` value 
 and `ie.browserCommandLineSwitches` with `-private` value. Be note that it will work only 
 for InternetExplorer 8 and newer, and Windows Registry 

--- a/website_and_docs/content/documentation/ie_driver_server/internals.en.md
+++ b/website_and_docs/content/documentation/ie_driver_server/internals.en.md
@@ -8,7 +8,7 @@ description: >
 
 ## Client Code Into the Driver
 
-We use the W3C WebDriver protocol to communicate with a local instance of an HTTP server. This greatly simplifies the implementation of the language-specific code, and minimzes the number of entry points into the C++ DLL that must be called using a native-code interop technology such as [JNA](https://jna.dev.java.net/), [ctypes](http://docs.python.org/library/ctypes.html), [pinvoke](http://msdn.microsoft.com/en-us/library/aa446536.aspx) or [DL](http://www.ruby-doc.org/stdlib/libdoc/dl/rdoc/index.html).
+We use the W3C WebDriver protocol to communicate with a local instance of an HTTP server. This greatly simplifies the implementation of the language-specific code, and minimizes the number of entry points into the C++ DLL that must be called using a native-code interop technology such as [JNA](https://jna.dev.java.net/), [ctypes](http://docs.python.org/library/ctypes.html), [pinvoke](http://msdn.microsoft.com/en-us/library/aa446536.aspx) or [DL](http://www.ruby-doc.org/stdlib/libdoc/dl/rdoc/index.html).
 
 ### Memory Management
 
@@ -20,7 +20,7 @@ IE 7 on Windows Vista introduced the concept of Protected Mode, which allows for
 
 In IE 7, this will usually manifest itself as a new top-level browser window; in IE 8, a new IExplore.exe process will be created, but it will usually (not always!) seamlessly attach it to the existing IE top-level frame window. Any browser automation framework that drives IE externally (as opposed to using a WebBrowser control) will run into these problems.
 
-In order to work around that problem, we dictate that to work with IE, all zones must have the same Protected Mode setting. As long as it's on for all zones, or off for all zones, we can prevent the transistions to different Protected Mode zones that would invalidate our browser object. It also allows users to continue to run with UAC turned on, and to run securely in the browser if they set Protected Mode "on" for all zones.
+In order to work around that problem, we dictate that to work with IE, all zones must have the same Protected Mode setting. As long as it's on for all zones, or off for all zones, we can prevent the transitions to different Protected Mode zones that would invalidate our browser object. It also allows users to continue to run with UAC turned on, and to run securely in the browser if they set Protected Mode "on" for all zones.
 
 In earlier releases of the IE driver, if the user's Protected Mode settings were not correctly set, we would launch IE, and the process would simply hang until the HTTP request timed out. This was suboptimal, as it gave no indication what needed to be set. Erring on the side of caution, we do not modify the user's Protected Mode settings. Current versions, however check that the Protected Mode settings are properly set, and will return an error response if they are not.
 

--- a/website_and_docs/content/documentation/ie_driver_server/internals.ja.md
+++ b/website_and_docs/content/documentation/ie_driver_server/internals.ja.md
@@ -9,7 +9,7 @@ description: >
 
 ## Client Code Into the Driver
 
-We use the W3C WebDriver protocol to communicate with a local instance of an HTTP server. This greatly simplifies the implementation of the language-specific code, and minimzes the number of entry points into the C++ DLL that must be called using a native-code interop technology such as [JNA](https://jna.dev.java.net/), [ctypes](http://docs.python.org/library/ctypes.html), [pinvoke](http://msdn.microsoft.com/en-us/library/aa446536.aspx) or [DL](http://www.ruby-doc.org/stdlib/libdoc/dl/rdoc/index.html).
+We use the W3C WebDriver protocol to communicate with a local instance of an HTTP server. This greatly simplifies the implementation of the language-specific code, and minimizes the number of entry points into the C++ DLL that must be called using a native-code interop technology such as [JNA](https://jna.dev.java.net/), [ctypes](http://docs.python.org/library/ctypes.html), [pinvoke](http://msdn.microsoft.com/en-us/library/aa446536.aspx) or [DL](http://www.ruby-doc.org/stdlib/libdoc/dl/rdoc/index.html).
 
 ### Memory Management
 
@@ -21,7 +21,7 @@ IE 7 on Windows Vista introduced the concept of Protected Mode, which allows for
 
 In IE 7, this will usually manifest itself as a new top-level browser window; in IE 8, a new IExplore.exe process will be created, but it will usually (not always!) seamlessly attach it to the existing IE top-level frame window. Any browser automation framework that drives IE externally (as opposed to using a WebBrowser control) will run into these problems.
 
-In order to work around that problem, we dictate that to work with IE, all zones must have the same Protected Mode setting. As long as it's on for all zones, or off for all zones, we can prevent the transistions to different Protected Mode zones that would invalidate our browser object. It also allows users to continue to run with UAC turned on, and to run securely in the browser if they set Protected Mode "on" for all zones.
+In order to work around that problem, we dictate that to work with IE, all zones must have the same Protected Mode setting. As long as it's on for all zones, or off for all zones, we can prevent the transitions to different Protected Mode zones that would invalidate our browser object. It also allows users to continue to run with UAC turned on, and to run securely in the browser if they set Protected Mode "on" for all zones.
 
 In earlier releases of the IE driver, if the user's Protected Mode settings were not correctly set, we would launch IE, and the process would simply hang until the HTTP request timed out. This was suboptimal, as it gave no indication what needed to be set. Erring on the side of caution, we do not modify the user's Protected Mode settings. Current versions, however check that the Protected Mode settings are properly set, and will return an error response if they are not.
 

--- a/website_and_docs/content/documentation/ie_driver_server/internals.pt-br.md
+++ b/website_and_docs/content/documentation/ie_driver_server/internals.pt-br.md
@@ -9,7 +9,7 @@ description: >
 
 ## Client Code Into the Driver
 
-We use the W3C WebDriver protocol to communicate with a local instance of an HTTP server. This greatly simplifies the implementation of the language-specific code, and minimzes the number of entry points into the C++ DLL that must be called using a native-code interop technology such as [JNA](https://jna.dev.java.net/), [ctypes](http://docs.python.org/library/ctypes.html), [pinvoke](http://msdn.microsoft.com/en-us/library/aa446536.aspx) or [DL](http://www.ruby-doc.org/stdlib/libdoc/dl/rdoc/index.html).
+We use the W3C WebDriver protocol to communicate with a local instance of an HTTP server. This greatly simplifies the implementation of the language-specific code, and minimizes the number of entry points into the C++ DLL that must be called using a native-code interop technology such as [JNA](https://jna.dev.java.net/), [ctypes](http://docs.python.org/library/ctypes.html), [pinvoke](http://msdn.microsoft.com/en-us/library/aa446536.aspx) or [DL](http://www.ruby-doc.org/stdlib/libdoc/dl/rdoc/index.html).
 
 ### Memory Management
 
@@ -21,7 +21,7 @@ IE 7 on Windows Vista introduced the concept of Protected Mode, which allows for
 
 In IE 7, this will usually manifest itself as a new top-level browser window; in IE 8, a new IExplore.exe process will be created, but it will usually (not always!) seamlessly attach it to the existing IE top-level frame window. Any browser automation framework that drives IE externally (as opposed to using a WebBrowser control) will run into these problems.
 
-In order to work around that problem, we dictate that to work with IE, all zones must have the same Protected Mode setting. As long as it's on for all zones, or off for all zones, we can prevent the transistions to different Protected Mode zones that would invalidate our browser object. It also allows users to continue to run with UAC turned on, and to run securely in the browser if they set Protected Mode "on" for all zones.
+In order to work around that problem, we dictate that to work with IE, all zones must have the same Protected Mode setting. As long as it's on for all zones, or off for all zones, we can prevent the transitions to different Protected Mode zones that would invalidate our browser object. It also allows users to continue to run with UAC turned on, and to run securely in the browser if they set Protected Mode "on" for all zones.
 
 In earlier releases of the IE driver, if the user's Protected Mode settings were not correctly set, we would launch IE, and the process would simply hang until the HTTP request timed out. This was suboptimal, as it gave no indication what needed to be set. Erring on the side of caution, we do not modify the user's Protected Mode settings. Current versions, however check that the Protected Mode settings are properly set, and will return an error response if they are not.
 

--- a/website_and_docs/content/documentation/ie_driver_server/internals.zh-cn.md
+++ b/website_and_docs/content/documentation/ie_driver_server/internals.zh-cn.md
@@ -9,7 +9,7 @@ description: >
 
 ## Client Code Into the Driver
 
-We use the W3C WebDriver protocol to communicate with a local instance of an HTTP server. This greatly simplifies the implementation of the language-specific code, and minimzes the number of entry points into the C++ DLL that must be called using a native-code interop technology such as [JNA](https://jna.dev.java.net/), [ctypes](http://docs.python.org/library/ctypes.html), [pinvoke](http://msdn.microsoft.com/en-us/library/aa446536.aspx) or [DL](http://www.ruby-doc.org/stdlib/libdoc/dl/rdoc/index.html).
+We use the W3C WebDriver protocol to communicate with a local instance of an HTTP server. This greatly simplifies the implementation of the language-specific code, and minimizes the number of entry points into the C++ DLL that must be called using a native-code interop technology such as [JNA](https://jna.dev.java.net/), [ctypes](http://docs.python.org/library/ctypes.html), [pinvoke](http://msdn.microsoft.com/en-us/library/aa446536.aspx) or [DL](http://www.ruby-doc.org/stdlib/libdoc/dl/rdoc/index.html).
 
 ### Memory Management
 
@@ -21,7 +21,7 @@ IE 7 on Windows Vista introduced the concept of Protected Mode, which allows for
 
 In IE 7, this will usually manifest itself as a new top-level browser window; in IE 8, a new IExplore.exe process will be created, but it will usually (not always!) seamlessly attach it to the existing IE top-level frame window. Any browser automation framework that drives IE externally (as opposed to using a WebBrowser control) will run into these problems.
 
-In order to work around that problem, we dictate that to work with IE, all zones must have the same Protected Mode setting. As long as it's on for all zones, or off for all zones, we can prevent the transistions to different Protected Mode zones that would invalidate our browser object. It also allows users to continue to run with UAC turned on, and to run securely in the browser if they set Protected Mode "on" for all zones.
+In order to work around that problem, we dictate that to work with IE, all zones must have the same Protected Mode setting. As long as it's on for all zones, or off for all zones, we can prevent the transitions to different Protected Mode zones that would invalidate our browser object. It also allows users to continue to run with UAC turned on, and to run securely in the browser if they set Protected Mode "on" for all zones.
 
 In earlier releases of the IE driver, if the user's Protected Mode settings were not correctly set, we would launch IE, and the process would simply hang until the HTTP request timed out. This was suboptimal, as it gave no indication what needed to be set. Erring on the side of caution, we do not modify the user's Protected Mode settings. Current versions, however check that the Protected Mode settings are properly set, and will return an error response if they are not.
 


### PR DESCRIPTION
  ### Description
  Fixes a few typos in the IE Driver Server documentation:

  - `quiting` -> `quitting`
  - `minimzes` -> `minimizes`
  - `transistions` -> `transitions`

  The same typo fixes were applied to the matching localized IE Driver Server internals pages where the English text is currently shared.

  ### Motivation and Context
  These are small documentation cleanup changes to improve readability and polish. No behavior, examples, or site layout are changed.

  ### Types of changes
  - [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
  - [ ] Code example added (and I also added the example to all translated languages)
  - [x] Improved translation
  - [ ] Added new translation (and I also added a notice to each document missing translation)

  ### Checklist
  - [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
  - [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.