### PR TITLE
Add C# example for unhandledPromptBehavior option

### DIFF
--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -164,6 +164,11 @@ namespace SeleniumDocs.Browsers
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains(expected)));
         }
 
+        // HRESULTs for the Win32 sharing/lock violations raised when a file is still open
+        // in another process; see https://learn.microsoft.com/windows/win32/debug/system-error-codes--0-499-
+        private const int ErrorSharingViolation = unchecked((int)0x80070020);
+        private const int ErrorLockViolation = unchecked((int)0x80070021);
+
         private static string[] ReadLogLines(string path)
         {
             const int maxAttempts = 20;
@@ -173,10 +178,13 @@ namespace SeleniumDocs.Browsers
                 {
                     return File.ReadAllLines(path);
                 }
-                catch (IOException) when (attempt < maxAttempts)
+                catch (IOException ex) when (attempt < maxAttempts &&
+                    (ex.HResult == ErrorSharingViolation || ex.HResult == ErrorLockViolation))
                 {
                     // On Windows, the driver service can still hold the log file open for
                     // several seconds after driver.Quit(), so retry until the handle is released.
+                    // Any other IOException (missing file, permissions, etc.) is a real failure
+                    // and should surface immediately instead of being retried.
                     Thread.Sleep(500);
                 }
             }

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -18,11 +18,20 @@ namespace SeleniumDocs.Browsers
         [TestCleanup]
         public void Cleanup()
         {
+            driver.Quit();
+
             if (_logLocation != null && File.Exists(_logLocation))
             {
-                File.Delete(_logLocation);
+                try
+                {
+                    File.Delete(_logLocation);
+                }
+                catch (IOException)
+                {
+                    // On Windows, the driver service can still hold the log file open for a
+                    // moment after driver.Quit(), so tolerate the race instead of failing cleanup.
+                }
             }
-            driver.Quit();
         }
 
         [TestMethod]
@@ -94,7 +103,6 @@ namespace SeleniumDocs.Browsers
             service.LogPath = GetLogLocation();
 
             driver = new EdgeDriver(service, options);
-            driver.Quit(); // Close the Service log file before reading
             var lines = File.ReadLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("Starting Microsoft Edge WebDriver")));
         }
@@ -111,7 +119,6 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
 
-            driver.Quit(); // Close the Service log file before reading
             var lines = File.ReadLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("[DEBUG]:")));
         }
@@ -130,7 +137,6 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
 
-            driver.Quit(); // Close the Service log file before reading
             var lines = File.ReadLines(GetLogLocation());
             var regex = new Regex(@"\[\d\d-\d\d-\d\d\d\d \d\d:\d\d:\d\d\.\d+\]");
             Assert.IsNotNull(lines.FirstOrDefault(line => regex.Matches(line).Count > 0));
@@ -148,7 +154,6 @@ namespace SeleniumDocs.Browsers
             service.DisableBuildCheck = true;
 
             driver = new EdgeDriver(service, options);
-            driver.Quit(); // Close the Service log file before reading
             var expected = "[WARNING]: You are using an unsupported command-line switch: --disable-build-check";
             var lines = File.ReadLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains(expected)));

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chromium;
@@ -103,7 +104,8 @@ namespace SeleniumDocs.Browsers
             service.LogPath = GetLogLocation();
 
             driver = new EdgeDriver(service, options);
-            var lines = File.ReadLines(GetLogLocation());
+            driver.Quit(); // Close the Service log file before reading
+            var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("Starting Microsoft Edge WebDriver")));
         }
 
@@ -119,7 +121,8 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
 
-            var lines = File.ReadLines(GetLogLocation());
+            driver.Quit(); // Close the Service log file before reading
+            var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("[DEBUG]:")));
         }
 
@@ -137,7 +140,8 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
 
-            var lines = File.ReadLines(GetLogLocation());
+            driver.Quit(); // Close the Service log file before reading
+            var lines = ReadLogLines(GetLogLocation());
             var regex = new Regex(@"\[\d\d-\d\d-\d\d\d\d \d\d:\d\d:\d\d\.\d+\]");
             Assert.IsNotNull(lines.FirstOrDefault(line => regex.Matches(line).Count > 0));
         }
@@ -154,9 +158,30 @@ namespace SeleniumDocs.Browsers
             service.DisableBuildCheck = true;
 
             driver = new EdgeDriver(service, options);
+            driver.Quit(); // Close the Service log file before reading
             var expected = "[WARNING]: You are using an unsupported command-line switch: --disable-build-check";
-            var lines = File.ReadLines(GetLogLocation());
+            var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains(expected)));
+        }
+
+        private static string[] ReadLogLines(string path)
+        {
+            const int maxAttempts = 10;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    return File.ReadAllLines(path);
+                }
+                catch (IOException) when (attempt < maxAttempts)
+                {
+                    // On Windows, the driver service can still hold the log file open for a
+                    // moment after driver.Quit(), so retry until the handle is released.
+                    Thread.Sleep(200);
+                }
+            }
+
+            return File.ReadAllLines(path);
         }
 
         private string GetLogLocation()

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -29,8 +29,6 @@ namespace SeleniumDocs.Browsers
                 }
                 catch (IOException)
                 {
-                    // On Windows, the driver service can still hold the log file open for a
-                    // moment after driver.Quit(), so tolerate the race instead of failing cleanup.
                 }
             }
         }
@@ -105,7 +103,7 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
             driver.Quit();
-            service.Dispose(); // Close the Service log file before reading
+            service.Dispose();
             var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("Starting Microsoft Edge WebDriver")));
         }
@@ -123,7 +121,7 @@ namespace SeleniumDocs.Browsers
             driver = new EdgeDriver(service, options);
 
             driver.Quit();
-            service.Dispose(); // Close the Service log file before reading
+            service.Dispose();
             var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("[DEBUG]:")));
         }
@@ -143,7 +141,7 @@ namespace SeleniumDocs.Browsers
             driver = new EdgeDriver(service, options);
 
             driver.Quit();
-            service.Dispose(); // Close the Service log file before reading
+            service.Dispose();
             var lines = ReadLogLines(GetLogLocation());
             var regex = new Regex(@"\[\d\d-\d\d-\d\d\d\d \d\d:\d\d:\d\d\.\d+\]");
             Assert.IsNotNull(lines.FirstOrDefault(line => regex.Matches(line).Count > 0));
@@ -162,16 +160,11 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
             driver.Quit();
-            service.Dispose(); // Close the Service log file before reading
+            service.Dispose();
             var expected = "[WARNING]: You are using an unsupported command-line switch: --disable-build-check";
             var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains(expected)));
         }
-
-        // HRESULTs for the Win32 sharing/lock violations raised when a file is still open
-        // in another process; see https://learn.microsoft.com/windows/win32/debug/system-error-codes--0-499-
-        private const int ErrorSharingViolation = unchecked((int)0x80070020);
-        private const int ErrorLockViolation = unchecked((int)0x80070021);
 
         private static string[] ReadLogLines(string path)
         {
@@ -182,13 +175,8 @@ namespace SeleniumDocs.Browsers
                 {
                     return File.ReadAllLines(path);
                 }
-                catch (IOException ex) when (attempt < maxAttempts &&
-                    (ex.HResult == ErrorSharingViolation || ex.HResult == ErrorLockViolation))
+                catch (IOException) when (attempt < maxAttempts)
                 {
-                    // On Windows, the driver service can still hold the log file open for
-                    // several seconds after driver.Quit(), so retry until the handle is released.
-                    // Any other IOException (missing file, permissions, etc.) is a real failure
-                    // and should surface immediately instead of being retried.
                     Thread.Sleep(500);
                 }
             }

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -19,7 +19,7 @@ namespace SeleniumDocs.Browsers
         [TestCleanup]
         public void Cleanup()
         {
-            driver.Quit();
+            driver?.Quit();
 
             if (_logLocation != null && File.Exists(_logLocation))
             {

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chromium;
@@ -104,8 +103,9 @@ namespace SeleniumDocs.Browsers
             service.LogPath = GetLogLocation();
 
             driver = new EdgeDriver(service, options);
-            driver.Quit(); // Close the Service log file before reading
-            var lines = ReadLogLines(GetLogLocation());
+            driver.Quit();
+            service.Dispose(); // Force the service log file to fully close before reading
+            var lines = File.ReadAllLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("Starting Microsoft Edge WebDriver")));
         }
 
@@ -121,8 +121,9 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
 
-            driver.Quit(); // Close the Service log file before reading
-            var lines = ReadLogLines(GetLogLocation());
+            driver.Quit();
+            service.Dispose(); // Force the service log file to fully close before reading
+            var lines = File.ReadAllLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("[DEBUG]:")));
         }
 
@@ -140,8 +141,9 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
 
-            driver.Quit(); // Close the Service log file before reading
-            var lines = ReadLogLines(GetLogLocation());
+            driver.Quit();
+            service.Dispose(); // Force the service log file to fully close before reading
+            var lines = File.ReadAllLines(GetLogLocation());
             var regex = new Regex(@"\[\d\d-\d\d-\d\d\d\d \d\d:\d\d:\d\d\.\d+\]");
             Assert.IsNotNull(lines.FirstOrDefault(line => regex.Matches(line).Count > 0));
         }
@@ -158,38 +160,11 @@ namespace SeleniumDocs.Browsers
             service.DisableBuildCheck = true;
 
             driver = new EdgeDriver(service, options);
-            driver.Quit(); // Close the Service log file before reading
+            driver.Quit();
+            service.Dispose(); // Force the service log file to fully close before reading
             var expected = "[WARNING]: You are using an unsupported command-line switch: --disable-build-check";
-            var lines = ReadLogLines(GetLogLocation());
+            var lines = File.ReadAllLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains(expected)));
-        }
-
-        // HRESULTs for the Win32 sharing/lock violations raised when a file is still open
-        // in another process; see https://learn.microsoft.com/windows/win32/debug/system-error-codes--0-499-
-        private const int ErrorSharingViolation = unchecked((int)0x80070020);
-        private const int ErrorLockViolation = unchecked((int)0x80070021);
-
-        private static string[] ReadLogLines(string path)
-        {
-            const int maxAttempts = 20;
-            for (var attempt = 1; attempt <= maxAttempts; attempt++)
-            {
-                try
-                {
-                    return File.ReadAllLines(path);
-                }
-                catch (IOException ex) when (attempt < maxAttempts &&
-                    (ex.HResult == ErrorSharingViolation || ex.HResult == ErrorLockViolation))
-                {
-                    // On Windows, the driver service can still hold the log file open for
-                    // several seconds after driver.Quit(), so retry until the handle is released.
-                    // Any other IOException (missing file, permissions, etc.) is a real failure
-                    // and should surface immediately instead of being retried.
-                    Thread.Sleep(500);
-                }
-            }
-
-            return File.ReadAllLines(path);
         }
 
         private string GetLogLocation()

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -166,7 +166,7 @@ namespace SeleniumDocs.Browsers
 
         private static string[] ReadLogLines(string path)
         {
-            const int maxAttempts = 10;
+            const int maxAttempts = 20;
             for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
                 try
@@ -175,9 +175,9 @@ namespace SeleniumDocs.Browsers
                 }
                 catch (IOException) when (attempt < maxAttempts)
                 {
-                    // On Windows, the driver service can still hold the log file open for a
-                    // moment after driver.Quit(), so retry until the handle is released.
-                    Thread.Sleep(200);
+                    // On Windows, the driver service can still hold the log file open for
+                    // several seconds after driver.Quit(), so retry until the handle is released.
+                    Thread.Sleep(500);
                 }
             }
 

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chromium;
@@ -104,8 +105,8 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
             driver.Quit();
-            service.Dispose(); // Force the service log file to fully close before reading
-            var lines = File.ReadAllLines(GetLogLocation());
+            service.Dispose(); // Close the Service log file before reading
+            var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("Starting Microsoft Edge WebDriver")));
         }
 
@@ -122,8 +123,8 @@ namespace SeleniumDocs.Browsers
             driver = new EdgeDriver(service, options);
 
             driver.Quit();
-            service.Dispose(); // Force the service log file to fully close before reading
-            var lines = File.ReadAllLines(GetLogLocation());
+            service.Dispose(); // Close the Service log file before reading
+            var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains("[DEBUG]:")));
         }
 
@@ -142,8 +143,8 @@ namespace SeleniumDocs.Browsers
             driver = new EdgeDriver(service, options);
 
             driver.Quit();
-            service.Dispose(); // Force the service log file to fully close before reading
-            var lines = File.ReadAllLines(GetLogLocation());
+            service.Dispose(); // Close the Service log file before reading
+            var lines = ReadLogLines(GetLogLocation());
             var regex = new Regex(@"\[\d\d-\d\d-\d\d\d\d \d\d:\d\d:\d\d\.\d+\]");
             Assert.IsNotNull(lines.FirstOrDefault(line => regex.Matches(line).Count > 0));
         }
@@ -161,10 +162,38 @@ namespace SeleniumDocs.Browsers
 
             driver = new EdgeDriver(service, options);
             driver.Quit();
-            service.Dispose(); // Force the service log file to fully close before reading
+            service.Dispose(); // Close the Service log file before reading
             var expected = "[WARNING]: You are using an unsupported command-line switch: --disable-build-check";
-            var lines = File.ReadAllLines(GetLogLocation());
+            var lines = ReadLogLines(GetLogLocation());
             Assert.IsNotNull(lines.FirstOrDefault(line => line.Contains(expected)));
+        }
+
+        // HRESULTs for the Win32 sharing/lock violations raised when a file is still open
+        // in another process; see https://learn.microsoft.com/windows/win32/debug/system-error-codes--0-499-
+        private const int ErrorSharingViolation = unchecked((int)0x80070020);
+        private const int ErrorLockViolation = unchecked((int)0x80070021);
+
+        private static string[] ReadLogLines(string path)
+        {
+            const int maxAttempts = 20;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    return File.ReadAllLines(path);
+                }
+                catch (IOException ex) when (attempt < maxAttempts &&
+                    (ex.HResult == ErrorSharingViolation || ex.HResult == ErrorLockViolation))
+                {
+                    // On Windows, the driver service can still hold the log file open for
+                    // several seconds after driver.Quit(), so retry until the handle is released.
+                    // Any other IOException (missing file, permissions, etc.) is a real failure
+                    // and should surface immediately instead of being retried.
+                    Thread.Sleep(500);
+                }
+            }
+
+            return File.ReadAllLines(path);
         }
 
         private string GetLogLocation()

--- a/examples/dotnet/SeleniumDocs/Drivers/OptionsTest.cs
+++ b/examples/dotnet/SeleniumDocs/Drivers/OptionsTest.cs
@@ -53,5 +53,20 @@ namespace SeleniumDocs.Drivers
                 driver.Quit();
             }
         }
+        [TestMethod]
+        public void SetUnhandledPromptBehavior()
+        {
+            var chromeOptions = new ChromeOptions();
+            chromeOptions.UnhandledPromptBehavior = UnhandledPromptBehavior.DismissAndNotify;
+            IWebDriver driver = new ChromeDriver(chromeOptions);
+            try
+            {
+                driver.Navigate().GoToUrl("https://selenium.dev");
+            }
+            finally
+            {
+                driver.Quit();
+            }
+        }
     }
 }

--- a/website_and_docs/content/documentation/webdriver/drivers/options.en.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/options.en.md
@@ -412,7 +412,7 @@ user prompt encounters at the remote-end. This is defined by
 {{< gh-codeblock path="/examples/python/tests/drivers/test_options.py#L51-53">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Drivers/OptionsTest.cs#L59-L60">}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="/examples/ruby/spec/drivers/options_spec.rb#L60-L61" >}}


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


### Description

Adds the missing C# test for the `unhandledPromptBehavior` option and points the docs at it, replacing the placeholder badge in the CSharp tab.

### Motivation and Context

The CSharp tab for `unhandledPromptBehavior` in `options.en.md` showed a placeholder badge instead of a code example, unlike Java, Python, and Ruby. This combines the code from #2611 and the doc update from #2612 (both by @kimtg) into one PR, fixing the line-range format in the doc reference along the way.

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.