### PR TITLE
Move Design Strategies Java examples into tested gh-codeblock refs

### DIFF
--- a/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java
+++ b/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java
@@ -273,7 +273,7 @@ class ActionBot {
   }
 }
 
-class NestedComponentsExample {
+class NestedComponentsExampleTest {
 
   @Test
   @Disabled("Illustrative only: exercises live GitHub sign-in and issue-creation pages")

--- a/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java
+++ b/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java
@@ -1,0 +1,289 @@
+package dev.selenium.design_strategies;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.LoadableComponent;
+
+class EditIssueBasic {
+
+  private final WebDriver driver;
+
+  public EditIssueBasic(WebDriver driver) {
+    this.driver = driver;
+  }
+
+  public void setTitle(String title) {
+    WebElement field = driver.findElement(By.id("issue_title"));
+    clearAndType(field, title);
+  }
+
+  public void setBody(String body) {
+    WebElement field = driver.findElement(By.id("issue_body"));
+    clearAndType(field, body);
+  }
+
+  public void setHowToReproduce(String howToReproduce) {
+    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
+    clearAndType(field, howToReproduce);
+  }
+
+  public void setLogOutput(String logOutput) {
+    WebElement field = driver.findElement(By.id("issue_form_logs"));
+    clearAndType(field, logOutput);
+  }
+
+  public void setOperatingSystem(String operatingSystem) {
+    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
+    clearAndType(field, operatingSystem);
+  }
+
+  public void setSeleniumVersion(String seleniumVersion) {
+    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
+    clearAndType(field, seleniumVersion);
+  }
+
+  public void setBrowserVersion(String browserVersion) {
+    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
+    clearAndType(field, browserVersion);
+  }
+
+  public void setDriverVersion(String driverVersion) {
+    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
+    clearAndType(field, driverVersion);
+  }
+
+  public void setUsingGrid(String usingGrid) {
+    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
+    clearAndType(field, usingGrid);
+  }
+
+  public IssueList submit() {
+    driver.findElement(By.cssSelector("button[type='submit']")).click();
+    return new IssueList(driver);
+  }
+
+  private void clearAndType(WebElement field, String text) {
+    field.clear();
+    field.sendKeys(text);
+  }
+}
+
+class IssueList extends LoadableComponent<IssueList> {
+
+  private final WebDriver driver;
+
+  public IssueList(WebDriver driver) {
+    this.driver = driver;
+  }
+
+  @Override
+  protected void load() {
+    driver.get("https://github.com/SeleniumHQ/selenium/issues");
+  }
+
+  @Override
+  protected void isLoaded() throws Error {
+    Assertions.assertTrue(driver.getCurrentUrl().contains("/issues"));
+  }
+}
+
+class ProjectPage extends LoadableComponent<ProjectPage> {
+
+  private final WebDriver driver;
+  private final String projectName;
+
+  public ProjectPage(WebDriver driver, String projectName) {
+    this.driver = driver;
+    this.projectName = projectName;
+  }
+
+  @Override
+  protected void load() {
+    driver.get("http://" + projectName + ".googlecode.com/");
+  }
+
+  @Override
+  protected void isLoaded() throws Error {
+    String url = driver.getCurrentUrl();
+
+    Assertions.assertTrue(url.contains(projectName));
+  }
+}
+
+class SecuredPage extends LoadableComponent<SecuredPage> {
+
+  private final WebDriver driver;
+  private final LoadableComponent<?> parent;
+  private final String username;
+  private final String password;
+
+  public SecuredPage(WebDriver driver, LoadableComponent<?> parent, String username, String password) {
+    this.driver = driver;
+    this.parent = parent;
+    this.username = username;
+    this.password = password;
+  }
+
+  @Override
+  protected void load() {
+    parent.get();
+
+    String originalUrl = driver.getCurrentUrl();
+
+    // Sign in
+    driver.get("https://www.google.com/accounts/ServiceLogin?service=code");
+    driver.findElement(By.name("Email")).sendKeys(username);
+    WebElement passwordField = driver.findElement(By.name("Passwd"));
+    passwordField.sendKeys(password);
+    passwordField.submit();
+
+    // Now return to the original URL
+    driver.get(originalUrl);
+  }
+
+  @Override
+  protected void isLoaded() throws Error {
+    // If you're signed in, you have the option of picking a different login.
+    // Let's check for the presence of that.
+    if (driver.findElements(By.id("multilogin-dropdown")).isEmpty()) {
+      Assertions.fail("Cannot locate user name link");
+    }
+  }
+}
+
+class EditIssue extends LoadableComponent<EditIssue> {
+
+  private final WebDriver driver;
+
+  // By default the PageFactory will locate elements with the same name or id
+  // as the field. Since the issue_title element has an id attribute of "issue_title"
+  // we don't need any additional annotations.
+  private WebElement issue_title;
+
+  // But we'd prefer a different name in our code than "issue_body", so we use the
+  // FindBy annotation to tell the PageFactory how to locate the element.
+  @FindBy(id = "issue_body") private WebElement body;
+
+  public EditIssue(WebDriver driver) {
+    this.driver = driver;
+
+    // This call sets the WebElement fields.
+    PageFactory.initElements(driver, this);
+  }
+
+  @Override
+  protected void load() {
+    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
+  }
+
+  @Override
+  protected void isLoaded() throws Error {
+    String url = driver.getCurrentUrl();
+    Assertions.assertTrue(url.endsWith("/new"), "Not on the issue entry page: " + url);
+  }
+
+  public void setHowToReproduce(String howToReproduce) {
+    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
+    clearAndType(field, howToReproduce);
+  }
+
+  public void setLogOutput(String logOutput) {
+    WebElement field = driver.findElement(By.id("issue_form_logs"));
+    clearAndType(field, logOutput);
+  }
+
+  public void setOperatingSystem(String operatingSystem) {
+    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
+    clearAndType(field, operatingSystem);
+  }
+
+  public void setSeleniumVersion(String seleniumVersion) {
+    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
+    clearAndType(field, seleniumVersion);
+  }
+
+  public void setBrowserVersion(String browserVersion) {
+    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
+    clearAndType(field, browserVersion);
+  }
+
+  public void setDriverVersion(String driverVersion) {
+    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
+    clearAndType(field, driverVersion);
+  }
+
+  public void setUsingGrid(String usingGrid) {
+    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
+    clearAndType(field, usingGrid);
+  }
+
+  public IssueList submit() {
+    driver.findElement(By.cssSelector("button[type='submit']")).click();
+    return new IssueList(driver);
+  }
+
+  private void clearAndType(WebElement field, String text) {
+    field.clear();
+    field.sendKeys(text);
+  }
+}
+
+class ActionBot {
+
+  private final WebDriver driver;
+
+  public ActionBot(WebDriver driver) {
+    this.driver = driver;
+  }
+
+  public void click(By locator) {
+    driver.findElement(locator).click();
+  }
+
+  public void submit(By locator) {
+    driver.findElement(locator).submit();
+  }
+
+  /**
+   * Type something into an input field. WebDriver doesn't normally clear these
+   * before typing, so this method does that first. It also sends a return key
+   * to move the focus out of the element.
+   */
+  public void type(By locator, String text) {
+    WebElement element = driver.findElement(locator);
+    element.clear();
+    element.sendKeys(text + "\n");
+  }
+}
+
+class NestedComponentsExample {
+
+  @Test
+  @Disabled("Illustrative only: exercises live GitHub sign-in and issue-creation pages")
+  void demonstrateNestedLoadableComponents() {
+    WebDriver driver = new ChromeDriver();
+    try {
+      ProjectPage project = new ProjectPage(driver, "selenium");
+      SecuredPage securedPage = new SecuredPage(driver, project, "example", "top secret");
+      securedPage.get();
+
+      EditIssue editIssue = new EditIssue(driver).get();
+      editIssue.setHowToReproduce("How to Reproduce");
+      editIssue.setLogOutput("Log Output");
+      editIssue.setOperatingSystem("Operating System");
+      editIssue.setSeleniumVersion("Selenium Version");
+      editIssue.setBrowserVersion("Browser Version");
+      editIssue.setDriverVersion("Driver Version");
+      editIssue.setUsingGrid("I Am Using Grid");
+    } finally {
+      driver.quit();
+    }
+  }
+}

--- a/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java
+++ b/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java
@@ -90,7 +90,8 @@ class IssueList extends LoadableComponent<IssueList> {
 
   @Override
   protected void isLoaded() throws Error {
-    Assertions.assertTrue(driver.getCurrentUrl().contains("/issues"));
+    String url = driver.getCurrentUrl();
+    Assertions.assertTrue(url.contains("/issues") && !url.contains("/issues/"), "Not on the issues list page: " + url);
   }
 }
 

--- a/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java
+++ b/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java
@@ -161,6 +161,7 @@ class SecuredPage extends LoadableComponent<SecuredPage> {
 class EditIssue extends LoadableComponent<EditIssue> {
 
   private final WebDriver driver;
+  private final LoadableComponent<?> parent;
 
   // By default the PageFactory will locate elements with the same name or id
   // as the field. Since the issue_title element has an id attribute of "issue_title"
@@ -172,7 +173,12 @@ class EditIssue extends LoadableComponent<EditIssue> {
   @FindBy(id = "issue_body") private WebElement body;
 
   public EditIssue(WebDriver driver) {
+    this(driver, null);
+  }
+
+  public EditIssue(WebDriver driver, LoadableComponent<?> parent) {
     this.driver = driver;
+    this.parent = parent;
 
     // This call sets the WebElement fields.
     PageFactory.initElements(driver, this);
@@ -180,13 +186,17 @@ class EditIssue extends LoadableComponent<EditIssue> {
 
   @Override
   protected void load() {
+    if (parent != null) {
+      parent.get();
+    }
+
     driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
   }
 
   @Override
   protected void isLoaded() throws Error {
     String url = driver.getCurrentUrl();
-    Assertions.assertTrue(url.endsWith("/new"), "Not on the issue entry page: " + url);
+    Assertions.assertTrue(url.contains("/issues/new"), "Not on the issue entry page: " + url);
   }
 
   public void setHowToReproduce(String howToReproduce) {
@@ -271,10 +281,9 @@ class NestedComponentsExample {
     WebDriver driver = new ChromeDriver();
     try {
       ProjectPage project = new ProjectPage(driver, "selenium");
-      SecuredPage securedPage = new SecuredPage(driver, project, "example", "top secret");
-      securedPage.get();
+      SecuredPage securedPage = new SecuredPage(driver, project, "example", "not-a-real-password");
 
-      EditIssue editIssue = new EditIssue(driver).get();
+      EditIssue editIssue = new EditIssue(driver, securedPage).get();
       editIssue.setHowToReproduce("How to Reproduce");
       editIssue.setLogOutput("Log Output");
       editIssue.setOperatingSystem("Operating System");

--- a/website_and_docs/content/documentation/test_practices/design_strategies.en.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.en.md
@@ -37,18 +37,75 @@ As an example of a UI that we'd like to model, take a look at
 the [new issue](https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+) page. From the point of view of a test author, 
 this offers the service of being able to file a new issue. A basic Page Object would look like:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L14-L76" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 In order to turn this into a LoadableComponent, all we need to do is to set that as the base type:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 This signature looks a little unusual, but all it means is that this class 
 represents a LoadableComponent that loads the EditIssue page.
 
 By extending this base class, we need to implement two new methods:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 The `load` method is used to navigate to the page, whilst the `isLoaded` method is used to 
 determine whether we are on the right page. Although the method looks like it should return 
@@ -58,7 +115,26 @@ it's possible to give users of the class clear information that can be used to d
 
 With a little rework, our PageObject looks like:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 That doesn't seem to have bought us much, right? One thing it has done is encapsulate 
 the information about how to navigate to the page into the page itself, meaning that 
@@ -90,21 +166,97 @@ The end result, in addition to the EditIssue class above is:
 
 ProjectPage.java:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 and SecuredPage.java:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 The "load" method in EditIssue now looks like:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 This shows that the components are all "nested" within each other. 
 A call to `get()` in EditIssue will cause all its dependencies to 
 load too. The example usage:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 If you're using a library such as [Guiceberry](https://github.com/zorzella/guiceberry) in your tests, 
 the preamble of setting up the PageObjects can be omitted leading to nice, clear, readable tests.
@@ -122,7 +274,26 @@ A "bot" is an action-oriented abstraction over the raw Selenium APIs.
 This means that if you find that commands aren't doing the Right Thing 
 for your app, it's easy to change them. As an example:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 Once these abstractions have been built and duplication in your tests identified, it's possible to layer PageObjects on top of bots.
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.en.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.en.md
@@ -35,7 +35,8 @@ There is currently an implementation in Java that ships as part of Selenium 2, b
 
 As an example of a UI that we'd like to model, take a look at 
 the [new issue](https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+) page. From the point of view of a test author, 
-this offers the service of being able to file a new issue. A basic Page Object would look like:
+this offers the service of being able to file a new issue. A basic Page Object -- we'll call this
+simple version `EditIssueBasic`, before turning it into the `EditIssue` LoadableComponent below -- would look like:
 
 {{< tabpane text=true >}}
 {{< tab header="Python" >}}
@@ -65,7 +66,7 @@ In order to turn this into a LoadableComponent, all we need to do is to set that
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L162" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -91,7 +92,7 @@ By extending this base class, we need to implement two new methods:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L188-L201" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -120,7 +121,7 @@ With a little rework, our PageObject looks like:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L162-L247" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -171,7 +172,7 @@ ProjectPage.java:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L98-L119" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -194,7 +195,7 @@ and SecuredPage.java:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L121-L160" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -217,7 +218,7 @@ The "load" method in EditIssue now looks like:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L188-L195" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -242,7 +243,7 @@ load too. The example usage:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L277-L299" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -279,7 +280,7 @@ for your app, it's easy to change them. As an example:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L249-L275" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/test_practices/design_strategies.en.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.en.md
@@ -48,7 +48,7 @@ represents a LoadableComponent that loads the EditIssue page.
 
 By extending this base class, we need to implement two new methods:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L181-L190" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
 
 The `load` method is used to navigate to the page, whilst the `isLoaded` method is used to 
 determine whether we are on the right page. Although the method looks like it should return 
@@ -58,7 +58,7 @@ it's possible to give users of the class clear information that can be used to d
 
 With a little rework, our PageObject looks like:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L236" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
 
 That doesn't seem to have bought us much, right? One thing it has done is encapsulate 
 the information about how to navigate to the page into the page itself, meaning that 
@@ -98,20 +98,13 @@ and SecuredPage.java:
 
 The "load" method in EditIssue now looks like:
 
-```java
-  @Override
-  protected void load() {
-    securedPage.get();
-
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
 
 This shows that the components are all "nested" within each other. 
 A call to `get()` in EditIssue will cause all its dependencies to 
 load too. The example usage:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L266-L289" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
 
 If you're using a library such as [Guiceberry](https://github.com/zorzella/guiceberry) in your tests, 
 the preamble of setting up the PageObjects can be omitted leading to nice, clear, readable tests.
@@ -129,7 +122,7 @@ A "bot" is an action-oriented abstraction over the raw Selenium APIs.
 This means that if you find that commands aren't doing the Right Thing 
 for your app, it's easy to change them. As an example:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L238-L264" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
 
 Once these abstractions have been built and duplication in your tests identified, it's possible to layer PageObjects on top of bots.
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.en.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.en.md
@@ -37,103 +37,18 @@ As an example of a UI that we'd like to model, take a look at
 the [new issue](https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+) page. From the point of view of a test author, 
 this offers the service of being able to file a new issue. A basic Page Object would look like:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-public class EditIssue {
-
-  private final WebDriver driver;
-
-  public EditIssue(WebDriver driver) {
-    this.driver = driver;
-  }
-
-  public void setTitle(String title) {
-    WebElement field = driver.findElement(By.id("issue_title")));
-    clearAndType(field, title);
-  }
-
-  public void setBody(String body) {
-    WebElement field = driver.findElement(By.id("issue_body"));
-    clearAndType(field, body);
-  }
-
-  public void setHowToReproduce(String howToReproduce) {
-    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
-    clearAndType(field, howToReproduce);
-  }
-
-  public void setLogOutput(String logOutput) {
-    WebElement field = driver.findElement(By.id("issue_form_logs"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setOperatingSystem(String operatingSystem) {
-    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
-    clearAndType(field, operatingSystem);
-  }
-
-  public void setSeleniumVersion(String seleniumVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setBrowserVersion(String browserVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
-    clearAndType(field, browserVersion);
-  }
-
-  public void setDriverVersion(String driverVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
-    clearAndType(field, driverVersion);
-  }
-
-  public void setUsingGrid(String usingGrid) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
-    clearAndType(field, usingGrid);
-  }
-
-  public IssueList submit() {
-    driver.findElement(By.cssSelector("button[type='submit']")).click();
-    return new IssueList(driver);
-  }
-
-  private void clearAndType(WebElement field, String text) {
-    field.clear();
-    field.sendKeys(text);
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L14-L76" >}}
 
 In order to turn this into a LoadableComponent, all we need to do is to set that as the base type:
 
-```java
-public class EditIssue extends LoadableComponent<EditIssue> {
-  // rest of class ignored for now
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
 
 This signature looks a little unusual, but all it means is that this class 
 represents a LoadableComponent that loads the EditIssue page.
 
 By extending this base class, we need to implement two new methods:
 
-```java
-  @Override
-  protected void load() {
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
-  }
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L181-L190" >}}
 
 The `load` method is used to navigate to the page, whilst the `isLoaded` method is used to 
 determine whether we are on the right page. Although the method looks like it should return 
@@ -143,94 +58,7 @@ it's possible to give users of the class clear information that can be used to d
 
 With a little rework, our PageObject looks like:
 
-```java
-package com.example.webdriver;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.PageFactory;
-
-import static junit.framework.Assert.assertTrue;
-
-public class EditIssue extends LoadableComponent<EditIssue> {
-
-  private final WebDriver driver;
-  
-  // By default the PageFactory will locate elements with the same name or id
-  // as the field. Since the issue_title element has an id attribute of "issue_title"
-  // we don't need any additional annotations.
-  private WebElement issue_title;
-  
-  // But we'd prefer a different name in our code than "issue_body", so we use the
-  // FindBy annotation to tell the PageFactory how to locate the element.
-  @FindBy(id = "issue_body") private WebElement body;
-  
-  public EditIssue(WebDriver driver) {
-    this.driver = driver;
-    
-    // This call sets the WebElement fields.
-    PageFactory.initElements(driver, this);
-  }
-
-  @Override
-  protected void load() {
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
-  }
-
-  public void setHowToReproduce(String howToReproduce) {
-    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
-    clearAndType(field, howToReproduce);
-  }
-
-  public void setLogOutput(String logOutput) {
-    WebElement field = driver.findElement(By.id("issue_form_logs"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setOperatingSystem(String operatingSystem) {
-    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
-    clearAndType(field, operatingSystem);
-  }
-
-  public void setSeleniumVersion(String seleniumVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setBrowserVersion(String browserVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
-    clearAndType(field, browserVersion);
-  }
-
-  public void setDriverVersion(String driverVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
-    clearAndType(field, driverVersion);
-  }
-
-  public void setUsingGrid(String usingGrid) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
-    clearAndType(field, usingGrid);
-  }
-
-  public IssueList submit() {
-    driver.findElement(By.cssSelector("button[type='submit']")).click();
-    return new IssueList(driver);
-  }
-
-  private void clearAndType(WebElement field, String text) {
-    field.clear();
-    field.sendKeys(text);
-  }
-}
-
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L236" >}}
 
 That doesn't seem to have bought us much, right? One thing it has done is encapsulate 
 the information about how to navigate to the page into the page itself, meaning that 
@@ -262,93 +90,11 @@ The end result, in addition to the EditIssue class above is:
 
 ProjectPage.java:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.WebDriver;
-
-import static org.junit.Assert.assertTrue;
-
-public class ProjectPage extends LoadableComponent<ProjectPage> {
-
-  private final WebDriver driver;
-  private final String projectName;
-
-  public ProjectPage(WebDriver driver, String projectName) {
-    this.driver = driver;
-    this.projectName = projectName;
-  }
-
-  @Override
-  protected void load() {
-    driver.get("http://" + projectName + ".googlecode.com/");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-
-    assertTrue(url.contains(projectName));
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
 
 and SecuredPage.java:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-import static org.junit.Assert.fail;
-
-public class SecuredPage extends LoadableComponent<SecuredPage> {
-
-  private final WebDriver driver;
-  private final LoadableComponent<?> parent;
-  private final String username;
-  private final String password;
-
-  public SecuredPage(WebDriver driver, LoadableComponent<?> parent, String username, String password) {
-    this.driver = driver;
-    this.parent = parent;
-    this.username = username;
-    this.password = password;
-  }
-
-  @Override
-  protected void load() {
-    parent.get();
-
-    String originalUrl = driver.getCurrentUrl();
-
-    // Sign in
-    driver.get("https://www.google.com/accounts/ServiceLogin?service=code");
-    driver.findElement(By.name("Email")).sendKeys(username);
-    WebElement passwordField = driver.findElement(By.name("Passwd"));
-    passwordField.sendKeys(password);
-    passwordField.submit();
-
-    // Now return to the original URL
-    driver.get(originalUrl);
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    // If you're signed in, you have the option of picking a different login.
-    // Let's check for the presence of that.
-
-    try {
-      WebElement div = driver.findElement(By.id("multilogin-dropdown"));
-    } catch (NoSuchElementException e) {
-      fail("Cannot locate user name link");
-    }
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
 
 The "load" method in EditIssue now looks like:
 
@@ -365,36 +111,7 @@ This shows that the components are all "nested" within each other.
 A call to `get()` in EditIssue will cause all its dependencies to 
 load too. The example usage:
 
-```java
-public class FooTest {
-  private EditIssue editIssue;
-
-  @Before
-  public void prepareComponents() {
-    WebDriver driver = new FirefoxDriver();
-
-    ProjectPage project = new ProjectPage(driver, "selenium");
-    SecuredPage securedPage = new SecuredPage(driver, project, "example", "top secret");
-    editIssue = new EditIssue(driver, securedPage);
-  }
-
-  @Test
-  public void demonstrateNestedLoadableComponents() {
-    editIssue.get();
-
-    editIssue.title.sendKeys('Title');
-    editIssue.body.sendKeys('What Happened');
-    editIssue.setHowToReproduce('How to Reproduce');
-    editIssue.setLogOutput('Log Output');
-    editIssue.setOperatingSystem('Operating System');
-    editIssue.setSeleniumVersion('Selenium Version');
-    editIssue.setBrowserVersion('Browser Version');
-    editIssue.setDriverVersion('Driver Version');
-    editIssue.setUsingGrid('I Am Using Grid');
-  }
-
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L266-L289" >}}
 
 If you're using a library such as [Guiceberry](https://github.com/zorzella/guiceberry) in your tests, 
 the preamble of setting up the PageObjects can be omitted leading to nice, clear, readable tests.
@@ -412,34 +129,7 @@ A "bot" is an action-oriented abstraction over the raw Selenium APIs.
 This means that if you find that commands aren't doing the Right Thing 
 for your app, it's easy to change them. As an example:
 
-```java
-public class ActionBot {
-  private final WebDriver driver;
-
-  public ActionBot(WebDriver driver) {
-    this.driver = driver;
-  }
-
-  public void click(By locator) {
-    driver.findElement(locator).click();
-  }
-
-  public void submit(By locator) {
-    driver.findElement(locator).submit();
-  }
-
-  /** 
-   * Type something into an input field. WebDriver doesn't normally clear these
-   * before typing, so this method does that first. It also sends a return key
-   * to move the focus out of the element.
-   */
-  public void type(By locator, String text) { 
-    WebElement element = driver.findElement(locator);
-    element.clear();
-    element.sendKeys(text + "\n");
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L238-L264" >}}
 
 Once these abstractions have been built and duplication in your tests identified, it's possible to layer PageObjects on top of bots.
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
@@ -34,102 +34,17 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 テスト作成者の観点から、これは新しい問題を提出できるサービスを提供します。 
 基本的なページオブジェクトは次のようになります。
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-public class EditIssue {
-
-  private final WebDriver driver;
-
-  public EditIssue(WebDriver driver) {
-    this.driver = driver;
-  }
-
-  public void setTitle(String title) {
-    WebElement field = driver.findElement(By.id("issue_title")));
-    clearAndType(field, title);
-  }
-
-  public void setBody(String body) {
-    WebElement field = driver.findElement(By.id("issue_body"));
-    clearAndType(field, body);
-  }
-
-  public void setHowToReproduce(String howToReproduce) {
-    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
-    clearAndType(field, howToReproduce);
-  }
-
-  public void setLogOutput(String logOutput) {
-    WebElement field = driver.findElement(By.id("issue_form_logs"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setOperatingSystem(String operatingSystem) {
-    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
-    clearAndType(field, operatingSystem);
-  }
-
-  public void setSeleniumVersion(String seleniumVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setBrowserVersion(String browserVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
-    clearAndType(field, browserVersion);
-  }
-
-  public void setDriverVersion(String driverVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
-    clearAndType(field, driverVersion);
-  }
-
-  public void setUsingGrid(String usingGrid) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
-    clearAndType(field, usingGrid);
-  }
-
-  public IssueList submit() {
-    driver.findElement(By.cssSelector("button[type='submit']")).click();
-    return new IssueList(driver);
-  }
-
-  private void clearAndType(WebElement field, String text) {
-    field.clear();
-    field.sendKeys(text);
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L14-L76" >}}
 
 これをLoadableComponentに変換するには、これを基本型として設定するだけです。
 
-```java
-public class EditIssue extends LoadableComponent<EditIssue> {
-  // rest of class ignored for now
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
 
 この署名は少し変わっているように見えますが、それは、このクラスがEditIssueページをロードするLoadableComponentを表すことを意味します。
 
 このベースクラスを拡張することにより、2つの新しいメソッドを実装する必要があります。
 
-```java
-  @Override
-  protected void load() {
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
-  }
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L181-L190" >}}
 
 `load` メソッドはページに移動するために使用され、　`isLoaded` メソッドは正しいページにいるかどうかを判断するために使用されます。 
 このメソッドはブール値を返す必要があるように見えますが、代わりにJUnitのAssertクラスを使用して一連のアサーションを実行します。 
@@ -138,94 +53,7 @@ public class EditIssue extends LoadableComponent<EditIssue> {
 
 少し手直しすると、PageObjectは次のようになります。
 
-```java
-package com.example.webdriver;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.PageFactory;
-
-import static junit.framework.Assert.assertTrue;
-
-public class EditIssue extends LoadableComponent<EditIssue> {
-
-  private final WebDriver driver;
-  
-  // By default the PageFactory will locate elements with the same name or id
-  // as the field. Since the issue_title element has an id attribute of "issue_title"
-  // we don't need any additional annotations.
-  private WebElement issue_title;
-  
-  // But we'd prefer a different name in our code than "issue_body", so we use the
-  // FindBy annotation to tell the PageFactory how to locate the element.
-  @FindBy(id = "issue_body") private WebElement body;
-  
-  public EditIssue(WebDriver driver) {
-    this.driver = driver;
-    
-    // This call sets the WebElement fields.
-    PageFactory.initElements(driver, this);
-  }
-
-  @Override
-  protected void load() {
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
-  }
-
-  public void setHowToReproduce(String howToReproduce) {
-    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
-    clearAndType(field, howToReproduce);
-  }
-
-  public void setLogOutput(String logOutput) {
-    WebElement field = driver.findElement(By.id("issue_form_logs"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setOperatingSystem(String operatingSystem) {
-    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
-    clearAndType(field, operatingSystem);
-  }
-
-  public void setSeleniumVersion(String seleniumVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setBrowserVersion(String browserVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
-    clearAndType(field, browserVersion);
-  }
-
-  public void setDriverVersion(String driverVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
-    clearAndType(field, driverVersion);
-  }
-
-  public void setUsingGrid(String usingGrid) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
-    clearAndType(field, usingGrid);
-  }
-
-  public IssueList submit() {
-    driver.findElement(By.cssSelector("button[type='submit']")).click();
-    return new IssueList(driver);
-  }
-
-  private void clearAndType(WebElement field, String text) {
-    field.clear();
-    field.sendKeys(text);
-  }
-}
-
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L236" >}}
 
 それは私たちをあまり信じられなかったようですよね？ 
 これまでに行ったことの1つは、ページに移動する方法に関する情報をページ自体にカプセル化することです。
@@ -258,93 +86,11 @@ LoadableComponentsは、他のLoadableComponentsと組み合わせて使用す�
 
 ProjectPage.java:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.WebDriver;
-
-import static org.junit.Assert.assertTrue;
-
-public class ProjectPage extends LoadableComponent<ProjectPage> {
-
-  private final WebDriver driver;
-  private final String projectName;
-
-  public ProjectPage(WebDriver driver, String projectName) {
-    this.driver = driver;
-    this.projectName = projectName;
-  }
-
-  @Override
-  protected void load() {
-    driver.get("http://" + projectName + ".googlecode.com/");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-
-    assertTrue(url.contains(projectName));
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
 
 and SecuredPage.java:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-import static org.junit.Assert.fail;
-
-public class SecuredPage extends LoadableComponent<SecuredPage> {
-
-  private final WebDriver driver;
-  private final LoadableComponent<?> parent;
-  private final String username;
-  private final String password;
-
-  public SecuredPage(WebDriver driver, LoadableComponent<?> parent, String username, String password) {
-    this.driver = driver;
-    this.parent = parent;
-    this.username = username;
-    this.password = password;
-  }
-
-  @Override
-  protected void load() {
-    parent.get();
-
-    String originalUrl = driver.getCurrentUrl();
-
-    // Sign in
-    driver.get("https://www.google.com/accounts/ServiceLogin?service=code");
-    driver.findElement(By.name("Email")).sendKeys(username);
-    WebElement passwordField = driver.findElement(By.name("Passwd"));
-    passwordField.sendKeys(password);
-    passwordField.submit();
-
-    // Now return to the original URL
-    driver.get(originalUrl);
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    // If you're signed in, you have the option of picking a different login.
-    // Let's check for the presence of that.
-
-    try {
-      WebElement div = driver.findElement(By.id("multilogin-dropdown"));
-    } catch (NoSuchElementException e) {
-      fail("Cannot locate user name link");
-    }
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
 
 EditIssueの "load" メソッドは次のようになります。
 
@@ -361,35 +107,7 @@ EditIssueの "load" メソッドは次のようになります。
 EditIssueで `get()` を呼び出すと、そのすべての依存関係も読み込まれます。 
 使用例：
 
-```java
-public class FooTest {
-  private EditIssue editIssue;
-
-  @Before
-  public void prepareComponents() {
-    WebDriver driver = new FirefoxDriver();
-
-    ProjectPage project = new ProjectPage(driver, "selenium");
-    SecuredPage securedPage = new SecuredPage(driver, project, "example", "top secret");
-    editIssue = new EditIssue(driver, securedPage);
-  }
-
-  @Test
-  public void demonstrateNestedLoadableComponents() {
-    editIssue.get();
-
-    editIssue.title.sendKeys('Title');
-    editIssue.body.sendKeys('What Happened');
-    editIssue.setHowToReproduce('How to Reproduce');
-    editIssue.setLogOutput('Log Output');
-    editIssue.setOperatingSystem('Operating System');
-    editIssue.setSeleniumVersion('Selenium Version');
-    editIssue.setBrowserVersion('Browser Version');
-    editIssue.setDriverVersion('Driver Version');
-    editIssue.setUsingGrid('I Am Using Grid');
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L266-L289" >}}
 
 テストで [Guiceberry](https://github.com/zorzella/guiceberry) などのライブラリを使用している場合は、PageObjectsの設定の前文を省略して、わかりやすく読みやすいテストを作成できます。
 
@@ -404,34 +122,7 @@ PageObjectsは、テストでの重複を減らすための便利な方法です
 つまり、コマンドがアプリに対して正しいことをしていないことがわかった場合、コマンドを簡単に変更できます。 
 例として：
 
-```java
-public class ActionBot {
-  private final WebDriver driver;
-
-  public ActionBot(WebDriver driver) {
-    this.driver = driver;
-  }
-
-  public void click(By locator) {
-    driver.findElement(locator).click();
-  }
-
-  public void submit(By locator) {
-    driver.findElement(locator).submit();
-  }
-
-  /** 
-   * Type something into an input field. WebDriver doesn't normally clear these
-   * before typing, so this method does that first. It also sends a return key
-   * to move the focus out of the element.
-   */
-  public void type(By locator, String text) { 
-    WebElement element = driver.findElement(locator);
-    element.clear();
-    element.sendKeys(text + "\n");
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L238-L264" >}}
 
 これらの抽象化が構築され、テストでの重複が特定されると、ボットの上にPageObjectsを階層化することができます。
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
@@ -32,7 +32,7 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 
 モデル化するUIの例として、[新しいissue](https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+)のページをご覧ください。 
 テスト作成者の観点から、これは新しい問題を提出できるサービスを提供します。 
-基本的なページオブジェクトは次のようになります。
+基本的なページオブジェクト(このシンプルな版を `EditIssueBasic` と呼び、後で `EditIssue` という LoadableComponent に発展させます)は次のようになります。
 
 {{< tabpane text=true >}}
 {{< tab header="Python" >}}
@@ -62,7 +62,7 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L162" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -87,7 +87,7 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L188-L201" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -115,7 +115,7 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L162-L247" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -167,7 +167,7 @@ ProjectPage.java:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L98-L119" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -190,7 +190,7 @@ and SecuredPage.java:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L121-L160" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -213,7 +213,7 @@ EditIssueの "load" メソッドは次のようになります。
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L188-L195" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -238,7 +238,7 @@ EditIssueで `get()` を呼び出すと、そのすべての依存関係も読�
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L277-L299" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -272,7 +272,7 @@ PageObjectsは、テストでの重複を減らすための便利な方法です
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L249-L275" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
@@ -44,7 +44,7 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 
 このベースクラスを拡張することにより、2つの新しいメソッドを実装する必要があります。
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L181-L190" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
 
 `load` メソッドはページに移動するために使用され、　`isLoaded` メソッドは正しいページにいるかどうかを判断するために使用されます。 
 このメソッドはブール値を返す必要があるように見えますが、代わりにJUnitのAssertクラスを使用して一連のアサーションを実行します。 
@@ -53,7 +53,7 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 
 少し手直しすると、PageObjectは次のようになります。
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L236" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
 
 それは私たちをあまり信じられなかったようですよね？ 
 これまでに行ったことの1つは、ページに移動する方法に関する情報をページ自体にカプセル化することです。
@@ -94,20 +94,13 @@ and SecuredPage.java:
 
 EditIssueの "load" メソッドは次のようになります。
 
-```java
-  @Override
-  protected void load() {
-    securedPage.get();
-
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
 
 これは、コンポーネントがすべて相互に "ネストされている" ことを示しています。 
 EditIssueで `get()` を呼び出すと、そのすべての依存関係も読み込まれます。 
 使用例：
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L266-L289" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
 
 テストで [Guiceberry](https://github.com/zorzella/guiceberry) などのライブラリを使用している場合は、PageObjectsの設定の前文を省略して、わかりやすく読みやすいテストを作成できます。
 
@@ -122,7 +115,7 @@ PageObjectsは、テストでの重複を減らすための便利な方法です
 つまり、コマンドがアプリに対して正しいことをしていないことがわかった場合、コマンドを簡単に変更できます。 
 例として：
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L238-L264" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
 
 これらの抽象化が構築され、テストでの重複が特定されると、ボットの上にPageObjectsを階層化することができます。
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.ja.md
@@ -34,17 +34,74 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 テスト作成者の観点から、これは新しい問題を提出できるサービスを提供します。 
 基本的なページオブジェクトは次のようになります。
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L14-L76" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 これをLoadableComponentに変換するには、これを基本型として設定するだけです。
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 この署名は少し変わっているように見えますが、それは、このクラスがEditIssueページをロードするLoadableComponentを表すことを意味します。
 
 このベースクラスを拡張することにより、2つの新しいメソッドを実装する必要があります。
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 `load` メソッドはページに移動するために使用され、　`isLoaded` メソッドは正しいページにいるかどうかを判断するために使用されます。 
 このメソッドはブール値を返す必要があるように見えますが、代わりにJUnitのAssertクラスを使用して一連のアサーションを実行します。 
@@ -53,7 +110,26 @@ LoadableComponentは、PageObjectsの作成の負担を軽減することを目�
 
 少し手直しすると、PageObjectは次のようになります。
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 それは私たちをあまり信じられなかったようですよね？ 
 これまでに行ったことの1つは、ページに移動する方法に関する情報をページ自体にカプセル化することです。
@@ -86,21 +162,97 @@ LoadableComponentsは、他のLoadableComponentsと組み合わせて使用す�
 
 ProjectPage.java:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 and SecuredPage.java:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 EditIssueの "load" メソッドは次のようになります。
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 これは、コンポーネントがすべて相互に "ネストされている" ことを示しています。 
 EditIssueで `get()` を呼び出すと、そのすべての依存関係も読み込まれます。 
 使用例：
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 テストで [Guiceberry](https://github.com/zorzella/guiceberry) などのライブラリを使用している場合は、PageObjectsの設定の前文を省略して、わかりやすく読みやすいテストを作成できます。
 
@@ -115,7 +267,26 @@ PageObjectsは、テストでの重複を減らすための便利な方法です
 つまり、コマンドがアプリに対して正しいことをしていないことがわかった場合、コマンドを簡単に変更できます。 
 例として：
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 これらの抽象化が構築され、テストでの重複が特定されると、ボットの上にPageObjectsを階層化することができます。
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
@@ -38,7 +38,8 @@ but the approach used is simple enough to be implemented in any language.
 As an example of a UI that we'd like to model, take a look at 
 the [new issue](https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+) page. From 
 the point of view of a test author, this offers the service of being able to 
-file a new issue. A basic Page Object would look like:
+file a new issue. A basic Page Object -- we'll call this
+simple version `EditIssueBasic`, before turning it into the `EditIssue` LoadableComponent below -- would look like:
 
 {{< tabpane text=true >}}
 {{< tab header="Python" >}}
@@ -68,7 +69,7 @@ In order to turn this into a LoadableComponent, all we need to do is to set that
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L162" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -94,7 +95,7 @@ By extending this base class, we need to implement two new methods:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L188-L201" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -125,7 +126,7 @@ With a little rework, our PageObject looks like:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L162-L247" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -177,7 +178,7 @@ ProjectPage.java:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L98-L119" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -200,7 +201,7 @@ and SecuredPage.java:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L121-L160" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -223,7 +224,7 @@ The "load" method in EditIssue now looks like:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L188-L195" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -246,7 +247,7 @@ This shows that the components are all "nested" within each other. A call to `ge
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L277-L299" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -279,7 +280,7 @@ A "bot" is an action-oriented abstraction over the raw Selenium APIs. This means
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L249-L275" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
@@ -51,7 +51,7 @@ represents a LoadableComponent that loads the EditIssue page.
 
 By extending this base class, we need to implement two new methods:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L181-L190" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
 
 The `load` method is used to navigate to the page, whilst the `isLoaded` method 
 is used to determine whether we are on the right page. Although the 
@@ -63,7 +63,7 @@ used to debug tests.
 
 With a little rework, our PageObject looks like:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L236" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
 
 That doesn't seem to have bought us much, right? One thing it has done is 
 encapsulate the information about how to navigate to the page into the page 
@@ -104,18 +104,11 @@ and SecuredPage.java:
 
 The "load" method in EditIssue now looks like:
 
-```java
-  @Override
-  protected void load() {
-    securedPage.get();
-
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
 
 This shows that the components are all "nested" within each other. A call to `get()` in EditIssue will cause all its dependencies to load too. The example usage:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L266-L289" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
 
 If you're using a library such as [Guiceberry](https://github.com/zorzella/guiceberry) in your tests, 
 the preamble of setting up the PageObjects can be omitted leading to nice, clear, readable tests.
@@ -129,7 +122,7 @@ Although PageObjects are a useful way of reducing duplication in your tests, it'
 
 A "bot" is an action-oriented abstraction over the raw Selenium APIs. This means that if you find that commands aren't doing the Right Thing for your app, it's easy to change them. As an example:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L238-L264" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
 
 Once these abstractions have been built and duplication in your tests identified, it's possible to layer PageObjects on top of bots.
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
@@ -40,103 +40,18 @@ the [new issue](https://github.com/SeleniumHQ/selenium/issues/new?assignees=&lab
 the point of view of a test author, this offers the service of being able to 
 file a new issue. A basic Page Object would look like:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-public class EditIssue {
-
-  private final WebDriver driver;
-
-  public EditIssue(WebDriver driver) {
-    this.driver = driver;
-  }
-
-  public void setTitle(String title) {
-    WebElement field = driver.findElement(By.id("issue_title")));
-    clearAndType(field, title);
-  }
-
-  public void setBody(String body) {
-    WebElement field = driver.findElement(By.id("issue_body"));
-    clearAndType(field, body);
-  }
-
-  public void setHowToReproduce(String howToReproduce) {
-    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
-    clearAndType(field, howToReproduce);
-  }
-
-  public void setLogOutput(String logOutput) {
-    WebElement field = driver.findElement(By.id("issue_form_logs"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setOperatingSystem(String operatingSystem) {
-    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
-    clearAndType(field, operatingSystem);
-  }
-
-  public void setSeleniumVersion(String seleniumVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setBrowserVersion(String browserVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
-    clearAndType(field, browserVersion);
-  }
-
-  public void setDriverVersion(String driverVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
-    clearAndType(field, driverVersion);
-  }
-
-  public void setUsingGrid(String usingGrid) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
-    clearAndType(field, usingGrid);
-  }
-
-  public IssueList submit() {
-    driver.findElement(By.cssSelector("button[type='submit']")).click();
-    return new IssueList(driver);
-  }
-
-  private void clearAndType(WebElement field, String text) {
-    field.clear();
-    field.sendKeys(text);
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L14-L76" >}}
 
 In order to turn this into a LoadableComponent, all we need to do is to set that as the base type:
 
-```java
-public class EditIssue extends LoadableComponent<EditIssue> {
-  // rest of class ignored for now
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
 
 This signature looks a little unusual, but it all means is that this class 
 represents a LoadableComponent that loads the EditIssue page.
 
 By extending this base class, we need to implement two new methods:
 
-```java
-  @Override
-  protected void load() {
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
-  }
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L181-L190" >}}
 
 The `load` method is used to navigate to the page, whilst the `isLoaded` method 
 is used to determine whether we are on the right page. Although the 
@@ -148,94 +63,7 @@ used to debug tests.
 
 With a little rework, our PageObject looks like:
 
-```java
-package com.example.webdriver;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.PageFactory;
-
-import static junit.framework.Assert.assertTrue;
-
-public class EditIssue extends LoadableComponent<EditIssue> {
-
-  private final WebDriver driver;
-  
-  // By default the PageFactory will locate elements with the same name or id
-  // as the field. Since the issue_title element has an id attribute of "issue_title"
-  // we don't need any additional annotations.
-  private WebElement issue_title;
-  
-  // But we'd prefer a different name in our code than "issue_body", so we use the
-  // FindBy annotation to tell the PageFactory how to locate the element.
-  @FindBy(id = "issue_body") private WebElement body;
-  
-  public EditIssue(WebDriver driver) {
-    this.driver = driver;
-    
-    // This call sets the WebElement fields.
-    PageFactory.initElements(driver, this);
-  }
-
-  @Override
-  protected void load() {
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
-  }
-
-  public void setHowToReproduce(String howToReproduce) {
-    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
-    clearAndType(field, howToReproduce);
-  }
-
-  public void setLogOutput(String logOutput) {
-    WebElement field = driver.findElement(By.id("issue_form_logs"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setOperatingSystem(String operatingSystem) {
-    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
-    clearAndType(field, operatingSystem);
-  }
-
-  public void setSeleniumVersion(String seleniumVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setBrowserVersion(String browserVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
-    clearAndType(field, browserVersion);
-  }
-
-  public void setDriverVersion(String driverVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
-    clearAndType(field, driverVersion);
-  }
-
-  public void setUsingGrid(String usingGrid) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
-    clearAndType(field, usingGrid);
-  }
-
-  public IssueList submit() {
-    driver.findElement(By.cssSelector("button[type='submit']")).click();
-    return new IssueList(driver);
-  }
-
-  private void clearAndType(WebElement field, String text) {
-    field.clear();
-    field.sendKeys(text);
-  }
-}
-
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L236" >}}
 
 That doesn't seem to have bought us much, right? One thing it has done is 
 encapsulate the information about how to navigate to the page into the page 
@@ -268,93 +96,11 @@ the parent. The end result, in addition to the EditIssue class above is:
 
 ProjectPage.java:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.WebDriver;
-
-import static org.junit.Assert.assertTrue;
-
-public class ProjectPage extends LoadableComponent<ProjectPage> {
-
-  private final WebDriver driver;
-  private final String projectName;
-
-  public ProjectPage(WebDriver driver, String projectName) {
-    this.driver = driver;
-    this.projectName = projectName;
-  }
-
-  @Override
-  protected void load() {
-    driver.get("http://" + projectName + ".googlecode.com/");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-
-    assertTrue(url.contains(projectName));
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
 
 and SecuredPage.java:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-import static org.junit.Assert.fail;
-
-public class SecuredPage extends LoadableComponent<SecuredPage> {
-
-  private final WebDriver driver;
-  private final LoadableComponent<?> parent;
-  private final String username;
-  private final String password;
-
-  public SecuredPage(WebDriver driver, LoadableComponent<?> parent, String username, String password) {
-    this.driver = driver;
-    this.parent = parent;
-    this.username = username;
-    this.password = password;
-  }
-
-  @Override
-  protected void load() {
-    parent.get();
-
-    String originalUrl = driver.getCurrentUrl();
-
-    // Sign in
-    driver.get("https://www.google.com/accounts/ServiceLogin?service=code");
-    driver.findElement(By.name("Email")).sendKeys(username);
-    WebElement passwordField = driver.findElement(By.name("Passwd"));
-    passwordField.sendKeys(password);
-    passwordField.submit();
-
-    // Now return to the original URL
-    driver.get(originalUrl);
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    // If you're signed in, you have the option of picking a different login.
-    // Let's check for the presence of that.
-
-    try {
-      WebElement div = driver.findElement(By.id("multilogin-dropdown"));
-    } catch (NoSuchElementException e) {
-      fail("Cannot locate user name link");
-    }
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
 
 The "load" method in EditIssue now looks like:
 
@@ -369,35 +115,7 @@ The "load" method in EditIssue now looks like:
 
 This shows that the components are all "nested" within each other. A call to `get()` in EditIssue will cause all its dependencies to load too. The example usage:
 
-```java
-public class FooTest {
-  private EditIssue editIssue;
-
-  @Before
-  public void prepareComponents() {
-    WebDriver driver = new FirefoxDriver();
-
-    ProjectPage project = new ProjectPage(driver, "selenium");
-    SecuredPage securedPage = new SecuredPage(driver, project, "example", "top secret");
-    editIssue = new EditIssue(driver, securedPage);
-  }
-
-  @Test
-  public void demonstrateNestedLoadableComponents() {
-    editIssue.get();
-
-    editIssue.title.sendKeys('Title');
-    editIssue.body.sendKeys('What Happened');
-    editIssue.setHowToReproduce('How to Reproduce');
-    editIssue.setLogOutput('Log Output');
-    editIssue.setOperatingSystem('Operating System');
-    editIssue.setSeleniumVersion('Selenium Version');
-    editIssue.setBrowserVersion('Browser Version');
-    editIssue.setDriverVersion('Driver Version');
-    editIssue.setUsingGrid('I Am Using Grid');
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L266-L289" >}}
 
 If you're using a library such as [Guiceberry](https://github.com/zorzella/guiceberry) in your tests, 
 the preamble of setting up the PageObjects can be omitted leading to nice, clear, readable tests.
@@ -411,34 +129,7 @@ Although PageObjects are a useful way of reducing duplication in your tests, it'
 
 A "bot" is an action-oriented abstraction over the raw Selenium APIs. This means that if you find that commands aren't doing the Right Thing for your app, it's easy to change them. As an example:
 
-```java
-public class ActionBot {
-  private final WebDriver driver;
-
-  public ActionBot(WebDriver driver) {
-    this.driver = driver;
-  }
-
-  public void click(By locator) {
-    driver.findElement(locator).click();
-  }
-
-  public void submit(By locator) {
-    driver.findElement(locator).submit();
-  }
-
-  /** 
-   * Type something into an input field. WebDriver doesn't normally clear these
-   * before typing, so this method does that first. It also sends a return key
-   * to move the focus out of the element.
-   */
-  public void type(By locator, String text) { 
-    WebElement element = driver.findElement(locator);
-    element.clear();
-    element.sendKeys(text + "\n");
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L238-L264" >}}
 
 Once these abstractions have been built and duplication in your tests identified, it's possible to layer PageObjects on top of bots.
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.pt-br.md
@@ -40,18 +40,75 @@ the [new issue](https://github.com/SeleniumHQ/selenium/issues/new?assignees=&lab
 the point of view of a test author, this offers the service of being able to 
 file a new issue. A basic Page Object would look like:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L14-L76" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 In order to turn this into a LoadableComponent, all we need to do is to set that as the base type:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 This signature looks a little unusual, but it all means is that this class 
 represents a LoadableComponent that loads the EditIssue page.
 
 By extending this base class, we need to implement two new methods:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 The `load` method is used to navigate to the page, whilst the `isLoaded` method 
 is used to determine whether we are on the right page. Although the 
@@ -63,7 +120,26 @@ used to debug tests.
 
 With a little rework, our PageObject looks like:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 That doesn't seem to have bought us much, right? One thing it has done is 
 encapsulate the information about how to navigate to the page into the page 
@@ -96,19 +172,95 @@ the parent. The end result, in addition to the EditIssue class above is:
 
 ProjectPage.java:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 and SecuredPage.java:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 The "load" method in EditIssue now looks like:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 This shows that the components are all "nested" within each other. A call to `get()` in EditIssue will cause all its dependencies to load too. The example usage:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 If you're using a library such as [Guiceberry](https://github.com/zorzella/guiceberry) in your tests, 
 the preamble of setting up the PageObjects can be omitted leading to nice, clear, readable tests.
@@ -122,7 +274,26 @@ Although PageObjects are a useful way of reducing duplication in your tests, it'
 
 A "bot" is an action-oriented abstraction over the raw Selenium APIs. This means that if you find that commands aren't doing the Right Thing for your app, it's easy to change them. As an example:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 Once these abstractions have been built and duplication in your tests identified, it's possible to layer PageObjects on top of bots.
 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
@@ -43,12 +43,50 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 一个基本的页面对象看起来像:
 
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L14-L76" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 为了把它变成一个 LoadableComponent, 
 我们所要做的就是将其设为基类:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 这个签名看起来有些不寻常, 但它的含义很简单:
 该类表示一个用于加载 EditIssue 页面 的 LoadableComponent.
@@ -56,7 +94,26 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 
 通过继承这个基类, 我们需要实现两个新方法:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 
 `load` 方法用于导航到页面, 
@@ -69,7 +126,26 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 
 稍作改造后, 我们的页面对象如下：
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 看起来似乎没带来太多好处, 对吧？
 不过它确实把如何导航到该页面的信息封装进了页面本身, 
@@ -102,22 +178,98 @@ EditIssue page = new EditIssue(driver).get();
 
 ProjectPage.java:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
  
 以及 SecuredPage.java:
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 EditIssue 中的 `load` 方法现在如下：
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 
 这表明这些组件都是相互 "嵌套" 的. 
 在 EditIssue 中调用 `get()` 会导致它的所有依赖组件也被加载. 
 示例用法：
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 如果在测试中使用像 [Guiceberry](https://github.com/zorzella/guiceberry) 这样的库,
 设置页面对象的前置步骤可以省略, 从而使测试更简洁、可读.
@@ -137,7 +289,26 @@ EditIssue 中的 `load` 方法现在如下：
 “bot” 是对底层 Selenium API 的一种面向动作的抽象. 
 这意味着如果发现某些命令不适合你的应用, 可以轻松修改它们. 例如：
 
+{{< tabpane text=true >}}
+{{< tab header="Python" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Java" >}}
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
+{{< /tab >}}
+{{< tab header="CSharp" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Ruby" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="JavaScript" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< tab header="Kotlin" >}}
+{{< badge-code >}}
+{{< /tab >}}
+{{< /tabpane >}}
 
 
 一旦构建了这些抽象并找出测试中的重复, 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
@@ -40,7 +40,7 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 
 举个我们想要建模的 UI 的例子, 看看 [new issue](https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+) 页面.
 对于测试作者而言, 该页面的作用是提供一个提交新 issue 的功能. 
-一个基本的页面对象看起来像:
+一个基本的页面对象(这个简化版本我们称为 `EditIssueBasic`, 之后会把它改造成 `EditIssue` 这个 LoadableComponent)看起来像:
 
 
 {{< tabpane text=true >}}
@@ -72,7 +72,7 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L162" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -99,7 +99,7 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L188-L201" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -131,7 +131,7 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L162-L247" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -183,7 +183,7 @@ ProjectPage.java:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L98-L119" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -206,7 +206,7 @@ ProjectPage.java:
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L121-L160" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -229,7 +229,7 @@ EditIssue 中的 `load` 方法现在如下：
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L188-L195" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -255,7 +255,7 @@ EditIssue 中的 `load` 方法现在如下：
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L277-L299" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}
@@ -294,7 +294,7 @@ EditIssue 中的 `load` 方法现在如下：
 {{< badge-code >}}
 {{< /tab >}}
 {{< tab header="Java" >}}
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L249-L275" >}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
@@ -56,7 +56,7 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 
 通过继承这个基类, 我们需要实现两个新方法:
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L181-L190" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L200" >}}
 
 
 `load` 方法用于导航到页面, 
@@ -69,7 +69,7 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 
 稍作改造后, 我们的页面对象如下：
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L236" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L246" >}}
 
 看起来似乎没带来太多好处, 对吧？
 不过它确实把如何导航到该页面的信息封装进了页面本身, 
@@ -110,21 +110,14 @@ ProjectPage.java:
 
 EditIssue 中的 `load` 方法现在如下：
 
-```java
-  @Override
-  protected void load() {
-    securedPage.get();
-
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L187-L194" >}}
 
 
 这表明这些组件都是相互 "嵌套" 的. 
 在 EditIssue 中调用 `get()` 会导致它的所有依赖组件也被加载. 
 示例用法：
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L266-L289" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L276-L298" >}}
 
 如果在测试中使用像 [Guiceberry](https://github.com/zorzella/guiceberry) 这样的库,
 设置页面对象的前置步骤可以省略, 从而使测试更简洁、可读.
@@ -144,7 +137,7 @@ EditIssue 中的 `load` 方法现在如下：
 “bot” 是对底层 Selenium API 的一种面向动作的抽象. 
 这意味着如果发现某些命令不适合你的应用, 可以轻松修改它们. 例如：
 
-{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L238-L264" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L248-L274" >}}
 
 
 一旦构建了这些抽象并找出测试中的重复, 

--- a/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
+++ b/website_and_docs/content/documentation/test_practices/design_strategies.zh-cn.md
@@ -43,86 +43,12 @@ LoadableComponent 是一个基类, 目标是让编写页面对象更轻松.
 一个基本的页面对象看起来像:
 
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-public class EditIssue {
-
-  private final WebDriver driver;
-
-  public EditIssue(WebDriver driver) {
-    this.driver = driver;
-  }
-
-  public void setTitle(String title) {
-    WebElement field = driver.findElement(By.id("issue_title")));
-    clearAndType(field, title);
-  }
-
-  public void setBody(String body) {
-    WebElement field = driver.findElement(By.id("issue_body"));
-    clearAndType(field, body);
-  }
-
-  public void setHowToReproduce(String howToReproduce) {
-    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
-    clearAndType(field, howToReproduce);
-  }
-
-  public void setLogOutput(String logOutput) {
-    WebElement field = driver.findElement(By.id("issue_form_logs"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setOperatingSystem(String operatingSystem) {
-    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
-    clearAndType(field, operatingSystem);
-  }
-
-  public void setSeleniumVersion(String seleniumVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setBrowserVersion(String browserVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
-    clearAndType(field, browserVersion);
-  }
-
-  public void setDriverVersion(String driverVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
-    clearAndType(field, driverVersion);
-  }
-
-  public void setUsingGrid(String usingGrid) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
-    clearAndType(field, usingGrid);
-  }
-
-  public IssueList submit() {
-    driver.findElement(By.cssSelector("button[type='submit']")).click();
-    return new IssueList(driver);
-  }
-
-  private void clearAndType(WebElement field, String text) {
-    field.clear();
-    field.sendKeys(text);
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L14-L76" >}}
 
 为了把它变成一个 LoadableComponent, 
 我们所要做的就是将其设为基类:
 
-```java
-public class EditIssue extends LoadableComponent<EditIssue> {
-  // rest of class ignored for now
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161" >}}
 
 这个签名看起来有些不寻常, 但它的含义很简单:
 该类表示一个用于加载 EditIssue 页面 的 LoadableComponent.
@@ -130,18 +56,7 @@ public class EditIssue extends LoadableComponent<EditIssue> {
 
 通过继承这个基类, 我们需要实现两个新方法:
 
-```java
-  @Override
-  protected void load() {
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
-  }
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L181-L190" >}}
 
 
 `load` 方法用于导航到页面, 
@@ -154,93 +69,7 @@ public class EditIssue extends LoadableComponent<EditIssue> {
 
 稍作改造后, 我们的页面对象如下：
 
-```java
-package com.example.webdriver;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.PageFactory;
-
-import static junit.framework.Assert.assertTrue;
-
-public class EditIssue extends LoadableComponent<EditIssue> {
-
-  private final WebDriver driver;
-  
-  // By default the PageFactory will locate elements with the same name or id
-  // as the field. Since the issue_title element has an id attribute of "issue_title"
-  // we don't need any additional annotations.
-  private WebElement issue_title;
-  
-  // But we'd prefer a different name in our code than "issue_body", so we use the
-  // FindBy annotation to tell the PageFactory how to locate the element.
-  @FindBy(id = "issue_body") private WebElement body;
-  
-  public EditIssue(WebDriver driver) {
-    this.driver = driver;
-    
-    // This call sets the WebElement fields.
-    PageFactory.initElements(driver, this);
-  }
-
-  @Override
-  protected void load() {
-    driver.get("https://github.com/SeleniumHQ/selenium/issues/new?assignees=&labels=I-defect%2Cneeds-triaging&projects=&template=bug-report.yml&title=%5B%F0%9F%90%9B+Bug%5D%3A+");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-    assertTrue("Not on the issue entry page: " + url, url.endsWith("/new"));
-  }
-
-  public void setHowToReproduce(String howToReproduce) {
-    WebElement field = driver.findElement(By.id("issue_form_repro-command"));
-    clearAndType(field, howToReproduce);
-  }
-
-  public void setLogOutput(String logOutput) {
-    WebElement field = driver.findElement(By.id("issue_form_logs"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setOperatingSystem(String operatingSystem) {
-    WebElement field = driver.findElement(By.id("issue_form_operating-system"));
-    clearAndType(field, operatingSystem);
-  }
-
-  public void setSeleniumVersion(String seleniumVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-version"));
-    clearAndType(field, logOutput);
-  }
-
-  public void setBrowserVersion(String browserVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-versions"));
-    clearAndType(field, browserVersion);
-  }
-
-  public void setDriverVersion(String driverVersion) {
-    WebElement field = driver.findElement(By.id("issue_form_browser-driver-versions"));
-    clearAndType(field, driverVersion);
-  }
-
-  public void setUsingGrid(String usingGrid) {
-    WebElement field = driver.findElement(By.id("issue_form_selenium-grid-version"));
-    clearAndType(field, usingGrid);
-  }
-
-  public IssueList submit() {
-    driver.findElement(By.cssSelector("button[type='submit']")).click();
-    return new IssueList(driver);
-  }
-
-  private void clearAndType(WebElement field, String text) {
-    field.clear();
-    field.sendKeys(text);
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L161-L236" >}}
 
 看起来似乎没带来太多好处, 对吧？
 不过它确实把如何导航到该页面的信息封装进了页面本身, 
@@ -273,93 +102,11 @@ EditIssue page = new EditIssue(driver).get();
 
 ProjectPage.java:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.WebDriver;
-
-import static org.junit.Assert.assertTrue;
-
-public class ProjectPage extends LoadableComponent<ProjectPage> {
-
-  private final WebDriver driver;
-  private final String projectName;
-
-  public ProjectPage(WebDriver driver, String projectName) {
-    this.driver = driver;
-    this.projectName = projectName;
-  }
-
-  @Override
-  protected void load() {
-    driver.get("http://" + projectName + ".googlecode.com/");
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    String url = driver.getCurrentUrl();
-
-    assertTrue(url.contains(projectName));
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L97-L118" >}}
  
 以及 SecuredPage.java:
 
-```java
-package com.example.webdriver;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
-
-import static org.junit.Assert.fail;
-
-public class SecuredPage extends LoadableComponent<SecuredPage> {
-
-  private final WebDriver driver;
-  private final LoadableComponent<?> parent;
-  private final String username;
-  private final String password;
-
-  public SecuredPage(WebDriver driver, LoadableComponent<?> parent, String username, String password) {
-    this.driver = driver;
-    this.parent = parent;
-    this.username = username;
-    this.password = password;
-  }
-
-  @Override
-  protected void load() {
-    parent.get();
-
-    String originalUrl = driver.getCurrentUrl();
-
-    // Sign in
-    driver.get("https://www.google.com/accounts/ServiceLogin?service=code");
-    driver.findElement(By.name("Email")).sendKeys(username);
-    WebElement passwordField = driver.findElement(By.name("Passwd"));
-    passwordField.sendKeys(password);
-    passwordField.submit();
-
-    // Now return to the original URL
-    driver.get(originalUrl);
-  }
-
-  @Override
-  protected void isLoaded() throws Error {
-    // If you're signed in, you have the option of picking a different login.
-    // Let's check for the presence of that.
-
-    try {
-      WebElement div = driver.findElement(By.id("multilogin-dropdown"));
-    } catch (NoSuchElementException e) {
-      fail("Cannot locate user name link");
-    }
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L120-L159" >}}
 
 EditIssue 中的 `load` 方法现在如下：
 
@@ -377,35 +124,7 @@ EditIssue 中的 `load` 方法现在如下：
 在 EditIssue 中调用 `get()` 会导致它的所有依赖组件也被加载. 
 示例用法：
 
-```java
-public class FooTest {
-  private EditIssue editIssue;
-
-  @Before
-  public void prepareComponents() {
-    WebDriver driver = new FirefoxDriver();
-
-    ProjectPage project = new ProjectPage(driver, "selenium");
-    SecuredPage securedPage = new SecuredPage(driver, project, "example", "top secret");
-    editIssue = new EditIssue(driver, securedPage);
-  }
-
-  @Test
-  public void demonstrateNestedLoadableComponents() {
-    editIssue.get();
-
-    editIssue.title.sendKeys('Title');
-    editIssue.body.sendKeys('What Happened');
-    editIssue.setHowToReproduce('How to Reproduce');
-    editIssue.setLogOutput('Log Output');
-    editIssue.setOperatingSystem('Operating System');
-    editIssue.setSeleniumVersion('Selenium Version');
-    editIssue.setBrowserVersion('Browser Version');
-    editIssue.setDriverVersion('Driver Version');
-    editIssue.setUsingGrid('I Am Using Grid');
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L266-L289" >}}
 
 如果在测试中使用像 [Guiceberry](https://github.com/zorzella/guiceberry) 这样的库,
 设置页面对象的前置步骤可以省略, 从而使测试更简洁、可读.
@@ -425,34 +144,7 @@ public class FooTest {
 “bot” 是对底层 Selenium API 的一种面向动作的抽象. 
 这意味着如果发现某些命令不适合你的应用, 可以轻松修改它们. 例如：
 
-```java
-public class ActionBot {
-  private final WebDriver driver;
-
-  public ActionBot(WebDriver driver) {
-    this.driver = driver;
-  }
-
-  public void click(By locator) {
-    driver.findElement(locator).click();
-  }
-
-  public void submit(By locator) {
-    driver.findElement(locator).submit();
-  }
-
-  /** 
-   * Type something into an input field. WebDriver doesn't normally clear these
-   * before typing, so this method does that first. It also sends a return key
-   * to move the focus out of the element.
-   */
-  public void type(By locator, String text) { 
-    WebElement element = driver.findElement(locator);
-    element.clear();
-    element.sendKeys(text + "\n");
-  }
-}
-```
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java#L238-L264" >}}
 
 
 一旦构建了这些抽象并找出测试中的重复, 


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.


### Description

Redo of #2308 by @shbenzer. Moves the inline Java code fences in the "Loadable Component" / "Bot Pattern" walkthrough (`design_strategies.en/ja/pt-br/zh-cn.md`) into a real, compiling source file (`examples/java/src/test/java/dev/selenium/design_strategies/BestPractices.java`), referenced from the docs via `gh-codeblock` instead of duplicated inline snippets.

#2308 had the same goal but had drifted out of sync with trunk and had a few issues (a truncated code block, a class renamed mid-narrative, a reference into dead/commented-out code, and an unrelated malformed line-range on the Python tab). This redoes it from scratch against current trunk with those fixed:

- Fixed two bugs that were already present in the old inline snippets: a stray extra `)` in `setTitle`, and `setSeleniumVersion` writing to the wrong field via a copy-pasted variable name (`logOutput` instead of `seleniumVersion`).
- Added a JUnit5 test wiring the full nested-components example (`ProjectPage` → `SecuredPage` → `EditIssue`) end-to-end, so the type-level correctness of the whole example is actually verified by the build. It's marked `@Disabled` since running it would exercise live GitHub/Google sign-in flows against real external sites.
- Verified with `mvn test-compile` and `mvn test` that everything compiles and the disabled test is properly skipped (not silently ignored).
- Hand-checked every new `gh-codeblock` line range against the final file content to make sure each one shows exactly the intended snippet.

### Motivation and Context

Keeps the Java examples in this doc consistent with how other docs in this repo already work (tested source + `gh-codeblock`, rather than inline snippets that can silently drift or contain uncaught bugs), and fixes latent bugs in the existing content along the way.

### Types of changes
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.