### PR TITLE
Fix Python doc line ranges for BiDi network examples (#2639 follow-up)

### DIFF
--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
@@ -19,7 +19,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L23-L29" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L22-L28" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -42,7 +42,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L32-L38" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L31-L37" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -130,8 +130,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L104-L108" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L41-L65" >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L58" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -157,7 +157,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L68-L89" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L61-L76" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.ja.md
@@ -29,7 +29,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L23-L29" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L22-L28" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -52,7 +52,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L32-L38" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L31-L37" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -140,8 +140,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L104-L108" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L41-L65" >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L58" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -167,7 +167,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L68-L89" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L61-L76" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.pt-br.md
@@ -29,7 +29,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L23-L29" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L22-L28" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -52,7 +52,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L32-L38" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L31-L37" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -140,8 +140,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L104-L108" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L41-L65" >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L58" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -167,7 +167,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L68-L89" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L61-L76" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.zh-cn.md
@@ -29,7 +29,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L23-L29" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L22-L28" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -52,7 +52,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L32-L38" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L31-L37" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -140,8 +140,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L104-L108" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L41-L65" >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L58" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -167,7 +167,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L68-L89" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L61-L76" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}


### PR DESCRIPTION
 (#2639 follow-up)

**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

### Description

The final commit in #2639 missed the documentation line-range updates, so the Python snippets on the live Network page are misaligned with the merged test file (for example, the Fail request snippet starts below its decorator and bleeds into the next test).
This corrects the gh-codeblock ranges in all four language pages (en, ja, pt-br, zh-cn).

It also updates the Fail request badge from 4.32 to 4.46, since request.fail() is a 4.46 API.

### Motivation and Context 
The live docs currently render misaligned Python snippets; follow-up to #2639.

### Types of changes
- [ ] "Change to the site - I have double-checked the Netlify deployment, and my changes look good".

### Checklist
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
