### PR TITLE
Add schema.org JSON-LD structured data

### DIFF
--- a/website_and_docs/layouts/partials/hooks/head-end.html
+++ b/website_and_docs/layouts/partials/hooks/head-end.html
@@ -5,7 +5,9 @@
 <script src="/js/docsearch-fix.js"></script>
 {{ end }}
 {{/*
-  Canonical and hreflang links. Docsy emits neither for HTML pages.
+  Canonical and hreflang links, and schema.org structured data. Docsy emits no
+  canonical link and no hreflang alternates, and its call to Hugo's
+  _internal/schema.html produces only sparse microdata.
 
   Skipped for the "print" output format, whose pages already get a canonical
   link pointing back at the HTML page from Docsy's own alternate-format loop.
@@ -29,5 +31,53 @@
 <link rel="alternate" hreflang="x-default" href="{{ .Permalink }}">
 {{- end }}
 {{- end }}
+{{- end }}
+
+{{- $publisher := dict
+      "@type" "Organization"
+      "name" "Selenium"
+      "url" .Site.BaseURL
+      "logo" (dict "@type" "ImageObject" "url" (absURL "images/selenium_logo_square_green.png"))
+      "sameAs" (slice
+        "https://github.com/SeleniumHQ/selenium"
+        "https://www.linkedin.com/company/4826427/"
+        "https://x.com/SeleniumHQ"
+        "https://www.youtube.com/@SeleniumHQProject/") -}}
+{{- $ld := false -}}
+{{- if .IsHome -}}
+  {{- $ld = dict
+        "@context" "https://schema.org"
+        "@type" "WebSite"
+        "name" .Site.Title
+        "url" .Site.BaseURL
+        "description" .Site.Params.description
+        "inLanguage" .Language.Lang
+        "publisher" $publisher -}}
+{{- else if eq .Section "documentation" -}}
+  {{- $ld = dict
+        "@context" "https://schema.org"
+        "@type" "TechArticle"
+        "headline" .Title
+        "url" .Permalink
+        "inLanguage" .Language.Lang
+        "dateModified" (.Lastmod.Format "2006-01-02")
+        "publisher" $publisher
+        "isPartOf" (dict "@type" "WebSite" "name" .Site.Title "url" .Site.BaseURL) -}}
+  {{- with .Description }}{{ $ld = merge $ld (dict "description" .) }}{{ end -}}
+{{- else if eq .Section "blog" -}}
+  {{- $ld = dict
+        "@context" "https://schema.org"
+        "@type" "BlogPosting"
+        "headline" .Title
+        "url" .Permalink
+        "inLanguage" .Language.Lang
+        "datePublished" (.Date.Format "2006-01-02")
+        "dateModified" (.Lastmod.Format "2006-01-02")
+        "publisher" $publisher -}}
+  {{- with .Description }}{{ $ld = merge $ld (dict "description" .) }}{{ end -}}
+  {{- with .Params.author }}{{ $ld = merge $ld (dict "author" (dict "@type" "Person" "name" .)) }}{{ end -}}
+{{- end }}
+{{- with $ld }}
+<script type="application/ld+json">{{ . | jsonify (dict "indent" "  ") | safeJS }}</script>
 {{- end }}
 {{ end }}


### PR DESCRIPTION
### Description

Adds schema.org JSON-LD to every page, in the same `head-end.html` hook:

| Page | Type |
|---|---|
| Home | `WebSite` |
| `documentation/**` | `TechArticle` |
| `blog/**` | `BlogPosting` |

All three share one `Organization` publisher carrying the Selenium logo and the
project's `sameAs` profiles (GitHub, LinkedIn, X, YouTube). `inLanguage` is set
per page, so the translations describe themselves correctly rather than claiming
to be English. `dateModified` comes from `.Lastmod`; blog posts also get
`datePublished` and, where the front matter has one, an `author`.

`description` and `author` are merged in conditionally, so pages missing that
front matter emit valid JSON-LD without empty keys rather than `"author": ""`.

Like the canonical link, this is skipped for the `print` output format.

### Motivation and Context

Docsy calls Hugo's `_internal/schema.html`, which produces only sparse microdata —
not enough for search engines or AI crawlers to tell that a page is technical
reference documentation, which project publishes it, or when it was last updated.
`TechArticle` in particular is the signal that distinguishes our docs from blog
commentary about Selenium, which matters when both are competing for the same
query.

This pairs with the `llms.txt` index in #2757: that one states which pages
are canonical, this one describes what each page actually is.

### Types of changes

- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

Built locally against Hugo Extended 0.148.2 (the version CI pins), on this branch
in isolation. Verified in the rendered output by parsing every emitted
`<script type="application/ld+json">` block with a JSON parser rather than
eyeballing it:

| Page | Result |
|---|---|
| Home | valid JSON, `WebSite`, `inLanguage: en` |
| `/documentation/webdriver/` | valid JSON, `TechArticle`, `inLanguage: en`, `dateModified` |
| `/ja/documentation/webdriver/` | valid JSON, `TechArticle`, **`inLanguage: ja`** |
| latest blog post | valid JSON, `BlogPosting`, `datePublished` + `dateModified` |
| all 378 `_print/` pages | zero `ld+json` blocks, exactly one canonical |

No empty-string values on any page, and the publisher carries the logo plus all 4
`sameAs` profiles. On the print pages the single canonical is Docsy's own
(`<link rel="canonical" type="text/html" href=".../documentation/">`) — pointing
back at the HTML page, as intended — confirming this hook correctly emits nothing
there.

Rebased onto `trunk` after #2758 merged, so this now contains only the JSON-LD
change (+51/-1). The rebase was clean: #2757 and #2758 were squash-merged, so this
branch's former parent was no longer an ancestor of `trunk` and GitHub reported a
conflict — but trunk's `head-end.html` is byte-identical to what #2758 merged, so
it was a history-shape artifact rather than a content disagreement.

The build above is against current `trunk`, which matters because #2757 added
`llms` as an *alternative* output format on the home page, and this hook derives
the current format by subtracting alternatives. Verified those coexist: the home
page still emits exactly one canonical and one `ld+json` block, and `/llms.txt` is
still generated with its 119 links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
