### PR TITLE
[dotnet] Avoid blocking async operations in examples

### DIFF
--- a/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/ChromeTest.cs
@@ -22,11 +22,11 @@ namespace SeleniumDocs.Browsers
         [TestCleanup]
         public void Cleanup()
         {
+            driver?.Quit();
             if (_logLocation != null && File.Exists(_logLocation))
             {
                 File.Delete(_logLocation);
             }
-            driver?.Quit();
         }
 
         [TestMethod]
@@ -47,7 +47,7 @@ namespace SeleniumDocs.Browsers
         }
 
         [TestMethod]
-        public void SetBrowserLocation()
+        public async Task SetBrowserLocation()
         {
             string userDataDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(userDataDir);
@@ -56,7 +56,7 @@ namespace SeleniumDocs.Browsers
             options.AddArgument("--no-sandbox");
             options.AddArgument("--disable-dev-shm-usage");
 
-            options.BinaryLocation = GetChromeLocation();
+            options.BinaryLocation = await GetChromeLocationAsync();
 
             driver = new ChromeDriver(options);
         }
@@ -171,13 +171,13 @@ namespace SeleniumDocs.Browsers
             return _logLocation;
         }
 
-        private static string GetChromeLocation()
+        private static async Task<string> GetChromeLocationAsync()
         {
             var options = new ChromeOptions
             {
                 BrowserVersion = "stable"
             };
-            return new DriverFinder(options).GetBrowserPathAsync().AsTask().GetAwaiter().GetResult();
+            return await new DriverFinder(options).GetBrowserPathAsync();
         }
     }
 }

--- a/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/EdgeTest.cs
@@ -53,12 +53,12 @@ namespace SeleniumDocs.Browsers
         }
 
         [TestMethod]
-        public void SetBrowserLocation()
+        public async System.Threading.Tasks.Task SetBrowserLocation()
         {
             var options = new EdgeOptions();
             options.AddArgument("--no-sandbox");
 
-            options.BinaryLocation = GetEdgeLocation();
+            options.BinaryLocation = await GetEdgeLocationAsync();
 
             driver = new EdgeDriver(options);
         }
@@ -194,13 +194,13 @@ namespace SeleniumDocs.Browsers
             return _logLocation;
         }
 
-        private static string GetEdgeLocation()
+        private static async System.Threading.Tasks.Task<string> GetEdgeLocationAsync()
         {
             var options = new EdgeOptions
             {
                 BrowserVersion = "stable"
             };
-            return new DriverFinder(options).GetBrowserPathAsync().AsTask().GetAwaiter().GetResult();
+            return await new DriverFinder(options).GetBrowserPathAsync();
         }
     }
 }

--- a/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/FirefoxTest.cs
@@ -19,11 +19,11 @@ namespace SeleniumDocs.Browsers
         [TestCleanup]
         public void Cleanup()
         {
+            driver?.Quit();
             if (!String.IsNullOrEmpty(_logLocation) && File.Exists(_logLocation))
             {
                 File.Delete(_logLocation);
             }
-            driver.Quit();
             if (_tempPath != null && Directory.Exists(_tempPath))
             {
                 Directory.Delete(_tempPath, true);
@@ -48,11 +48,11 @@ namespace SeleniumDocs.Browsers
         }
 
         [TestMethod]
-        public void SetBinary()
+        public async System.Threading.Tasks.Task SetBinary()
         {
             var options = new FirefoxOptions();
 
-            options.BinaryLocation = GetFirefoxLocation();
+            options.BinaryLocation = await GetFirefoxLocationAsync();
 
             driver = new FirefoxDriver(options);
         }
@@ -170,7 +170,7 @@ namespace SeleniumDocs.Browsers
             IWebElement injected = driver.FindElement(By.Id("webextensions-selenium-example"));
             Assert.AreEqual("Content injected by webextensions-selenium-example", injected.Text);
         }
-        
+
         private string GetLogLocation()
         {
             if (string.IsNullOrEmpty(_logLocation) && !File.Exists(_logLocation))
@@ -197,13 +197,13 @@ namespace SeleniumDocs.Browsers
             driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(2);
         }
 
-        private static string GetFirefoxLocation()
+        private static async System.Threading.Tasks.Task<string> GetFirefoxLocationAsync()
         {
             var options = new FirefoxOptions()
             {
                 BrowserVersion = "stable"
             };
-            return new DriverFinder(options).GetBrowserPathAsync().AsTask().GetAwaiter().GetResult();
+            return await new DriverFinder(options).GetBrowserPathAsync();
         }
 
         private void ResetGlobalLog()

--- a/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs
+++ b/examples/dotnet/SeleniumDocs/Browsers/InternetExplorerTest.cs
@@ -18,6 +18,7 @@ namespace SeleniumDocs.Browsers
         [TestCleanup]
         public void Cleanup()
         {
+            _driver?.Quit();
             if (_logLocation != null && File.Exists(_logLocation))
             {
                 File.Delete(_logLocation);
@@ -26,7 +27,6 @@ namespace SeleniumDocs.Browsers
             {
                 File.Delete(_tempPath);
             }
-            _driver.Quit();
         }
 
         [TestMethod]

--- a/examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs
+++ b/examples/dotnet/SeleniumDocs/Drivers/ServiceTest.cs
@@ -17,10 +17,10 @@ namespace SeleniumDocs.Drivers
 
         [TestMethodCustom]
         [EnabledOnOs("OSX")]
-        public void DriverLocation()
+        public async System.Threading.Tasks.Task DriverLocation()
         {
             var options = GetLatestChromeOptions();
-            var service = ChromeDriverService.CreateDefaultService(GetDriverLocation(options));
+            var service = ChromeDriverService.CreateDefaultService(await GetDriverLocationAsync(options)); 
 
             driver = new ChromeDriver(service, options);
         }
@@ -34,9 +34,9 @@ namespace SeleniumDocs.Drivers
             driver = new ChromeDriver(service);
         }
         
-        private static string GetDriverLocation(ChromeOptions options)
+        private static async System.Threading.Tasks.Task<string> GetDriverLocationAsync(ChromeOptions options)
         {
-            return new DriverFinder(options).GetDriverPathAsync().AsTask().GetAwaiter().GetResult();
+            return await new DriverFinder(options).GetDriverPathAsync();
         }
 
         private static ChromeOptions GetLatestChromeOptions()


### PR DESCRIPTION
### Description
Correct usage of `async/await` in the examples. No code line numbers changed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
