### PR TITLE
Fix Python run command references in translated docs

### DIFF
--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.ja.md
@@ -234,7 +234,7 @@ Seleniumを使用して、それをうまく行うことは高度なトピック
 {{< gh-codeblock path="/examples/java/README.md#L60" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/README.md#L35" >}}
+{{< gh-codeblock path="/examples/python/README.md#L58" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/README.md#L55" >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.pt-br.md
@@ -235,7 +235,7 @@ See [Quitting Sessions]({{< ref "../drivers/#quitting-sessions" >}}).
 {{< gh-codeblock path="/examples/java/README.md#L60" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/README.md#L35" >}}
+{{< gh-codeblock path="/examples/python/README.md#L58" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/README.md#L55" >}}

--- a/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/getting_started/first_script.zh-cn.md
@@ -248,7 +248,7 @@ Selenium所做的一切,
 {{< gh-codeblock path="/examples/java/README.md#L60" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< gh-codeblock path="/examples/python/README.md#L35" >}}
+{{< gh-codeblock path="/examples/python/README.md#L58" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< gh-codeblock path="/examples/dotnet/README.md#L55" >}}


### PR DESCRIPTION
### Description

Updated the Python command reference in the “Run Selenium files” section of the Japanese, Portuguese (Brazil), and Simplified Chinese first-script documentation pages.

### Motivation and Context

The English documentation already referenced the correct line for running a specific Python test. This change aligns the translated pages with the English version.

```text
pytest path/to/test_script.py
```

### Types of changes

- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [x] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.