### PR TITLE
Fix Japanese wording in install library documentation

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/install_library.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/install_library.ja.md
@@ -34,7 +34,8 @@ Java用のSeleniumライブラリのインストールは、ビルドツール�
 
   {{% /tab %}}
   {{% tab header="Python" %}}
-各 Selenium バージョンでサポートされている最小 Python バージョンについては、次の場所にあります `サポートされている Python バージョン` オン [PyPi](https://pypi.org/project/selenium/)。
+各 Selenium バージョンでサポートされている最小の Python バージョンは、
+[PyPI](https://pypi.org/project/selenium/) の「Supported Python Versions」で確認できます。
 
 Seleniumをインストールするには、いくつかの方法があります。
 
@@ -115,8 +116,8 @@ Enter キーを押して、バージョンを選択します。
 
   {{% /tab %}}
   {{% tab header="Ruby" %}}
-特定の Selenium バージョンに対して最低限必要な Ruby のバージョンを確認できます
-オン [rubygems.org](https://rubygems.org/gems/selenium-webdriver/)
+特定の Selenium バージョンに必要な最小 Ruby バージョンは、
+[rubygems.org](https://rubygems.org/gems/selenium-webdriver/) で確認できます。
 
 Seleniumは2つの異なる方法でインストールできます。
 
@@ -133,7 +134,8 @@ gem install selenium-webdriver
 
   {{% /tab %}}
   {{% tab header="JavaScript" %}}
-Seleniumの特定のバージョンに最低限必要なNodeのバージョンは、`Node Support Policy` 節 オン [npmjs](https://www.npmjs.com/package/selenium-webdriver)
+Selenium の特定のバージョンに必要な最小 Node.js バージョンは、
+[npmjs](https://www.npmjs.com/package/selenium-webdriver) の「Node Support Policy」で確認できます。
 
 Seleniumは通常、npmを使用してインストールされます。
 


### PR DESCRIPTION
### Description

Improved the Japanese wording in the “Install a Selenium library” documentation.

- Replaced leftover English “on” wording in the Python, Ruby, and JavaScript sections.
- Clarified where to find the minimum supported language versions.

### Motivation and Context

The previous Japanese text contained unnatural phrasing, including untranslated English wording. This change makes the installation requirements easier to understand for Japanese readers.

### Types of changes

- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.