### PR TITLE
Fix missing Java examples for ByChained/ByAll locator strategies

### DIFF
--- a/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java
+++ b/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java
@@ -99,7 +99,7 @@ public class LocatorTest {
     public void testByChained() {
         driver.get("https://www.selenium.dev/selenium/web/login.html");
 
-        By locator = new ByChained(By.id("login-form"), By.id("username-field"));
+        By locator = new ByChained(By.id("login-form"), By.tagName("input"));
         WebElement usernameInput = driver.findElement(locator);
 
         Assertions.assertEquals("Username", usernameInput.getAttribute("placeholder"));

--- a/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java
+++ b/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java
@@ -1,3 +1,4 @@
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -6,6 +7,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.support.pagefactory.ByAll;
+import org.openqa.selenium.support.pagefactory.ByChained;
 
 public class LocatorTest {
 
@@ -80,5 +83,25 @@ public class LocatorTest {
         WebElement element = driver.findElement(By.xpath("//input[@value='f']"));
         Assertions.assertNotNull(element);
         Assertions.assertEquals("radio", element.getAttribute("type"));
+    }
+
+    @Test
+    public void testByAll() {
+        driver.get("https://www.selenium.dev/selenium/web/login.html");
+
+        By locator = new ByAll(By.id("password-field"), By.id("username-field"));
+        List<WebElement> loginInputs = driver.findElements(locator);
+
+        Assertions.assertEquals(2, loginInputs.size());
+    }
+
+    @Test
+    public void testByChained() {
+        driver.get("https://www.selenium.dev/selenium/web/login.html");
+
+        By locator = new ByChained(By.id("login-form"), By.id("username-field"));
+        WebElement usernameInput = driver.findElement(locator);
+
+        Assertions.assertEquals("Username", usernameInput.getAttribute("placeholder"));
     }
 }

--- a/website_and_docs/content/documentation/webdriver/elements/locators.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.en.md
@@ -77,7 +77,7 @@ available in Selenium.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L31" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L7-L9" >}}
@@ -108,7 +108,7 @@ textbox, using css.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L38" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L17-L19" >}}
@@ -137,7 +137,7 @@ We will identify the Last Name field using it.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L45" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L27-L29" >}}
@@ -167,7 +167,7 @@ We will identify the Newsletter checkbox using it.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L52" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L37-L39" >}}
@@ -195,7 +195,7 @@ In the HTML snippet shared, we have a link available, let's see how will we loca
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L59" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L47-L49" >}}
@@ -224,7 +224,7 @@ In the HTML snippet shared, we have a link available, lets see how will we locat
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L66" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L57-L59" >}}
@@ -251,7 +251,7 @@ From the above HTML snippet shared, lets identify the link, using its html tag "
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L73" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L67-L69" >}}
@@ -284,7 +284,7 @@ first name text box. Let us create locator for female radio button using xpath.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L80" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L77-L79" >}}
@@ -351,7 +351,7 @@ and then a child element of that parent, you can instead combine those two `Find
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorsTest.java#L37-L38">}}
+    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}
@@ -378,7 +378,7 @@ separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorsTest.java#L22-L23">}}
+    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.en.md
@@ -77,7 +77,7 @@ available in Selenium.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L7-L9" >}}
@@ -108,7 +108,7 @@ textbox, using css.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L17-L19" >}}
@@ -137,7 +137,7 @@ We will identify the Last Name field using it.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L27-L29" >}}
@@ -167,7 +167,7 @@ We will identify the Newsletter checkbox using it.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L37-L39" >}}
@@ -195,7 +195,7 @@ In the HTML snippet shared, we have a link available, let's see how will we loca
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L47-L49" >}}
@@ -224,7 +224,7 @@ In the HTML snippet shared, we have a link available, lets see how will we locat
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L57-L59" >}}
@@ -251,7 +251,7 @@ From the above HTML snippet shared, lets identify the link, using its html tag "
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L67-L69" >}}
@@ -284,7 +284,7 @@ first name text box. Let us create locator for female radio button using xpath.
 {{< tabpane langEqualsHeader=true >}}
 {{< badge-examples >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L77-L79" >}}
@@ -351,7 +351,7 @@ and then a child element of that parent, you can instead combine those two `Find
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103">}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}
@@ -378,7 +378,7 @@ separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
@@ -75,7 +75,7 @@ above shown HTML snippet. We can identify these elements using the class name lo
 available in Selenium. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L31" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L7-L9" >}}
@@ -106,7 +106,7 @@ textbox, using css.
 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L38" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L17-L19" >}}
@@ -135,7 +135,7 @@ We will identify the Last Name field using it.
 
 {{< tabpane langEqualsHeader=true >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L45" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L27-L29" >}}
@@ -165,7 +165,7 @@ We will identify the Newsletter checkbox using it.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L52" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L37-L39" >}}
@@ -193,7 +193,7 @@ to identify it on the web page. The link text is the text displayed of the link.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
     {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L59" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L47-L49" >}}
@@ -222,7 +222,7 @@ We can pass partial text as value.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L66" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L57-L59" >}}
@@ -249,7 +249,7 @@ We can use the HTML TAG itself as a locator to identify the web element on the p
 From the above HTML snippet shared, lets identify the link, using its html tag "a". 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L73" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L67-L69" >}}
@@ -282,7 +282,7 @@ first name text box. Let us create locator for female radio button using xpath.
 
 {{< tabpane langEqualsHeader=true >}}
     {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L80" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L77-L79" >}}
@@ -350,7 +350,7 @@ functions into one.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorsTest.java#L37-L38" >}}
+    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}
@@ -377,7 +377,7 @@ you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorsTest.java#L22-L23">}}
+    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.ja.md
@@ -75,7 +75,7 @@ above shown HTML snippet. We can identify these elements using the class name lo
 available in Selenium. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L7-L9" >}}
@@ -106,7 +106,7 @@ textbox, using css.
 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L17-L19" >}}
@@ -135,7 +135,7 @@ We will identify the Last Name field using it.
 
 {{< tabpane langEqualsHeader=true >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L27-L29" >}}
@@ -165,7 +165,7 @@ We will identify the Newsletter checkbox using it.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L37-L39" >}}
@@ -193,7 +193,7 @@ to identify it on the web page. The link text is the text displayed of the link.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
     {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L47-L49" >}}
@@ -222,7 +222,7 @@ We can pass partial text as value.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L57-L59" >}}
@@ -249,7 +249,7 @@ We can use the HTML TAG itself as a locator to identify the web element on the p
 From the above HTML snippet shared, lets identify the link, using its html tag "a". 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L67-L69" >}}
@@ -282,7 +282,7 @@ first name text box. Let us create locator for female radio button using xpath.
 
 {{< tabpane langEqualsHeader=true >}}
     {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L77-L79" >}}
@@ -350,7 +350,7 @@ functions into one.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}
@@ -377,7 +377,7 @@ you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
@@ -78,7 +78,7 @@ above shown HTML snippet. We can identify these elements using the class name lo
 available in Selenium. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L7-L9" >}}
@@ -109,7 +109,7 @@ textbox, using css.
 
 {{< tabpane langEqualsHeader=true >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L17-L19" >}}
@@ -138,7 +138,7 @@ We will identify the Last Name field using it.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L27-L29" >}}
@@ -168,7 +168,7 @@ We will identify the Newsletter checkbox using it.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L37-L39" >}}
@@ -196,7 +196,7 @@ to identify it on the web page. The link text is the text displayed of the link.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L47-L49" >}}
@@ -225,7 +225,7 @@ We can pass partial text as value.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L57-L59" >}}
@@ -252,7 +252,7 @@ We can use the HTML TAG itself as a locator to identify the web element on the p
 From the above HTML snippet shared, lets identify the link, using its html tag "a". 
 {{< tabpane langEqualsHeader=true >}}
     {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L67-L69" >}}
@@ -285,7 +285,7 @@ first name text box. Let us create locator for female radio button using xpath.
 
 {{< tabpane langEqualsHeader=true >}}
     {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L77-L79" >}}
@@ -353,7 +353,7 @@ combine those two `FindElement` functions into one.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}
@@ -380,7 +380,7 @@ separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.pt-br.md
@@ -78,7 +78,7 @@ above shown HTML snippet. We can identify these elements using the class name lo
 available in Selenium. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L31" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L7-L9" >}}
@@ -109,7 +109,7 @@ textbox, using css.
 
 {{< tabpane langEqualsHeader=true >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L38" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L17-L19" >}}
@@ -138,7 +138,7 @@ We will identify the Last Name field using it.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L45" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L27-L29" >}}
@@ -168,7 +168,7 @@ We will identify the Newsletter checkbox using it.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L52" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L37-L39" >}}
@@ -196,7 +196,7 @@ to identify it on the web page. The link text is the text displayed of the link.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L59" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L47-L49" >}}
@@ -225,7 +225,7 @@ We can pass partial text as value.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L66" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L57-L59" >}}
@@ -252,7 +252,7 @@ We can use the HTML TAG itself as a locator to identify the web element on the p
 From the above HTML snippet shared, lets identify the link, using its html tag "a". 
 {{< tabpane langEqualsHeader=true >}}
     {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L73" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L67-L69" >}}
@@ -285,7 +285,7 @@ first name text box. Let us create locator for female radio button using xpath.
 
 {{< tabpane langEqualsHeader=true >}}
     {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L80" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L77-L79" >}}
@@ -353,7 +353,7 @@ combine those two `FindElement` functions into one.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorsTest.java#L37-L38" >}}
+    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}
@@ -380,7 +380,7 @@ separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorsTest.java#L22-L23">}}
+    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
@@ -78,7 +78,7 @@ above shown HTML snippet. We can identify these elements using the class name lo
 available in Selenium. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L7-L9" >}}
@@ -109,7 +109,7 @@ textbox, using css.
 
 {{< tabpane langEqualsHeader=true >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L17-L19" >}}
@@ -138,7 +138,7 @@ We will identify the Last Name field using it.
 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L27-L29" >}}
@@ -168,7 +168,7 @@ We will identify the Newsletter checkbox using it.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L37-L39" >}}
@@ -196,7 +196,7 @@ to identify it on the web page. The link text is the text displayed of the link.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L47-L49" >}}
@@ -225,7 +225,7 @@ We can pass partial text as value.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L57-L59" >}}
@@ -252,7 +252,7 @@ We can use the HTML TAG itself as a locator to identify the web element on the p
 From the above HTML snippet shared, lets identify the link, using its html tag "a". 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L67-L69" >}}
@@ -285,7 +285,7 @@ first name text box. Let us create locator for female radio button using xpath.
 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L77-L79" >}}
@@ -353,7 +353,7 @@ you can instead combine those two `FindElement` functions into one.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}
@@ -380,7 +380,7 @@ separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
+{{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/locators.zh-cn.md
@@ -78,7 +78,7 @@ above shown HTML snippet. We can identify these elements using the class name lo
 available in Selenium. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L31" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L34" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L7-L9" >}}
@@ -109,7 +109,7 @@ textbox, using css.
 
 {{< tabpane langEqualsHeader=true >}}
  {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L38" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L41" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L17-L19" >}}
@@ -138,7 +138,7 @@ We will identify the Last Name field using it.
 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L45" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L48" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L27-L29" >}}
@@ -168,7 +168,7 @@ We will identify the Newsletter checkbox using it.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L52" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L55" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L37-L39" >}}
@@ -196,7 +196,7 @@ to identify it on the web page. The link text is the text displayed of the link.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L59" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L62" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L47-L49" >}}
@@ -225,7 +225,7 @@ We can pass partial text as value.
 In the HTML snippet shared, we have a link available, lets see how will we locate it. 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L66" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L69" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L57-L59" >}}
@@ -252,7 +252,7 @@ We can use the HTML TAG itself as a locator to identify the web element on the p
 From the above HTML snippet shared, lets identify the link, using its html tag "a". 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L73" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L76" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L67-L69" >}}
@@ -285,7 +285,7 @@ first name text box. Let us create locator for female radio button using xpath.
 
 {{< tabpane langEqualsHeader=true >}}
    {{< tab header="Java" >}}
-   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L80" >}}
+   {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L83" >}}
   {{< /tab >}}
 {{< tab header="Python" text=true >}}
 {{< gh-codeblock path="/examples/python/tests/elements/test_locators.py#L77-L79" >}}
@@ -353,7 +353,7 @@ you can instead combine those two `FindElement` functions into one.
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorsTest.java#L37-L38" >}}
+    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L102-L103" >}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}
@@ -380,7 +380,7 @@ separately, you can instead find them together in one clean `FindElements()`
 
 {{< tabpane langEqualsHeader=true >}}
   {{< tab header="Java" text=true >}}
-    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorsTest.java#L22-L23">}}
+    {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/LocatorTest.java#L92-L93">}}
   {{< /tab >}}
   {{< tab header="Python" text=true >}}
   {{< badge-code >}}


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.

### Description
Adds `testByAll` and `testByChained` methods to `examples/java/src/test/java/dev/selenium/elements/LocatorTest.java`, and updates the Locator Strategies documentation (en, ja, pt-br, zh-cn) to reference them with corrected line numbers.

### Motivation and Context
Reported in #2620 ("Missing Java examples for Locator strategies").

A prior refactor (#2583) consolidated the Java locator examples into `LocatorTest.java` and deleted the old `LocatorsTest.java`, but the "ByChained" and "ByAll" sections of the [Locator Strategies](https://www.selenium.dev/documentation/webdriver/elements/locators/) doc, in all four languages, were left pointing at the deleted file. Those `gh-codeblock` references resolved to nothing since the file no longer exists.

This adds real, runnable implementations of `ByAll` and `ByChained` (verified against `https://www.selenium.dev/selenium/web/login.html`) to `LocatorTest.java`, and repoints the four language docs at the correct file. Adding the new imports shifted every existing line number in the file by 3, so the doc's other Java `gh-codeblock` references (class name, css selector, id, name, link text, partial link text, tag name, xpath) were also updated to match.

Note: the "Relative Locators" section (above/below/left of/right of/near/chaining) still uses hardcoded snippets rather than `gh-codeblock` for all languages, not just Java — that's a larger change (needs a fixture page with matching elements) and is left out of this PR to keep it focused.

### Types of changes
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

Closes #2620.