### PR TITLE
Document Go and Node.js prerequisites in contributing guide

### DIFF
--- a/website_and_docs/content/documentation/about/contributing.en.md
+++ b/website_and_docs/content/documentation/about/contributing.en.md
@@ -125,6 +125,25 @@ to use Hugo 0.148.2 .
 Please follow the [Install Hugo](https://www.docsy.dev/docs/getting-started/#install-hugo) 
 instructions from Docsy.
 
+#### Dependencies: Go
+
+The Docsy theme is pulled in as a [Hugo Module](https://gohugo.io/hugo-modules/),
+so Hugo needs [Go](https://go.dev/dl/) to resolve it when you run `hugo server`.
+Install any version satisfying the minimum in `go.mod`.
+
+#### Dependencies: Node.js (optional, for the production CSS pipeline)
+
+Node.js is **not** required to preview the site with `hugo server` — in
+development mode Docsy skips PostCSS. You only need [Node.js](https://nodejs.org/)
+(any current release) if you want your local build to match the production CSS
+pipeline (autoprefixer/PostCSS), as run by `hugo --minify` in `build-site.sh`.
+In that case, run `npm install` in `website_and_docs` first.
+
+> **Note:** This may change with a future Hugo/Docsy upgrade. If theme assets
+> (e.g. Bootstrap/Font Awesome) move from Hugo Modules to npm packages,
+> `npm install` — and therefore Node.js — could become required for all builds,
+> not just the production pipeline.
+
 ### Step 2: Branch
 
 Create a feature branch and start hacking:

--- a/website_and_docs/content/documentation/about/contributing.ja.md
+++ b/website_and_docs/content/documentation/about/contributing.ja.md
@@ -101,6 +101,25 @@ Seleniumプロジェクトは新しいコントリビュータを歓迎します
 
 [Docsyのインストール手順](https://www.docsy.dev/docs/getting-started/#install-hugo)に従ってください。
 
+#### 依存関係: Go
+
+Docsyテーマは[Hugo Module](https://gohugo.io/hugo-modules/)として取り込まれているため、
+`hugo server`を実行する際にHugoがこれを解決するには[Go](https://go.dev/dl/)が必要です。
+`go.mod`に記載された最小バージョンを満たす任意のバージョンをインストールしてください。
+
+#### 依存関係: Node.js（省略可、本番用CSSパイプライン向け）
+
+`hugo server`でサイトをプレビューするだけであれば、Node.jsは**不要**です。開発モードでは
+Docsyが PostCSS の処理をスキップします。ローカルのビルドを、`build-site.sh`内の
+`hugo --minify`が実行する本番用CSSパイプライン（autoprefixer/PostCSS）に合わせたい場合にのみ、
+[Node.js](https://nodejs.org/)（現行の任意のリリース）が必要です。その場合は、先に
+`website_and_docs`で`npm install`を実行してください。
+
+> **注：** 今後のHugo/Docsyのアップグレードで状況が変わる可能性があります。テーマのアセット
+> （例: BootstrapやFont Awesome）がHugo Modulesからnpmパッケージへ移行された場合、
+> `npm install`（つまりNode.js）が本番用パイプラインだけでなく、すべてのビルドで
+> 必要になることがあります。
+
 ### ステップ 2: ブランチの作成
 
 フィーチャーブランチを作成し、ハックを開始します。:

--- a/website_and_docs/content/documentation/about/contributing.pt-br.md
+++ b/website_and_docs/content/documentation/about/contributing.pt-br.md
@@ -124,6 +124,25 @@ Sass/SCSS do binário Hugo. Recomendamos a versão 0.148.2 .
 
 Por favor siga as instruções do Docsy [Install Hugo](https://www.docsy.dev/docs/getting-started/#install-hugo) 
 
+#### Dependências: Go
+
+O tema Docsy é obtido como um [Hugo Module](https://gohugo.io/hugo-modules/),
+então o Hugo precisa do [Go](https://go.dev/dl/) para resolvê-lo ao executar `hugo server`.
+Instale qualquer versão que satisfaça o mínimo definido em `go.mod`.
+
+#### Dependências: Node.js (opcional, para o pipeline de CSS de produção)
+
+Node.js **não** é necessário para pré-visualizar o site com `hugo server` — no
+modo de desenvolvimento o Docsy ignora o PostCSS. Você só precisa do [Node.js](https://nodejs.org/)
+(qualquer versão atual) se quiser que o seu build local corresponda ao pipeline de CSS
+de produção (autoprefixer/PostCSS), executado por `hugo --minify` em `build-site.sh`.
+Nesse caso, execute `npm install` em `website_and_docs` primeiro.
+
+> **Nota:** Isso pode mudar em uma futura atualização do Hugo/Docsy. Se os assets do tema
+> (por exemplo, Bootstrap/Font Awesome) migrarem do Hugo Modules para pacotes npm,
+> `npm install` — e, portanto, o Node.js — pode se tornar necessário para todos os builds,
+> não apenas para o pipeline de produção.
+
 
 ### Passo 2: Branch
 

--- a/website_and_docs/content/documentation/about/contributing.zh-cn.md
+++ b/website_and_docs/content/documentation/about/contributing.zh-cn.md
@@ -119,6 +119,25 @@ Selenium 项目欢迎新的贡献者。
 请参考来自 Docsy 的说明
 [安装 Hugo](https://www.docsy.dev/docs/getting-started/#install-hugo)。
 
+#### 依赖：Go
+
+Docsy 主题是作为 [Hugo Module](https://gohugo.io/hugo-modules/) 引入的，
+因此运行 `hugo server` 时，Hugo 需要 [Go](https://go.dev/dl/) 来解析它。
+请安装满足 `go.mod` 中最低版本要求的任意版本。
+
+#### 依赖：Node.js（可选，用于生产环境 CSS 流水线）
+
+使用 `hugo server` 预览站点**不**需要 Node.js —— 开发模式下 Docsy 会跳过 PostCSS。
+只有当您希望本地构建结果与生产环境 CSS 流水线（autoprefixer/PostCSS，
+由 `build-site.sh` 中的 `hugo --minify` 运行）保持一致时，才需要安装
+[Node.js](https://nodejs.org/)（任意当前发行版本）。此时请先在 `website_and_docs`
+目录下运行 `npm install`。
+
+> **注意：** 未来的 Hugo/Docsy 升级可能会改变这一点。如果主题资源
+> （例如 Bootstrap/Font Awesome）从 Hugo Modules 迁移到 npm 包，
+> `npm install`（以及 Node.js）可能会成为所有构建的必需项，
+> 而不仅仅是生产环境流水线。
+
 ### 步骤 2：分支
 
 创建一个功能分支并开始工作：


### PR DESCRIPTION
### Description

Adds two short subsections to the "Dependencies" area of the contributing guide (contributing.en.md), documenting two prerequisites the guide currently omits:

- Go — the Docsy theme is pulled in via Hugo Modules (go.mod), so Hugo needs Go to resolve the theme when you run hugo server. This is worded as "any version satisfying the minimum in go.mod" so no version is hardcoded.
- Node.js — clarified as optional for local preview. Docsy skips PostCSS in development mode, so hugo server works without Node. Node is only needed if you want your local build to match the production CSS pipeline (autoprefixer/PostCSS) that hugo --minify runs in build-site.sh. This is worded as "any current release" so no version is hardcoded.

A short forward-looking note flags that Node.js may become required for all builds if a future Hugo/Docsy upgrade moves theme assets (for example Bootstrap and Font Awesome) from Hugo Modules to npm packages.

The existing Hugo version guidance in that section is left untouched.

### Motivation and Context

The contributing guide links to Docsy's Hugo install instructions but never mentions Go or Node.js, even though the project needs both. A new contributor setting up the environment hits this gap with no explanation of why the build depends on them. This change documents both dependencies and, more importantly, draws the accurate distinction between them: Go is required to preview the site locally with hugo server, whereas Node.js is not required for local preview and only affects whether the local CSS output matches the production build.

### Types of changes

- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.