### PR TITLE
[ja] Fix contributing page formatting and typo

### DIFF
--- a/website_and_docs/content/documentation/about/contributing.ja.md
+++ b/website_and_docs/content/documentation/about/contributing.ja.md
@@ -82,7 +82,7 @@ tabには`text=true`を含めてください。デフォルトではtabはコー
 ## 貢献
 
 Seleniumプロジェクトは新しいコントリビュータを歓迎します。目立った価値ある貢献を継続的に行った個人は _コミッター_
-として認められ、プロジェクトへのコミットアクセス件が与えられます。
+として認められ、プロジェクトへのコミットアクセス権が与えられます。
 
 本ガイドでは、貢献のプロセスについて説明します。
 
@@ -177,7 +177,7 @@ Fixes #141
 % git push origin my-feature-branch
 ```
 
-https://github.com/yourusername/seleniumhq.github.io.git を開き、_Pull Request_を押し、フォームを入力してください。 **CLAに署名したことを示してください** (ステップ7を参照)
+https://github.com/yourusername/seleniumhq.github.io.git を開き、 _Pull Request_ を押し、フォームを入力してください。 **CLAに署名したことを示してください** (ステップ7を参照)
 
 プルリクエストは通常数日以内にレビューされます。対応すべきコメントがある場合は、新しく(できれば
 [fixups](http://git-scm.com/docs/git-commit)で)コミットし、同じブランチにプッシュしてください。


### PR DESCRIPTION
### Description

- Fixed italic formatting for “Pull Request” in the Japanese contributing guide.
- Corrected a typo in the Japanese text: `コミットアクセス件` → `コミットアクセス権`.

### Motivation and Context

The “Pull Request” label was not rendered as italic text, and the typo affected the clarity of the Japanese contributing documentation.

### Types of changes

- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.