### PR TITLE
[dotnet] Stabilize example for uploading files

### DIFF
--- a/examples/dotnet/SeleniumDocs/Elements/FileUploadTest.cs
+++ b/examples/dotnet/SeleniumDocs/Elements/FileUploadTest.cs
@@ -23,7 +23,6 @@ namespace SeleniumDocs.Elements
             driver.FindElement(By.Id("file-submit")).Click();
 
             var fileName = new OpenQA.Selenium.Support.UI.WebDriverWait(driver, TimeSpan.FromSeconds(5)).Until(d => d.FindElement(By.Id("uploaded-files")));
-
             Assert.AreEqual("selenium-snapshot.png", fileName.Text);
         }
     }

--- a/examples/dotnet/SeleniumDocs/Elements/FileUploadTest.cs
+++ b/examples/dotnet/SeleniumDocs/Elements/FileUploadTest.cs
@@ -22,7 +22,8 @@ namespace SeleniumDocs.Elements
             fileInput.SendKeys(uploadFile);
             driver.FindElement(By.Id("file-submit")).Click();
 
-            IWebElement fileName = driver.FindElement(By.Id("uploaded-files"));
+            var fileName = new OpenQA.Selenium.Support.UI.WebDriverWait(driver, TimeSpan.FromSeconds(5)).Until(d => d.FindElement(By.Id("uploaded-files")));
+
             Assert.AreEqual("selenium-snapshot.png", fileName.Text);
         }
     }


### PR DESCRIPTION
### Description
This pull request improves the reliability of the file upload test in `FileUploadTest.cs` by ensuring the test waits for the uploaded file name element to appear before making assertions.

Test stability improvement:

* Updated the retrieval of the `uploaded-files` element to use an explicit wait (`WebDriverWait`) for up to 5 seconds, reducing the likelihood of flaky tests due to timing issues.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
<!--- Provide a general summary of your changes in the Title above -->
