### PR TITLE
Use EC.alert_is_present() for Python alert examples

### DIFF
--- a/examples/python/tests/interactions/test_alerts.py
+++ b/examples/python/tests/interactions/test_alerts.py
@@ -1,6 +1,7 @@
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 global url
 url = "https://www.selenium.dev/documentation/webdriver/interactions/alerts/"
@@ -13,11 +14,11 @@ def test_alert_popup():
     element.click()
 
     wait = WebDriverWait(driver, timeout=2)
-    alert = wait.until(lambda d : d.switch_to.alert)
+    alert = wait.until(EC.alert_is_present())
     text = alert.text
     alert.accept()
     assert text == "Sample alert"
-
+    
     driver.quit()
 
 def test_confirm_popup():
@@ -27,7 +28,7 @@ def test_confirm_popup():
     driver.execute_script("arguments[0].click();", element)
 
     wait = WebDriverWait(driver, timeout=2)
-    alert = wait.until(lambda d : d.switch_to.alert)
+    alert = wait.until(EC.alert_is_present())
     text = alert.text
     alert.dismiss()
     assert text == "Are you sure?"
@@ -41,7 +42,7 @@ def test_prompt_popup():
     driver.execute_script("arguments[0].click();", element)
 
     wait = WebDriverWait(driver, timeout=2)
-    alert = wait.until(lambda d : d.switch_to.alert)
+    alert = wait.until(EC.alert_is_present())
     alert.send_keys("Selenium")
     text = alert.text
     alert.accept()

--- a/examples/python/tests/interactions/test_alerts.py
+++ b/examples/python/tests/interactions/test_alerts.py
@@ -18,7 +18,7 @@ def test_alert_popup():
     text = alert.text
     alert.accept()
     assert text == "Sample alert"
-    
+
     driver.quit()
 
 def test_confirm_popup():

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.en.md
@@ -30,7 +30,7 @@ alerts.
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L20" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L13-L19" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -81,7 +81,7 @@ This example also shows a different approach to storing an alert:
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L34" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L27-L33" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -140,7 +140,7 @@ See a sample prompt</a>.
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L49" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L41-L48" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.en.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.en.md
@@ -30,7 +30,7 @@ alerts.
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L18" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L20" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -81,7 +81,7 @@ This example also shows a different approach to storing an alert:
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L32" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L34" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -140,7 +140,7 @@ See a sample prompt</a>.
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L47" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L49" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.ja.md
@@ -26,7 +26,7 @@ WebDriverはポップアップからテキストを取得し、これらのア�
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L20" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L13-L19" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -76,7 +76,7 @@ alert.accept()
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L34" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L27-L33" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -133,7 +133,7 @@ alert.dismiss()
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L49" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L41-L48" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.ja.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.ja.md
@@ -26,7 +26,7 @@ WebDriverはポップアップからテキストを取得し、これらのア�
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L18" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L20" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -76,7 +76,7 @@ alert.accept()
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L32" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L34" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -133,7 +133,7 @@ alert.dismiss()
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L47" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L49" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.pt-br.md
@@ -29,7 +29,7 @@ alertas.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/AlertsTest.java#L36-L41" >}}
 {{< /tab >}}
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L18" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L20" >}}
 {{< /tab >}}
 
 {{< tab header="Ruby" text=true >}}
@@ -67,7 +67,7 @@ Este exemplo também mostra uma abordagem diferente para armazenar um alerta:
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L32" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L34" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -126,7 +126,7 @@ Veja um exemplo de prompt </a>.
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L47" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L49" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.pt-br.md
@@ -29,7 +29,7 @@ alertas.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/interactions/AlertsTest.java#L36-L41" >}}
 {{< /tab >}}
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L20" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L13-L19" >}}
 {{< /tab >}}
 
 {{< tab header="Ruby" text=true >}}
@@ -67,7 +67,7 @@ Este exemplo também mostra uma abordagem diferente para armazenar um alerta:
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L34" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L27-L33" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -126,7 +126,7 @@ Veja um exemplo de prompt </a>.
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L49" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L41-L48" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.zh-cn.md
@@ -23,7 +23,7 @@ WebDriver可以从弹窗获取文本并接受或关闭这些警告.
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L20" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L13-L19" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -72,7 +72,7 @@ alert.accept()
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L34" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L27-L33" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -128,7 +128,7 @@ alert.dismiss()
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L49" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L41-L48" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}

--- a/website_and_docs/content/documentation/webdriver/interactions/alerts.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/interactions/alerts.zh-cn.md
@@ -23,7 +23,7 @@ WebDriver可以从弹窗获取文本并接受或关闭这些警告.
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L18" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L12-L20" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -72,7 +72,7 @@ alert.accept()
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L32" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L26-L34" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}
@@ -128,7 +128,7 @@ alert.dismiss()
 {{< /tab >}}
 
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L47" >}}
+{{< gh-codeblock path="/examples/python/tests/interactions/test_alerts.py#L40-L49" >}}
 {{< /tab >}}
 
   {{< tab header="CSharp" >}}


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


### Description

Picks up #2589 (by @beinghumantester): replaces `wait.until(lambda d: d.switch_to.alert)` with `wait.until(EC.alert_is_present())` in all three Python alert examples, and addresses the review feedback that PR didn't get to: removes the trailing whitespace cgoldberg flagged, and fixes the `gh-codeblock` line ranges in `alerts.en.md`, `alerts.ja.md`, `alerts.pt-br.md`, and `alerts.zh-cn.md`, which had drifted to include `driver.get(url)` and the `assert` line instead of matching the same scope shown before (and in the other language tabs).

### Motivation and Context

`WebDriverWait` only ignores `NoSuchElementException` by default, not `NoAlertPresentException`, so the old lambda would raise instead of retrying if the alert hadn't appeared yet on the first poll. `EC.alert_is_present()` catches that exception internally, so the wait actually retries as intended.

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.