### PR TITLE
Add Grid CLI options introduced in Selenium 4.48

### DIFF
--- a/website_and_docs/content/documentation/grid/configuration/cli_options.en.md
+++ b/website_and_docs/content/documentation/grid/configuration/cli_options.en.md
@@ -174,6 +174,7 @@ pull request updating this page.
 | `--slot-selector` | string | `org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector` | Full class name of non-default slot selector. This is used to select a slot in a Node once the Node has been matched. |
 | `--newsession-threadpool-size` | int | `24` | The Distributor uses a fixed-sized thread pool to create new sessions as it consumes new session requests from the queue. This allows configuring the size of the thread pool. The default value is no. of available processors * 3. Note: If the no. of threads is way greater than the available processors it will not always increase the performance. A high number of threads causes more context switching which is an expensive operation. |
 | `--purge-nodes-interval` | int | `30` | How often, in seconds, will the Distributor purge Nodes that have been down for a while. This is calculated based on the heartbeat received from a particular node. |
+| `--distributor-backend-url` | string | `redis://localhost:6379` | Backend datastore URL for the Distributor implementation. Used by Redis-backed and other external implementations loaded via `--ext`. |
 
 ### Docker
 
@@ -190,6 +191,7 @@ pull request updating this page.
 | `--docker-api-version` | string | `1.40` | Docker API version to use. Pin a specific API version instead of relying on auto-detection by the implementation. |
 | `--docker-server-start-timeout` | int | `55` | Max time (in seconds) to wait for the browser server to successfully start up inside the container, before cancelling the process. |
 | `--docker-grouping-labels` | string[] | `azure.container.group aws.ecs.cluster` | Custom labels used for grouping dynamic containers. Makes the system more flexible for different platforms and use cases. |
+| `--docker-stop-grace-period` | int | `60` | Grace period (in seconds) to wait for browser and video containers to stop gracefully before they are forcibly terminated. |
 
 ### Kubernetes
 
@@ -286,6 +288,7 @@ pull request updating this page.
 | `--username` | string | `admin` | User name clients must use to connect to the server. Both this and the password need to be set in order to be used. |
 | `--sub-path` | string | `my_company/selenium_grid` | A sub-path that should be considered for all user facing routes on the Hub/Router/Standalone. |
 | `--disable-ui` | boolean | `true` | Disable the Grid UI. |
+| `--tcp-tunnel` | boolean | `true` | Enable the transparent TCP tunnel for WebSocket connections (BiDi, CDP). Disable to route WebSocket traffic through the Grid proxy instead, e.g. for benchmarking the proxy path or in network topologies where the Router cannot open direct TCP connections to Nodes (e.g. Kubernetes port-forward setups). |
 
 
 ### Server
@@ -314,6 +317,8 @@ pull request updating this page.
 | `--session-retry-interval` | int | `15` | Retry interval in milliseconds. If all slots are busy, new session request will be retried after the given interval. |
 | `--sessionqueue-batch-size` | int | `20` | Maximum number of session requests that can be consumed from the queue at a time, based on the available slots. |
 | `--maximum-response-delay` | int | `8` | How often, in seconds, will the SessionQueue respond in case there is no data, to reduce the http requests while polling for new session requests. (Config file only; not a CLI flag.) |
+| `--sessionqueue-implementation` | string | `org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue` | Full class name of non-default session queue implementation. |
+| `--sessionqueue-backend-url` | string | `redis://localhost:6379` | Backend datastore URL for the SessionQueue implementation. Used by Redis-backed and other external implementations loaded via `--ext`. |
 
 ### Sessions
 
@@ -322,6 +327,8 @@ pull request updating this page.
 | `--sessions` | uri | `http://localhost:1234` | Address of the session map server. |
 | `--sessions-host` | string | `localhost` | Host on which the session map server is listening. |
 | `--sessions-port` | int | `1234` | Port on which the session map server is listening. |
+| `--sessions-implementation` | string | `org.openqa.selenium.grid.sessionmap.redis.RedisBackedSessionMap` | Full class name of non-default session map implementation. |
+| `--sessions-scheme` | string | `redis` | URI scheme for the session map server (e.g. `redis`, `http`). |
 
 
 ## Configuration examples

--- a/website_and_docs/content/documentation/grid/configuration/cli_options.ja.md
+++ b/website_and_docs/content/documentation/grid/configuration/cli_options.ja.md
@@ -163,6 +163,7 @@ Grid の設定には、さまざまなセクションが用意されています
 | `--slot-selector`              | string  | `org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector` | デフォルト以外のスロットセレクターの完全なクラス名。これは、ノードがマッチした後ノード内のスロットを選択するために使用されます。                                                                      |
 | `--newsession-threadpool-size` | int | `24` | The Distributor uses a fixed-sized thread pool to create new sessions as it consumes new session requests from the queue. This allows configuring the size of the thread pool. The default value is no. of available processors * 3. Note: If the no. of threads is way greater than the available processors it will not always increase the performance. A high number of threads causes more context switching which is an expensive operation. |
 | `--purge-nodes-interval` | int | `30` | How often, in seconds, will the Distributor purge Nodes that have been down for a while. This is calculated based on the heartbeat received from a particular node. |
+| `--distributor-backend-url` | string | `redis://localhost:6379` | Backend datastore URL for the Distributor implementation. Used by Redis-backed and other external implementations loaded via `--ext`. |
 
 ### Docker
 
@@ -176,6 +177,7 @@ Grid の設定には、さまざまなセクションが用意されています
 | `--docker-url`         | string   | `http://localhost:2375`                                           | Docker デーモンに接続するための URL。                                                                                                                                                            |
 | `--docker-video-image` | string   | `selenium/video:latest`                                           | ビデオレコーディングが有効になっているときに利用される Docker イメージ。                                                                                                                         |
 | `--docker-host-config-keys` | string[] | `Dns DnsOptions DnsSearch ExtraHosts Binds` | Specify which docker host configuration keys should be passed to browser containers. Keys name can be found in the Docker API [documentation](https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerCreate), or by running `docker inspect` the node-docker container. |
+| `--docker-stop-grace-period` | int | `60` | Grace period (in seconds) to wait for browser and video containers to stop gracefully before they are forcibly terminated. |
 
 ### Events
 
@@ -249,6 +251,7 @@ Grid の設定には、さまざまなセクションが用意されています
 | `--username` | string | `admin`            | クライアントがサーバーに接続する際に使用するユーザー名。このユーザー名とパスワードの両方が設定されていないと使用できません。 |
 | `--sub-path` | string | `my_company/selenium_grid` | A sub-path that should be considered for all user facing routes on the Hub/Router/Standalone. |
 | `--disable-ui` | boolean | `true` | Disable the Grid UI. |
+| `--tcp-tunnel` | boolean | `true` | Enable the transparent TCP tunnel for WebSocket connections (BiDi, CDP). Disable to route WebSocket traffic through the Grid proxy instead, e.g. for benchmarking the proxy path or in network topologies where the Router cannot open direct TCP connections to Nodes (e.g. Kubernetes port-forward setups). |
 
 ### Server
 
@@ -272,6 +275,8 @@ Grid の設定には、さまざまなセクションが用意されています
 | `--session-request-timeout` | int    | `300`                   | タイムアウト(秒)。 新規セッションリクエストはキューに追加され、設定された時間以上キューに残っているリクエストはタイムアウトします。 |
 | `--session-retry-interval`  | int    | `5`                     | リトライ間隔(秒)。すべてのスロットがビジーな場合、 新規セッションリクエストはこの時間の間隔をおいてからリトライされます。           |
 | `--maximum-response-delay` | int | `8` | How often, in seconds, will the the SessionQueue response in case there is no data, to reduce the http requests while polling for new session requests. |
+| `--sessionqueue-implementation` | string | `org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue` | Full class name of non-default session queue implementation. |
+| `--sessionqueue-backend-url` | string | `redis://localhost:6379` | Backend datastore URL for the SessionQueue implementation. Used by Redis-backed and other external implementations loaded via `--ext`. |
 
 ### Sessions
 
@@ -280,6 +285,8 @@ Grid の設定には、さまざまなセクションが用意されています
 | `--sessions`      | uri    | `http://localhost:1234` | セッションマップサーバーのアドレス。           |
 | `--sessions-host` | string | `localhost`             | セッションマップサーバーがリッスンするホスト。 |
 | `--sessions-port` | int    | `1234`                  | セッションマップサーバーがリッスンするポート。 |
+| `--sessions-implementation` | string | `org.openqa.selenium.grid.sessionmap.redis.RedisBackedSessionMap` | Full class name of non-default session map implementation. |
+| `--sessions-scheme` | string | `redis` | URI scheme for the session map server (e.g. `redis`, `http`). |
 
 ## 設定例
 

--- a/website_and_docs/content/documentation/grid/configuration/cli_options.pt-br.md
+++ b/website_and_docs/content/documentation/grid/configuration/cli_options.pt-br.md
@@ -166,6 +166,7 @@ e esteja à vontade para nos enviar um pull request com alterações a esta pág
 | `--slot-selector` | string | `org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector` | Nome completo da class para uma implementação não padrão do selector de slots. Isto é usado para selecionar um slot no Node caso tenha sido "matched". |
 | `--newsession-threadpool-size` | int | `24` | The Distributor uses a fixed-sized thread pool to create new sessions as it consumes new session requests from the queue. This allows configuring the size of the thread pool. The default value is no. of available processors * 3. Note: If the no. of threads is way greater than the available processors it will not always increase the performance. A high number of threads causes more context switching which is an expensive operation. |
 | `--purge-nodes-interval` | int | `30` | How often, in seconds, will the Distributor purge Nodes that have been down for a while. This is calculated based on the heartbeat received from a particular node. |
+| `--distributor-backend-url` | string | `redis://localhost:6379` | Backend datastore URL for the Distributor implementation. Used by Redis-backed and other external implementations loaded via `--ext`. |
 
 ### Docker
 
@@ -179,6 +180,7 @@ e esteja à vontade para nos enviar um pull request com alterações a esta pág
 | `--docker-url` | string | `http://localhost:2375` | URL for connecting to the Docker daemon |
 | `--docker-video-image` | string | `selenium/video:latest` | Docker image to be used when video recording is enabled |
 | `--docker-host-config-keys` | string[] | `Dns DnsOptions DnsSearch ExtraHosts Binds` | Specify which docker host configuration keys should be passed to browser containers. Keys name can be found in the Docker API [documentation](https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerCreate), or by running `docker inspect` the node-docker container. |
+| `--docker-stop-grace-period` | int | `60` | Grace period (in seconds) to wait for browser and video containers to stop gracefully before they are forcibly terminated. |
 
 ### Events
 
@@ -253,6 +255,7 @@ e esteja à vontade para nos enviar um pull request com alterações a esta pág
 | `--username` | string | `admin` | User name clients must use to connect to the server. Both this and the password need to be set in order to be used. |
 | `--sub-path` | string | `my_company/selenium_grid` | A sub-path that should be considered for all user facing routes on the Hub/Router/Standalone. |
 | `--disable-ui` | boolean | `true` | Disable the Grid UI. |
+| `--tcp-tunnel` | boolean | `true` | Enable the transparent TCP tunnel for WebSocket connections (BiDi, CDP). Disable to route WebSocket traffic through the Grid proxy instead, e.g. for benchmarking the proxy path or in network topologies where the Router cannot open direct TCP connections to Nodes (e.g. Kubernetes port-forward setups). |
 
 
 ### Server
@@ -277,6 +280,8 @@ e esteja à vontade para nos enviar um pull request com alterações a esta pág
 | `--session-request-timeout` | int | `300` | Timeout in seconds. A new incoming session request is added to the queue. Requests sitting in the queue for longer than the configured time will timeout. |
 | `--session-retry-interval` | int | `5` | Retry interval in seconds. If all slots are busy, new session request will be retried after the given interval. |
 | `--maximum-response-delay` | int | `8` | How often, in seconds, will the the SessionQueue response in case there is no data, to reduce the http requests while polling for new session requests. |
+| `--sessionqueue-implementation` | string | `org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue` | Full class name of non-default session queue implementation. |
+| `--sessionqueue-backend-url` | string | `redis://localhost:6379` | Backend datastore URL for the SessionQueue implementation. Used by Redis-backed and other external implementations loaded via `--ext`. |
 
 ### Sessions
 
@@ -285,6 +290,8 @@ e esteja à vontade para nos enviar um pull request com alterações a esta pág
 | `--sessions` | uri | `http://localhost:1234` | Address of the session map server. |
 | `--sessions-host` | string | `localhost` | Host on which the session map server is listening. |
 | `--sessions-port` | int | `1234` | Port on which the session map server is listening. |
+| `--sessions-implementation` | string | `org.openqa.selenium.grid.sessionmap.redis.RedisBackedSessionMap` | Full class name of non-default session map implementation. |
+| `--sessions-scheme` | string | `redis` | URI scheme for the session map server (e.g. `redis`, `http`). |
 
 
 ## Configuration examples

--- a/website_and_docs/content/documentation/grid/configuration/cli_options.zh-cn.md
+++ b/website_and_docs/content/documentation/grid/configuration/cli_options.zh-cn.md
@@ -173,6 +173,7 @@ pull request updating this page.
 | `--slot-selector` | string | `org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector` | Full class name of non-default slot selector. This is used to select a slot in a Node once the Node has been matched. |
 | `--newsession-threadpool-size` | int | `24` | The Distributor uses a fixed-sized thread pool to create new sessions as it consumes new session requests from the queue. This allows configuring the size of the thread pool. The default value is no. of available processors * 3. Note: If the no. of threads is way greater than the available processors it will not always increase the performance. A high number of threads causes more context switching which is an expensive operation. |
 | `--purge-nodes-interval` | int | `30` | How often, in seconds, will the Distributor purge Nodes that have been down for a while. This is calculated based on the heartbeat received from a particular node. |
+| `--distributor-backend-url` | string | `redis://localhost:6379` | Backend datastore URL for the Distributor implementation. Used by Redis-backed and other external implementations loaded via `--ext`. |
 
 ### Docker
 
@@ -186,6 +187,7 @@ pull request updating this page.
 | `--docker-url` | string | `http://localhost:2375` | URL for connecting to the Docker daemon |
 | `--docker-video-image` | string | `selenium/video:latest` | Docker image to be used when video recording is enabled |
 | `--docker-host-config-keys` | string[] | `Dns DnsOptions DnsSearch ExtraHosts Binds` | Specify which docker host configuration keys should be passed to browser containers. Keys name can be found in the Docker API [documentation](https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerCreate), or by running `docker inspect` the node-docker container. |
+| `--docker-stop-grace-period` | int | `60` | Grace period (in seconds) to wait for browser and video containers to stop gracefully before they are forcibly terminated. |
 
 ### Events
 
@@ -259,6 +261,7 @@ pull request updating this page.
 | `--username` | string | `admin` | User name clients must use to connect to the server. Both this and the password need to be set in order to be used. |
 | `--sub-path` | string | `my_company/selenium_grid` | A sub-path that should be considered for all user facing routes on the Hub/Router/Standalone. |
 | `--disable-ui` | boolean | `true` | Disable the Grid UI. |
+| `--tcp-tunnel` | boolean | `true` | Enable the transparent TCP tunnel for WebSocket connections (BiDi, CDP). Disable to route WebSocket traffic through the Grid proxy instead, e.g. for benchmarking the proxy path or in network topologies where the Router cannot open direct TCP connections to Nodes (e.g. Kubernetes port-forward setups). |
 
 
 ### Server
@@ -283,6 +286,8 @@ pull request updating this page.
 | `--session-request-timeout` | int | `300` | Timeout in seconds. A new incoming session request is added to the queue. Requests sitting in the queue for longer than the configured time will timeout. |
 | `--session-retry-interval` | int | `5` | Retry interval in seconds. If all slots are busy, new session request will be retried after the given interval. |
 | `--maximum-response-delay` | int | `8` | How often, in seconds, will the the SessionQueue response in case there is no data, to reduce the http requests while polling for new session requests. |
+| `--sessionqueue-implementation` | string | `org.openqa.selenium.grid.sessionqueue.local.LocalNewSessionQueue` | Full class name of non-default session queue implementation. |
+| `--sessionqueue-backend-url` | string | `redis://localhost:6379` | Backend datastore URL for the SessionQueue implementation. Used by Redis-backed and other external implementations loaded via `--ext`. |
 
 ### Sessions
 
@@ -291,6 +296,8 @@ pull request updating this page.
 | `--sessions` | uri | `http://localhost:1234` | Address of the session map server. |
 | `--sessions-host` | string | `localhost` | Host on which the session map server is listening. |
 | `--sessions-port` | int | `1234` | Port on which the session map server is listening. |
+| `--sessions-implementation` | string | `org.openqa.selenium.grid.sessionmap.redis.RedisBackedSessionMap` | Full class name of non-default session map implementation. |
+| `--sessions-scheme` | string | `redis` | URI scheme for the session map server (e.g. `redis`, `http`). |
 
 
 ## Configuration examples


### PR DESCRIPTION
### Description

Adds the Grid CLI options that were introduced in Selenium 4.48.0 but are missing from the [CLI options](https://www.selenium.dev/documentation/grid/configuration/cli_options/) page:

| Option | Section | Added by |
|---|---|---|
| `--distributor-backend-url` | Distributor | #17396 (Redis-backed Distributor) |
| `--sessionqueue-backend-url` | SessionQueue | #17678 (Redis-backed SessionQueue) |
| `--sessionqueue-implementation` | SessionQueue | #17678 (Redis-backed SessionQueue) |
| `--sessions-implementation` | Sessions | #17396 / session map backends |
| `--sessions-scheme` | Sessions | #17396 / session map backends |
| `--docker-stop-grace-period` | Docker | #17222 (Docker container stop grace period) |
| `--tcp-tunnel` | Router | #17197 (WebSocket TCP tunnel for BiDi/CDP) |

Types, defaults and descriptions are taken verbatim (lightly condensed where needed) from the `@Parameter`/`@ConfigValue` annotations in the Grid source. I verified every option is present in the `selenium-4.48.0` tag, so nothing unreleased is documented.

The page was last aligned to Grid 4.41.0 in #2596, so everything added to the Grid since then is currently undocumented — this PR closes that gap for 4.48.

### Motivation and Context

The Redis-backed Grid support shipped in 4.48 is a headline feature (it even has dedicated CI jobs in the main repository), but none of its configuration flags are documented, and users configuring WebSocket tunneling or Docker container teardown also have nothing to point at. The page itself invites these updates in its note box, and this follows the established precedent of alignment PRs (#1683, #2022, #2596).

### Types of changes

- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [ ] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

*Note: change is a pure Markdown table addition following the exact structure of the adjacent rows; will verify the Netlify preview build once available.*

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [ ] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.
