### PR TITLE
Fix typos in page object model docs

### DIFF
--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.en.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.en.md
@@ -466,7 +466,7 @@ public class LoginPage {
     // The login page allows the user to submit the login form
     public HomePage submitLogin() {
         // This is the only place that submits the login form and expects the destination to be the home page.
-        // A seperate method should be created for the instance of clicking login whilst expecting a login failure. 
+        // A separate method should be created for the instance of clicking login whilst expecting a login failure. 
         driver.findElement(loginButtonLocator).submit();
 
         // Return a new page object representing the destination. Should the login page ever
@@ -480,7 +480,7 @@ public class LoginPage {
         // This is the only place that submits the login form and expects the destination to be the login page due to login failure.
         driver.findElement(loginButtonLocator).submit();
 
-        // Return a new page object representing the destination. Should the user ever be navigated to the home page after submiting a login with credentials 
+        // Return a new page object representing the destination. Should the user ever be navigated to the home page after submitting a login with credentials 
         // expected to fail login, the script will fail when it attempts to instantiate the LoginPage PageObject.
         return new LoginPage(driver);	
     }

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.ja.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.ja.md
@@ -467,7 +467,7 @@ public class LoginPage {
     // The login page allows the user to submit the login form
     public HomePage submitLogin() {
         // This is the only place that submits the login form and expects the destination to be the home page.
-        // A seperate method should be created for the instance of clicking login whilst expecting a login failure. 
+        // A separate method should be created for the instance of clicking login whilst expecting a login failure. 
         driver.findElement(loginButtonLocator).submit();
 
         // Return a new page object representing the destination. Should the login page ever
@@ -481,7 +481,7 @@ public class LoginPage {
         // This is the only place that submits the login form and expects the destination to be the login page due to login failure.
         driver.findElement(loginButtonLocator).submit();
 
-        // Return a new page object representing the destination. Should the user ever be navigated to the home page after submiting a login with credentials 
+        // Return a new page object representing the destination. Should the user ever be navigated to the home page after submitting a login with credentials 
         // expected to fail login, the script will fail when it attempts to instantiate the LoginPage PageObject.
         return new LoginPage(driver);	
     }

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.pt-br.md
@@ -467,7 +467,7 @@ public class LoginPage {
     // The login page allows the user to submit the login form
     public HomePage submitLogin() {
         // This is the only place that submits the login form and expects the destination to be the home page.
-        // A seperate method should be created for the instance of clicking login whilst expecting a login failure. 
+        // A separate method should be created for the instance of clicking login whilst expecting a login failure. 
         driver.findElement(loginButtonLocator).submit();
 
         // Return a new page object representing the destination. Should the login page ever
@@ -481,7 +481,7 @@ public class LoginPage {
         // This is the only place that submits the login form and expects the destination to be the login page due to login failure.
         driver.findElement(loginButtonLocator).submit();
 
-        // Return a new page object representing the destination. Should the user ever be navigated to the home page after submiting a login with credentials 
+        // Return a new page object representing the destination. Should the user ever be navigated to the home page after submitting a login with credentials 
         // expected to fail login, the script will fail when it attempts to instantiate the LoginPage PageObject.
         return new LoginPage(driver);	
     }

--- a/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/encouraged/page_object_models.zh-cn.md
@@ -467,7 +467,7 @@ public class LoginPage {
     // The login page allows the user to submit the login form
     public HomePage submitLogin() {
         // This is the only place that submits the login form and expects the destination to be the home page.
-        // A seperate method should be created for the instance of clicking login whilst expecting a login failure. 
+        // A separate method should be created for the instance of clicking login whilst expecting a login failure. 
         driver.findElement(loginButtonLocator).submit();
 
         // Return a new page object representing the destination. Should the login page ever
@@ -481,7 +481,7 @@ public class LoginPage {
         // This is the only place that submits the login form and expects the destination to be the login page due to login failure.
         driver.findElement(loginButtonLocator).submit();
 
-        // Return a new page object representing the destination. Should the user ever be navigated to the home page after submiting a login with credentials 
+        // Return a new page object representing the destination. Should the user ever be navigated to the home page after submitting a login with credentials 
         // expected to fail login, the script will fail when it attempts to instantiate the LoginPage PageObject.
         return new LoginPage(driver);	
     }


### PR DESCRIPTION
### Description

Fixes two spelling mistakes in the Java Page Object Model example across the English, Japanese, Portuguese (Brazil), and Simplified Chinese documentation.

### Motivation and Context

Correcting `seperate` to `separate` and `submiting` to `submitting` improves the accuracy and consistency of the shared example.

### Types of changes

- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.