### PR TITLE
Add C# example for unhandledPromptBehavior to translated docs

### DIFF
--- a/website_and_docs/content/documentation/webdriver/drivers/options.ja.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/options.ja.md
@@ -389,7 +389,7 @@ WebDriverの `セッション` には特定の `セッションタイムアウ�
 {{< gh-codeblock path="/examples/python/tests/drivers/test_options.py#L51-53">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Drivers/OptionsTest.cs#L59-L60">}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="/examples/ruby/spec/drivers/options_spec.rb#L60-L61" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/options.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/options.pt-br.md
@@ -424,7 +424,7 @@ user prompt encounters at the remote-end. This is defined by
 {{< gh-codeblock path="/examples/python/tests/drivers/test_options.py#L51-53">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Drivers/OptionsTest.cs#L59-L60">}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="/examples/ruby/spec/drivers/options_spec.rb#L60-L61" >}}

--- a/website_and_docs/content/documentation/webdriver/drivers/options.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/drivers/options.zh-cn.md
@@ -414,7 +414,7 @@ WebDriver创建新会话时,
 {{< gh-codeblock path="/examples/python/tests/drivers/test_options.py#L51-53">}}
 {{% /tab %}}
 {{< tab header="CSharp" >}}
-{{< badge-code >}}
+{{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Drivers/OptionsTest.cs#L59-L60">}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< gh-codeblock path="/examples/ruby/spec/drivers/options_spec.rb#L60-L61" >}}


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


### Description

Applies the CSharp `unhandledPromptBehavior` example from #2724 to the ja, pt-br, and zh-cn translations of `options.md`, which were missed in that PR.

### Motivation and Context

#2724 replaced the placeholder badge in the CSharp tab of `options.en.md` with a real `gh-codeblock` reference, but the translated versions of that page still show the placeholder badge for the same section.

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.