### PR TITLE
Translate remaining Japanese contributing docs text

### DIFF
--- a/website_and_docs/content/documentation/about/contributing.ja.md
+++ b/website_and_docs/content/documentation/about/contributing.ja.md
@@ -63,10 +63,10 @@ Seleniumのすべてのコンポーネントは、時間の経過とともに非
 ページにテストを追加する場合は、Markdownファイル内の他のすべての行番号が正しいことを確認してください。
 ページの先頭にテストを追加すると、そのファイルの行番号を持つドキュメント内のすべての参照が更新されます。
 
-Code examples may need a relevant website or web page to demonstrate the scenario. To ensure examples consistently work,
-it is recommended to use the test web pages available at https://www.selenium.dev/selenium/web/.
+コード例では、シナリオを示すために関連するWebサイトやWebページが必要になる場合があります。
+例が安定して動作するように、https://www.selenium.dev/selenium/web/ で利用できるテスト用Webページを使用することを推奨します。
 
-最後に、CIでテストがPassすることを確認してください。
+最後に、CIでテストがパスすることを確認してください。
 
 
 ### 例の移動


### PR DESCRIPTION
  ### Description
  Translated the remaining English sentence in the Japanese contributing documentation.

  Also updated `Pass` to `パス` for consistency with the surrounding Japanese text.

  ### Motivation and Context
  The Japanese contributing page still had a short untranslated paragraph about using Selenium test web pages for code examples. This change improves translation completeness and
  readability for Japanese readers.

  ### Types of changes
  - [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
  - [ ] Code example added (and I also added the example to all translated languages)
  - [x] Improved translation
  - [ ] Added new translation (and I also added a notice to each document missing translation)

  ### Checklist
  - [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
  - [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.