### PR TITLE
Add Python BiDi examples for Register Basic Auth (network.authRequired)

### DIFF
--- a/examples/python/tests/bidi/test_network_commands.py
+++ b/examples/python/tests/bidi/test_network_commands.py
@@ -77,12 +77,6 @@ def test_add_and_remove_request_handler(driver):
     assert not requests
 
 
-# The following auth-challenge tests use Firefox because Chrome does not
-# expose its native basic-auth dialog as a WebDriver Alert, so the fallback
-# and cancellation paths would hang waiting on a dialog Selenium can't see
-# or dismiss. This mirrors the Java and JavaScript BiDi examples.
-
-
 @pytest.mark.driver_type("firefox_bidi")
 def test_continue_with_auth_credentials(driver):
     callback_id = driver.network.add_auth_handler("admin", "admin")

--- a/examples/python/tests/bidi/test_network_commands.py
+++ b/examples/python/tests/bidi/test_network_commands.py
@@ -17,6 +17,7 @@
 
 import pytest
 from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.common.by import By
 
 
 @pytest.mark.driver_type("bidi")
@@ -74,3 +75,75 @@ def test_add_and_remove_request_handler(driver):
 
     driver.get("https://www.selenium.dev/selenium/web/blank.html")
     assert not requests
+
+
+# The following auth-challenge tests use Firefox because Chrome does not
+# expose its native basic-auth dialog as a WebDriver Alert, so the fallback
+# and cancellation paths would hang waiting on a dialog Selenium can't see
+# or dismiss. This mirrors the Java and JavaScript BiDi examples.
+
+
+@pytest.mark.driver_type("firefox_bidi")
+def test_continue_with_auth_credentials(driver):
+    callback_id = driver.network.add_auth_handler("admin", "admin")
+
+    try:
+        driver.get("https://the-internet.herokuapp.com/basic_auth")
+        success_message = "Congratulations! You must have the proper credentials."
+        assert driver.find_element(By.TAG_NAME, "p").text == success_message
+    finally:
+        driver.network.remove_auth_handler(callback_id)
+
+
+@pytest.mark.driver_type("firefox_bidi")
+def test_continue_without_auth_credentials(driver):
+    from selenium.webdriver.support import expected_conditions as EC
+    from selenium.webdriver.support.wait import WebDriverWait
+
+    def callback(request):
+        pass  # Neither provide_credentials() nor cancel(): falls back to the browser's default handling.
+
+    handler_id = driver.network.add_authentication_handler(callback)
+
+    try:
+        driver.get("https://the-internet.herokuapp.com/basic_auth")
+        alert = WebDriverWait(driver, 5).until(EC.alert_is_present())
+        alert.dismiss()
+        WebDriverWait(driver, 5).until(lambda d: "Not authorized" in d.page_source)
+    finally:
+        driver.network.remove_authentication_handler(handler_id)
+
+
+@pytest.mark.driver_type("firefox_bidi")
+def test_cancel_auth(driver):
+    def callback(request):
+        request.cancel()
+
+    handler_id = driver.network.add_authentication_handler(callback)
+
+    try:
+        driver.get("https://the-internet.herokuapp.com/basic_auth")
+        assert "Not authorized" in driver.page_source
+    finally:
+        driver.network.remove_authentication_handler(handler_id)
+
+
+@pytest.mark.driver_type("firefox_bidi")
+def test_auth_required_event(driver):
+    from selenium.webdriver.common.bidi.network import AuthenticationRequest
+
+    challenges = []
+
+    def callback(request: AuthenticationRequest):
+        challenges.append(request)
+        request.provide_credentials("admin", "admin")
+
+    handler_id = driver.network.add_authentication_handler(callback)
+
+    try:
+        driver.get("https://the-internet.herokuapp.com/basic_auth")
+        assert len(challenges) == 1
+        assert challenges[0].scheme == "Basic"
+        assert challenges[0].realm == "Restricted Area"
+    finally:
+        driver.network.remove_authentication_handler(handler_id)

--- a/examples/python/tests/conftest.py
+++ b/examples/python/tests/conftest.py
@@ -23,7 +23,7 @@ def pytest_configure(config):
 
 
 @pytest.fixture(scope='function')
-def driver(request):
+def driver(request, monkeypatch):
     marker = request.node.get_closest_marker("driver_type")
     driver_type = marker.args[0] if marker else None
 
@@ -32,13 +32,10 @@ def driver(request):
         options.enable_bidi = True
         driver = webdriver.Chrome(options=options)
     elif driver_type == "firefox":
-        os.environ["MOZ_ENABLE_WAYLAND"] = "0"
+        monkeypatch.setenv("MOZ_ENABLE_WAYLAND", "0")
         driver = webdriver.Firefox()
     elif driver_type == "firefox_bidi":
-        # Chrome does not expose its native basic-auth dialog as a WebDriver
-        # Alert, so auth-challenge tests that need to observe/dismiss it use
-        # Firefox instead, matching the Java and JavaScript BiDi examples.
-        os.environ["MOZ_ENABLE_WAYLAND"] = "0"
+        monkeypatch.setenv("MOZ_ENABLE_WAYLAND", "0")
         options = webdriver.FirefoxOptions()
         options.enable_bidi = True
         driver = webdriver.Firefox(options=options)

--- a/examples/python/tests/conftest.py
+++ b/examples/python/tests/conftest.py
@@ -34,6 +34,14 @@ def driver(request):
     elif driver_type == "firefox":
         os.environ["MOZ_ENABLE_WAYLAND"] = "0"
         driver = webdriver.Firefox()
+    elif driver_type == "firefox_bidi":
+        # Chrome does not expose its native basic-auth dialog as a WebDriver
+        # Alert, so auth-challenge tests that need to observe/dismiss it use
+        # Firefox instead, matching the Java and JavaScript BiDi examples.
+        os.environ["MOZ_ENABLE_WAYLAND"] = "0"
+        options = webdriver.FirefoxOptions()
+        options.enable_bidi = True
+        driver = webdriver.Firefox(options=options)
     else:
         driver = webdriver.Chrome()
 

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
@@ -64,7 +64,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L57-L64" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L86-L95" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -86,7 +87,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L74-L80" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L98-L114" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -108,7 +110,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L90-L96" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L117-L128" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -223,7 +226,8 @@ This section contains the APIs related to network events.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkEventsTest.java#L101-L106" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L131-L149" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
@@ -19,7 +19,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L22-L28" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L23-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -42,7 +42,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L31-L37" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L32-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -134,7 +134,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L58" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L41-L59" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -160,7 +160,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L61-L76" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L62-L77" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.en.md
@@ -65,7 +65,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L86-L95" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L80-L89" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -88,7 +88,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L98-L114" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L92-L108" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -111,7 +111,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L117-L128" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L111-L122" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -227,7 +227,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L131-L149" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L125-L143" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.ja.md
@@ -29,7 +29,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L22-L28" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L23-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -52,7 +52,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L31-L37" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L32-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -144,7 +144,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L58" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L41-L59" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -170,7 +170,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L61-L76" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L62-L77" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.ja.md
@@ -74,7 +74,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L57-L64" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L86-L95" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -96,7 +97,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L74-L80" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L98-L114" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -118,7 +120,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L90-L96" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L117-L128" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -233,7 +236,8 @@ This section contains the APIs related to network events.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkEventsTest.java#L101-L106" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L131-L149" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.ja.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.ja.md
@@ -75,7 +75,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L86-L95" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L80-L89" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -98,7 +98,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L98-L114" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L92-L108" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -121,7 +121,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L117-L128" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L111-L122" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -237,7 +237,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L131-L149" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L125-L143" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.pt-br.md
@@ -29,7 +29,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L22-L28" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L23-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -52,7 +52,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L31-L37" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L32-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -144,7 +144,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L58" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L41-L59" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -170,7 +170,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L61-L76" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L62-L77" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.pt-br.md
@@ -74,7 +74,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L57-L64" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L86-L95" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -96,7 +97,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L74-L80" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L98-L114" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -118,7 +120,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L90-L96" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L117-L128" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -233,7 +236,8 @@ This section contains the APIs related to network events.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkEventsTest.java#L101-L106" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L131-L149" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.pt-br.md
@@ -75,7 +75,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L86-L95" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L80-L89" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -98,7 +98,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L98-L114" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L92-L108" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -121,7 +121,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L117-L128" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L111-L122" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -237,7 +237,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L131-L149" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L125-L143" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.zh-cn.md
@@ -29,7 +29,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L22-L28" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L23-L29" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -52,7 +52,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L31-L37" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L32-L38" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -144,7 +144,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L40-L58" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L41-L59" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -170,7 +170,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.32" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L61-L76" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L62-L77" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.zh-cn.md
@@ -74,7 +74,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L57-L64" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L86-L95" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -96,7 +97,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L74-L80" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L98-L114" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -118,7 +120,8 @@ This section contains the APIs related to network commands.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkCommandsTest.java#L90-L96" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L117-L128" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -233,7 +236,8 @@ This section contains the APIs related to network events.
 {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/bidirectional/webdriver_bidi/NetworkEventsTest.java#L101-L106" >}}
 {{< /tab >}}
 {{< tab header="Python" >}}
-{{< badge-code >}}
+{{< badge-version version="4.46" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L131-L149" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}

--- a/website_and_docs/content/documentation/webdriver/bidi/w3c/network.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/bidi/w3c/network.zh-cn.md
@@ -75,7 +75,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L86-L95" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L80-L89" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -98,7 +98,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L98-L114" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L92-L108" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -121,7 +121,7 @@ This section contains the APIs related to network commands.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L117-L128" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L111-L122" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}
@@ -237,7 +237,7 @@ This section contains the APIs related to network events.
 {{< /tab >}}
 {{< tab header="Python" >}}
 {{< badge-version version="4.46" >}}
-{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L131-L149" >}}
+{{< gh-codeblock path="/examples/python/tests/bidi/test_network_commands.py#L125-L143" >}}
 {{< /tab >}}
 {{< tab header="Ruby" >}}
 {{< badge-code >}}


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.

### Description
Adds Python examples for the BiDi `network.authRequired` phase to `examples/python/tests/bidi/test_network_commands.py`, and wires up the four remaining `Python` `{{< badge-code >}}` placeholders on the [Network Commands/Events](https://www.selenium.dev/documentation/webdriver/bidi/w3c/network/) doc (en, ja, pt-br, zh-cn):

- Continue request blocked at authRequired phase **with credentials** (`test_continue_with_auth_credentials`)
- ...**without credentials** (`test_continue_without_auth_credentials`)
- **Cancel** request blocked at authRequired phase (`test_cancel_auth`)
- **Auth Required** event (`test_auth_required_event`)

### Motivation and Context
Reported in #815 ("Please add sample python code for BiDi APIs Register Basic Auth and Network Interception"). Some other Network sections have gained Python examples since 2021, but the "Register Basic Auth" scenarios specifically were still `{{< badge-code >}}` placeholders.

`selenium` already has purpose-built Python APIs for this — `driver.network.add_auth_handler(username, password)` and the more flexible `driver.network.add_authentication_handler(callback)` (with `AuthenticationRequest.provide_credentials()`/`.cancel()`) — they just had no doc example or test coverage.

### Why a new `firefox_bidi` driver type
The "without credentials" and "cancel" scenarios fall back to (or trigger failure of) the browser's native basic-auth prompt. Chrome does not expose that native dialog as a WebDriver `Alert`, so a test that waits for/dismisses it deadlocks — I hit this directly (`driver.get()` hung indefinitely on Chrome). The Java and JavaScript examples for these same scenarios already work around this by using Firefox specifically. I added a matching `firefox_bidi` option to the `driver_type` fixture in `conftest.py` and used it only for these four new tests; the existing Chrome-based `bidi` tests are untouched.

All 8 tests in the file (4 existing + 4 new) pass consistently against real Chrome/Firefox browsers, run 3x with no flakiness.

### Types of changes
- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist
- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

Closes #815.