### PR TITLE
Use hosted locator test page for Finders examples

### DIFF
--- a/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs
+++ b/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs
@@ -1,9 +1,95 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
 
 namespace SeleniumDocs.Elements
 {
     [TestClass]
     public class FindersTest : BaseTest
     {
+        private const string LocatorsPage = "https://www.selenium.dev/selenium/web/locators_tests/locators.html";
+
+        [TestMethod]
+        public void FindsFirstMatchingElement()
+        {
+            StartDriver();
+            driver.Url = LocatorsPage;
+            IWebElement firstInput = driver.FindElement(By.ClassName("information"));
+
+            Assert.AreEqual("fname", firstInput.GetAttribute("id"));
+        }
+
+        [TestMethod]
+        public void FindsElementWithinASubsetOfTheDom()
+        {
+            StartDriver();
+            driver.Url = LocatorsPage;
+            IWebElement form = driver.FindElement(By.TagName("form"));
+            IWebElement input = form.FindElement(By.ClassName("information"));
+
+            Assert.AreEqual("fname", input.GetAttribute("id"));
+        }
+
+        [TestMethod]
+        public void UsesAnOptimizedLocator()
+        {
+            StartDriver();
+            driver.Url = LocatorsPage;
+            IWebElement input = driver.FindElement(By.CssSelector("form .information"));
+
+            Assert.AreEqual("fname", input.GetAttribute("id"));
+        }
+
+        [TestMethod]
+        public void FindsAllMatchingElements()
+        {
+            StartDriver();
+            driver.Url = LocatorsPage;
+            var inputs = driver.FindElements(By.TagName("input"));
+
+            Assert.IsTrue(inputs.Count > 1);
+        }
+
+        [TestMethod]
+        public void GetsElementFromACollection()
+        {
+            StartDriver();
+            driver.Url = LocatorsPage;
+
+            var elements = driver.FindElements(By.TagName("p"));
+            foreach (var element in elements)
+            {
+                System.Console.WriteLine("Paragraph text:" + element.Text);
+            }
+
+            Assert.IsTrue(elements.Count > 0);
+        }
+
+        [TestMethod]
+        public void FindsElementsFromElement()
+        {
+            StartDriver();
+            driver.Url = LocatorsPage;
+
+            IWebElement form = driver.FindElement(By.TagName("form"));
+            var elements = form.FindElements(By.TagName("input"));
+            foreach (var e in elements)
+            {
+                System.Console.WriteLine(e.GetAttribute("value"));
+            }
+
+            Assert.IsTrue(elements.Count > 0);
+        }
+
+        [TestMethod]
+        public void GetsActiveElement()
+        {
+            StartDriver();
+            driver.Url = LocatorsPage;
+
+            driver.FindElement(By.CssSelector("#fname")).SendKeys("webElement");
+            string attr = driver.SwitchTo().ActiveElement().GetAttribute("name");
+
+            Assert.AreEqual("fname", attr);
+        }
     }
 }

--- a/examples/java/src/test/java/dev/selenium/elements/FindersTest.java
+++ b/examples/java/src/test/java/dev/selenium/elements/FindersTest.java
@@ -2,6 +2,92 @@ package dev.selenium.elements;
 
 import dev.selenium.BaseTest;
 
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class FindersTest extends BaseTest {
 
+  private static final String LOCATORS_PAGE =
+      "https://www.selenium.dev/selenium/web/locators_tests/locators.html";
+
+  @Test
+  public void findsFirstMatchingElement() {
+    startChromeDriver();
+    driver.get(LOCATORS_PAGE);
+    WebElement firstInput = driver.findElement(By.className("information"));
+
+    assertEquals("fname", firstInput.getAttribute("id"));
+  }
+
+  @Test
+  public void findsElementWithinASubsetOfTheDom() {
+    startChromeDriver();
+    driver.get(LOCATORS_PAGE);
+    WebElement form = driver.findElement(By.tagName("form"));
+    WebElement input = form.findElement(By.className("information"));
+
+    assertEquals("fname", input.getAttribute("id"));
+  }
+
+  @Test
+  public void usesAnOptimizedLocator() {
+    startChromeDriver();
+    driver.get(LOCATORS_PAGE);
+    WebElement input = driver.findElement(By.cssSelector("form .information"));
+
+    assertEquals("fname", input.getAttribute("id"));
+  }
+
+  @Test
+  public void findsAllMatchingElements() {
+    startChromeDriver();
+    driver.get(LOCATORS_PAGE);
+    List<WebElement> inputs = driver.findElements(By.tagName("input"));
+
+    assertTrue(inputs.size() > 1);
+  }
+
+  @Test
+  public void getsElementFromACollection() {
+    startChromeDriver();
+    driver.get(LOCATORS_PAGE);
+
+    List<WebElement> elements = driver.findElements(By.tagName("p"));
+    for (WebElement element : elements) {
+      System.out.println("Paragraph text:" + element.getText());
+    }
+
+    assertTrue(elements.size() > 0);
+  }
+
+  @Test
+  public void findsElementsFromElement() {
+    startChromeDriver();
+    driver.get(LOCATORS_PAGE);
+
+    WebElement form = driver.findElement(By.tagName("form"));
+    List<WebElement> elements = form.findElements(By.tagName("input"));
+    for (WebElement e : elements) {
+      System.out.println(e.getAttribute("value"));
+    }
+
+    assertTrue(elements.size() > 0);
+  }
+
+  @Test
+  public void getsActiveElement() {
+    startChromeDriver();
+    driver.get(LOCATORS_PAGE);
+
+    driver.findElement(By.cssSelector("#fname")).sendKeys("webElement");
+    String attr = driver.switchTo().activeElement().getAttribute("name");
+
+    assertEquals("fname", attr);
+  }
 }

--- a/examples/javascript/test/elements/finders.spec.js
+++ b/examples/javascript/test/elements/finders.spec.js
@@ -1,0 +1,78 @@
+const {Builder, By} = require('selenium-webdriver');
+const assert = require('assert');
+
+const LOCATORS_PAGE = 'https://www.selenium.dev/selenium/web/locators_tests/locators.html';
+
+describe('Finders', function () {
+  it('finds the first matching element', async function () {
+    let driver = await new Builder().forBrowser('chrome').build();
+    await driver.get(LOCATORS_PAGE);
+    const firstInput = await driver.findElement(By.className('information'));
+
+    assert.equal(await firstInput.getAttribute('id'), 'fname');
+    await driver.quit();
+  });
+
+  it('finds an element within a subset of the DOM', async function () {
+    let driver = await new Builder().forBrowser('chrome').build();
+    await driver.get(LOCATORS_PAGE);
+    const form = await driver.findElement(By.tagName('form'));
+    const input = await form.findElement(By.className('information'));
+
+    assert.equal(await input.getAttribute('id'), 'fname');
+    await driver.quit();
+  });
+
+  it('uses an optimized locator', async function () {
+    let driver = await new Builder().forBrowser('chrome').build();
+    await driver.get(LOCATORS_PAGE);
+    const input = await driver.findElement(By.css('form .information'));
+
+    assert.equal(await input.getAttribute('id'), 'fname');
+    await driver.quit();
+  });
+
+  it('finds all matching elements', async function () {
+    let driver = await new Builder().forBrowser('chrome').build();
+    await driver.get(LOCATORS_PAGE);
+    const inputs = await driver.findElements(By.tagName('input'));
+
+    assert.ok(inputs.length > 1);
+    await driver.quit();
+  });
+
+  it('gets an element from a collection', async function () {
+    let driver = await new Builder().forBrowser('chrome').build();
+    await driver.get(LOCATORS_PAGE);
+    const elements = await driver.findElements(By.tagName('p'));
+    for (const element of elements) {
+      console.log('Paragraph text:' + await element.getText());
+    }
+
+    assert.ok(elements.length > 0);
+    await driver.quit();
+  });
+
+  it('finds elements from an element', async function () {
+    let driver = await new Builder().forBrowser('chrome').build();
+    await driver.get(LOCATORS_PAGE);
+    const form = await driver.findElement(By.css('form'));
+    const elements = await form.findElements(By.css('input'));
+    for (const e of elements) {
+      console.log(await e.getAttribute('value'));
+    }
+
+    assert.ok(elements.length > 0);
+    await driver.quit();
+  });
+
+  it('gets the active element', async function () {
+    let driver = await new Builder().forBrowser('chrome').build();
+    await driver.get(LOCATORS_PAGE);
+    await driver.findElement(By.css('#fname')).sendKeys('webElement');
+    const attr = await driver.switchTo().activeElement().getAttribute('name');
+
+    assert.equal(attr, 'fname');
+    await driver.quit();
+  });
+});

--- a/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt
+++ b/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt
@@ -1,0 +1,86 @@
+package dev.selenium.elements
+
+import dev.selenium.BaseTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.openqa.selenium.By
+import java.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FindersTest : BaseTest() {
+
+    private val locatorsPage = "https://www.selenium.dev/selenium/web/locators_tests/locators.html"
+
+    @Test
+    fun findsFirstMatchingElement() {
+        driver.get(locatorsPage)
+        val firstInput = driver.findElement(By.className("information"))
+
+        assertEquals("fname", firstInput.getAttribute("id"))
+    }
+
+    @Test
+    fun findsElementWithinASubsetOfTheDom() {
+        driver.get(locatorsPage)
+        val form = driver.findElement(By.tagName("form"))
+        val input = form.findElement(By.className("information"))
+
+        assertEquals("fname", input.getAttribute("id"))
+    }
+
+    @Test
+    fun usesAnOptimizedLocator() {
+        driver.get(locatorsPage)
+        val input = driver.findElement(By.cssSelector("form .information"))
+
+        assertEquals("fname", input.getAttribute("id"))
+    }
+
+    @Test
+    fun findsAllMatchingElements() {
+        driver.get(locatorsPage)
+        val inputs = driver.findElements(By.tagName("input"))
+
+        assertTrue(inputs.size > 1)
+    }
+
+    @Test
+    fun getsElementFromACollection() {
+        driver.get(locatorsPage)
+        val elements = driver.findElements(By.tagName("p"))
+        for (element in elements) {
+            println("Paragraph text:" + element.text)
+        }
+
+        assertTrue(elements.isNotEmpty())
+    }
+
+    @Test
+    fun findsElementsFromElement() {
+        driver.get(locatorsPage)
+        val form = driver.findElement(By.tagName("form"))
+        val elements = form.findElements(By.tagName("input"))
+        for (e in elements) {
+            println(e.getAttribute("value"))
+        }
+
+        assertTrue(elements.isNotEmpty())
+    }
+
+    @Test
+    fun getsActiveElement() {
+        driver.get(locatorsPage)
+        driver.findElement(By.cssSelector("#fname")).sendKeys("webElement")
+        val attr = driver.switchTo().activeElement().getAttribute("name")
+
+        assertEquals("fname", attr)
+    }
+
+    @BeforeEach
+    fun configureImplicitWait() {
+        driver.manage().timeouts().implicitlyWait(Duration.ofMillis(500))
+    }
+}

--- a/examples/python/tests/elements/test_finders.py
+++ b/examples/python/tests/elements/test_finders.py
@@ -1,46 +1,38 @@
-import pytest
-from selenium import webdriver
 from selenium.webdriver.common.by import By
 
-# The tests below marked as skipped mirror the HTML snippet shown at the top of the
-# "Finding web elements" documentation and are illustrative only, matching how the
-# same examples are shown for the other language bindings:
-#
-# <ol id="vegetables">
-#  <li class="potatoes">…
-#  <li class="onions">…
-#  <li class="tomatoes"><span>Tomato is a Vegetable</span>…
-# </ol>
-# <ul id="fruits">
-#   <li class="bananas">…
-#   <li class="apples">…
-#   <li class="tomatoes"><span>Tomato is a Fruit</span>…
-# </ul>
+LOCATORS_PAGE = "https://www.selenium.dev/selenium/web/locators_tests/locators.html"
 
 
-@pytest.mark.skip(reason="illustrative example, not an executable test")
-def test_basic_finders(driver):
-    vegetable = driver.find_element(By.CLASS_NAME, 'tomatoes')
+def test_first_matching_element(driver):
+    driver.get(LOCATORS_PAGE)
+    first_input = driver.find_element(By.CLASS_NAME, "information")
+
+    assert first_input.get_attribute("id") == "fname"
 
 
-@pytest.mark.skip(reason="illustrative example, not an executable test")
 def test_subset_of_dom(driver):
-    fruits = driver.find_element(By.ID, 'fruits')
-    fruit = fruits.find_element(By.CLASS_NAME, 'tomatoes')
+    driver.get(LOCATORS_PAGE)
+    form = driver.find_element(By.TAG_NAME, "form")
+    input_element = form.find_element(By.CLASS_NAME, "information")
+
+    assert input_element.get_attribute("id") == "fname"
 
 
-@pytest.mark.skip(reason="illustrative example, not an executable test")
 def test_optimized_locator(driver):
-    fruit = driver.find_element(By.CSS_SELECTOR, '#fruits .tomatoes')
+    driver.get(LOCATORS_PAGE)
+    input_element = driver.find_element(By.CSS_SELECTOR, "form .information")
+
+    assert input_element.get_attribute("id") == "fname"
 
 
-@pytest.mark.skip(reason="illustrative example, not an executable test")
 def test_all_matching_elements(driver):
-    plants = driver.find_elements(By.TAG_NAME, 'li')
+    driver.get(LOCATORS_PAGE)
+    inputs = driver.find_elements(By.TAG_NAME, "input")
+
+    assert len(inputs) > 1
 
 
-def test_evaluating_shadow_dom():
-    driver = webdriver.Chrome()
+def test_evaluating_shadow_dom(driver):
     driver.implicitly_wait(5)
     driver.get('https://www.selenium.dev/selenium/web/shadowRootPage.html')
 
@@ -52,43 +44,32 @@ def test_evaluating_shadow_dom():
     assert shadow_host.is_displayed()
     assert shadow_content.is_displayed()
 
-    driver.quit()
 
-
-def test_get_element():
-    driver = webdriver.Chrome()
-    driver.get('https://www.example.com')
+def test_get_element(driver):
+    driver.get(LOCATORS_PAGE)
 
     elements = driver.find_elements(By.TAG_NAME, 'p')
     for element in elements:
-        print(element.text)
+        print(f"Paragraph text:{element.text}")
 
     assert len(elements) > 0
 
-    driver.quit()
 
+def test_find_elements_from_element(driver):
+    driver.get(LOCATORS_PAGE)
 
-def test_find_elements_from_element():
-    driver = webdriver.Chrome()
-    driver.get('https://www.example.com')
-
-    element = driver.find_element(By.TAG_NAME, 'div')
-    elements = element.find_elements(By.TAG_NAME, 'p')
-    for e in elements:
-        print(e.text)
+    form = driver.find_element(By.TAG_NAME, 'form')
+    elements = form.find_elements(By.TAG_NAME, 'input')
+    for element in elements:
+        print(element.get_attribute('value'))
 
     assert len(elements) > 0
 
-    driver.quit()
 
+def test_get_active_element(driver):
+    driver.get(LOCATORS_PAGE)
 
-def test_get_active_element():
-    driver = webdriver.Chrome()
-    driver.get('https://www.selenium.dev/selenium/web/web-form.html')
-
-    driver.find_element(By.CSS_SELECTOR, '[name="my-text"]').send_keys('webElement')
+    driver.find_element(By.CSS_SELECTOR, '#fname').send_keys('webElement')
     attr = driver.switch_to.active_element.get_attribute('name')
 
-    assert attr == 'my-text'
-
-    driver.quit()
+    assert attr == 'fname'

--- a/examples/ruby/spec/elements/finders_spec.rb
+++ b/examples/ruby/spec/elements/finders_spec.rb
@@ -4,41 +4,61 @@ require 'spec_helper'
 
 RSpec.describe 'Element Finders' do
   let(:driver) { start_session }
+  let(:locators_page) { 'https://www.selenium.dev/selenium/web/locators_tests/locators.html' }
 
-  context 'without executing finders', skip: 'these are just examples, not actual tests' do
-    it 'finds the first matching element' do
-      driver.find_element(class: 'tomatoes')
-    end
+  it 'finds the first matching element' do
+    driver.navigate.to locators_page
+    first_input = driver.find_element(class: 'information')
 
-    it 'uses a subset of the dom to find an element' do
-      fruits = driver.find_element(id: 'fruits')
-      fruits.find_element(class: 'tomatoes')
-    end
+    expect(first_input.attribute('id')).to eq('fname')
+  end
 
-    it 'uses an optimized locator' do
-      driver.find_element(css: '#fruits .tomatoes')
-    end
+  it 'uses a subset of the dom to find an element' do
+    driver.navigate.to locators_page
+    form = driver.find_element(tag_name: 'form')
+    input_element = form.find_element(class: 'information')
 
-    it 'finds all matching elements' do
-      driver.find_elements(tag_name: 'li')
-    end
+    expect(input_element.attribute('id')).to eq('fname')
+  end
 
-    # rubocop:disable RSpec/Output
-    it 'gets an element from a collection' do
-      elements = driver.find_elements(:tag_name, 'p')
-      elements.each { |e| puts e.text }
-    end
+  it 'uses an optimized locator' do
+    driver.navigate.to locators_page
+    input_element = driver.find_element(css: 'form .information')
 
-    it 'finds element from element' do
-      element = driver.find_element(:tag_name, 'div')
-      elements = element.find_elements(:tag_name, 'p')
-      elements.each { |e| puts e.text }
-    end
-    # rubocop:enable RSpec/Output
+    expect(input_element.attribute('id')).to eq('fname')
+  end
 
-    it 'find active element' do
-      driver.find_element(css: '[name="q"]').send_keys('webElement')
-      driver.switch_to.active_element.attribute('title')
-    end
+  it 'finds all matching elements' do
+    driver.navigate.to locators_page
+    inputs = driver.find_elements(tag_name: 'input')
+
+    expect(inputs.size).to be > 1
+  end
+
+  # rubocop:disable RSpec/Output
+  it 'gets an element from a collection' do
+    driver.navigate.to locators_page
+    elements = driver.find_elements(tag_name: 'p')
+    elements.each { |e| puts "Paragraph text:#{e.text}" }
+
+    expect(elements).not_to be_empty
+  end
+
+  it 'finds element from element' do
+    driver.navigate.to locators_page
+    form = driver.find_element(tag_name: 'form')
+    elements = form.find_elements(tag_name: 'input')
+    elements.each { |e| puts e.attribute('value') }
+
+    expect(elements).not_to be_empty
+  end
+  # rubocop:enable RSpec/Output
+
+  it 'finds the active element' do
+    driver.navigate.to locators_page
+    driver.find_element(css: '#fname').send_keys('webElement')
+    attr = driver.switch_to.active_element.attribute('name')
+
+    expect(attr).to eq('fname')
   end
 end

--- a/website_and_docs/content/documentation/webdriver/elements/finders.en.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.en.md
@@ -12,22 +12,8 @@ description: >
 
 One of the most fundamental aspects of using Selenium is obtaining element references to work with.
 Selenium offers a number of built-in [locator strategies]({{< ref "locators.md" >}}) to uniquely identify an element.
-There are many ways to use the locators in very advanced scenarios. For the purposes of this documentation, 
-let's consider this HTML snippet:
-
-
-```html
-<ol id="vegetables">
- <li class="potatoes">…
- <li class="onions">…
- <li class="tomatoes"><span>Tomato is a Vegetable</span>…
-</ol>
-<ul id="fruits">
-  <li class="bananas">…
-  <li class="apples">…
-  <li class="tomatoes"><span>Tomato is a Fruit</span>…
-</ul>
-```
+There are many ways to use the locators in very advanced scenarios. For the purposes of this documentation,
+use the [Selenium locator test page](https://www.selenium.dev/selenium/web/locators_tests/locators.html).
 
 ## First matching element 
 
@@ -38,28 +24,27 @@ first element found within a given context.
 
 When the find element method is called on the driver instance, it 
 returns a reference to the first element in the DOM that matches with the provided locator. 
-This value can be stored and used for future element actions. In our example HTML above, there are 
-two elements that have a class name of "tomatoes" so this method will return the element in the "vegetables" list.
+This value can be stored and used for future element actions. On the Selenium locator test page, there are
+two elements with the class name `information`, so this method returns the first text input.
 
-{{< tabpane langEqualsHeader=true >}}
-{{< badge-examples >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement vegetable = driver.findElement(By.className("tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L22-L23">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L23">}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L7-L8">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-var vegetable = driver.FindElement(By.ClassName("tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L15-L16">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L14-L15">}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L10-L11" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const vegetable = await driver.findElement(By.className('tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L9-L10">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L19-L20">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -67,35 +52,28 @@ val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
 ### Evaluating a subset of the DOM
 
 Rather than finding a unique locator in the entire DOM, it is often useful to narrow the search to the scope
-of another located element. In the above example there are two elements with a class name of "tomatoes" and 
-it is a little more challenging to get the reference for the second one.
+of another located element.
 
-One solution is to locate an element with a unique attribute that is an ancestor of the desired element and not an
-ancestor of the undesired element, then call find element on that object:
+One solution is to locate an ancestor of the desired element, then call find element on that object:
 
-{{< tabpane langEqualsHeader=true >}}
-{{< badge-examples >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement fruits = driver.findElement(By.id("fruits"));
-WebElement fruit = fruits.findElement(By.className("tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L31-L33">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L28-L29">}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L14-L16">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IWebElement fruits = driver.FindElement(By.Id("fruits"));
-IWebElement fruit = fruits.FindElement(By.ClassName("tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L25-L27">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L14-L15">}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L17-L19" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruits = await driver.findElement(By.id('fruits'));
-const fruit = fruits.findElement(By.className('tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L18-L20">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val fruits = driver.findElement(By.id("fruits"))
-val fruit = fruits.findElement(By.className("tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L27-L29">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -121,7 +99,7 @@ SearchContext shadowRoot = shadowHost.getShadowRoot();
 WebElement shadowContent = shadowRoot.findElement(By.cssSelector("#shadow_content"));
 {{< /tab >}}
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L47-L50">}}
+{{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L39-L42">}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var shadowHost = _driver.FindElement(By.CssSelector("#shadow_host"));
@@ -150,27 +128,26 @@ To improve the performance slightly, we can use either CSS or XPath to find this
 See the [Locator strategy suggestions]({{< ref "/documentation/test_practices/encouraged/locators" >}}) in our 
 [Encouraged test practices]({{< ref "/documentation/test_practices/encouraged" >}}) section.
 
-For this example, we'll use a CSS Selector:
+For this example, we'll use a CSS selector:
 
-{{< tabpane langEqualsHeader=true >}}
-{{< badge-examples >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L41-L42">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L34" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L22-L23">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-var fruit = driver.FindElement(By.CssSelector("#fruits .tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L36-L37">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L19" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L25-L26" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruit = await driver.findElement(By.css('#fruits .tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L28-L29">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L36-L37">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -180,27 +157,26 @@ val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
 There are several use cases for needing to get references to all elements that match a locator, rather
 than just the first one. The plural find elements methods return a collection of element references. 
 If there are no matches, an empty list is returned. In this case, 
-references to all fruits and vegetable list items will be returned in a collection. 
+references to all input elements will be returned in a collection.
 
-{{< tabpane langEqualsHeader=true >}}
-{{< badge-examples >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-List<WebElement> plants = driver.findElements(By.tagName("li"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L50-L51">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L39" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L29-L30">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L46-L47">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L23" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L32-L33" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const plants = await driver.findElements(By.tagName('li'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L37-L38">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val plants: List<WebElement> = driver.findElements(By.tagName("li"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L44-L45">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -209,83 +185,24 @@ Often you get a collection of elements but want to work with a specific element,
 need to iterate over the collection and identify the one you want.
 
 
-{{< tabpane langEqualsHeader=true >}}
-{{< badge-examples >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-List<WebElement> elements = driver.findElements(By.tagName("li"));
-
-for (WebElement element : elements) {
-    System.out.println("Paragraph text:" + element.getText());
-}
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L61-L64">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L62-L64" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L51-L53">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using OpenQA.Selenium;
-using OpenQA.Selenium.Firefox;
-using System.Collections.Generic;
-
-namespace FindElementsExample {
- class FindElementsExample {
-  public static void Main(string[] args) {
-   IWebDriver driver = new FirefoxDriver();
-   try {
-    // Navigate to Url
-    driver.Navigate().GoToUrl("https://example.com");
-
-    // Get all the elements available with tag name 'p'
-    IList < IWebElement > elements = driver.FindElements(By.TagName("p"));
-    foreach(IWebElement e in elements) {
-     System.Console.WriteLine(e.Text);
-    }
-
-   } finally {
-    driver.Quit();
-   }
-  }
- }
-}
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L58-L62">}}
   {{< /tab >}}
-   {{< tab header="Ruby" text=true >}}
-   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L28-L29" >}}
+   {{< tab header="Ruby" >}}
+   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L40-L42" >}}
    {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const {Builder, By} = require('selenium-webdriver');
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    try {
-        // Navigate to Url
-        await driver.get('https://www.example.com');
-
-        // Get all the elements available with tag 'p'
-        let elements = await driver.findElements(By.css('p'));
-        for(let e of elements) {
-            console.log(await e.getText());
-        }
-    }
-    finally {
-        await driver.quit();
-    }
-})();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L47-L50">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-import org.openqa.selenium.By
-import org.openqa.selenium.firefox.FirefoxDriver
-
-fun main() {
-    val driver = FirefoxDriver()
-    try {
-        driver.get("https://example.com")
-        // Get all the elements available with tag name 'p'
-        val elements = driver.findElements(By.tagName("p"))
-        for (element in elements) {
-            println("Paragraph text:" + element.text)
-        }
-    } finally {
-        driver.quit()
-    }
-}
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L53-L56">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -294,109 +211,24 @@ fun main() {
 It is used to find the list of matching child WebElements within the context of parent element.
 To achieve this, the parent WebElement is chained with 'findElements' to access child elements
 
-{{< tabpane langEqualsHeader=true >}}
-{{< badge-examples >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-  import org.openqa.selenium.By;
-  import org.openqa.selenium.WebDriver;
-  import org.openqa.selenium.WebElement;
-  import org.openqa.selenium.chrome.ChromeDriver;
-  import java.util.List;
-
-  public class findElementsFromElement {
-      public static void main(String[] args) {
-          WebDriver driver = new ChromeDriver();
-          try {
-              driver.get("https://example.com");
-
-              // Get element with tag name 'div'
-              WebElement element = driver.findElement(By.tagName("div"));
-
-              // Get all the elements available with tag name 'p'
-              List<WebElement> elements = element.findElements(By.tagName("p"));
-              for (WebElement e : elements) {
-                  System.out.println(e.getText());
-              }
-          } finally {
-              driver.quit();
-          }
-      }
-  }
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L74-L78">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L75-L78" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L61-L64">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using OpenQA.Selenium;
-using OpenQA.Selenium.Chrome;
-using System.Collections.Generic;
-
-namespace FindElementsFromElement {
- class FindElementsFromElement {
-  public static void Main(string[] args) {
-   IWebDriver driver = new ChromeDriver();
-   try {
-    driver.Navigate().GoToUrl("https://example.com");
-
-    // Get element with tag name 'div'
-    IWebElement element = driver.FindElement(By.TagName("div"));
-
-    // Get all the elements available with tag name 'p'
-    IList < IWebElement > elements = element.FindElements(By.TagName("p"));
-    foreach(IWebElement e in elements) {
-     System.Console.WriteLine(e.Text);
-    }
-   } finally {
-    driver.Quit();
-   }
-  }
- }
-}
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L73-L78">}}
   {{< /tab >}}
-   {{< tab header="Ruby" text=true >}}
-   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L33-L35" >}}
+   {{< tab header="Ruby" >}}
+   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L48-L51" >}}
    {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  const {Builder, By} = require('selenium-webdriver');
-
-  (async function example() {
-      let driver = new Builder()
-          .forBrowser('chrome')
-          .build();
-
-      await driver.get('https://www.example.com');
-
-      // Get element with tag name 'div'
-      let element = driver.findElement(By.css("div"));
-
-      // Get all the elements available with tag name 'p'
-      let elements = await element.findElements(By.css("p"));
-      for(let e of elements) {
-          console.log(await e.getText());
-      }
-  })();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L59-L63">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-  import org.openqa.selenium.By
-  import org.openqa.selenium.chrome.ChromeDriver
-
-  fun main() {
-      val driver = ChromeDriver()
-      try {
-          driver.get("https://example.com")
-
-          // Get element with tag name 'div'
-          val element = driver.findElement(By.tagName("div"))
-
-          // Get all the elements available with tag name 'p'
-          val elements = element.findElements(By.tagName("p"))
-          for (e in elements) {
-              println(e.text)
-          }
-      } finally {
-          driver.quit()
-      }
-  }
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L64-L68">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -404,87 +236,24 @@ namespace FindElementsFromElement {
 
 It is used to track (or) find DOM element which has the focus in the current browsing context.
 
-{{< tabpane langEqualsHeader=true >}}
-{{< badge-examples >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-  import org.openqa.selenium.*;
-  import org.openqa.selenium.chrome.ChromeDriver;
-
-  public class activeElementTest {
-    public static void main(String[] args) {
-      WebDriver driver = new ChromeDriver();
-      try {
-        driver.get("http://www.google.com");
-        driver.findElement(By.cssSelector("[name='q']")).sendKeys("webElement");
-
-        // Get attribute of current active element
-        String attr = driver.switchTo().activeElement().getAttribute("title");
-        System.out.println(attr);
-      } finally {
-        driver.quit();
-      }
-    }
-  }
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L88-L89">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L89-L90" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L72-L73">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Chrome;
-
-    namespace ActiveElement {
-     class ActiveElement {
-      public static void Main(string[] args) {
-       IWebDriver driver = new ChromeDriver();
-       try {
-        // Navigate to Url
-        driver.Navigate().GoToUrl("https://www.google.com");
-        driver.FindElement(By.CssSelector("[name='q']")).SendKeys("webElement");
-
-        // Get attribute of current active element
-        string attr = driver.SwitchTo().ActiveElement().GetAttribute("title");
-        System.Console.WriteLine(attr);
-       } finally {
-        driver.Quit();
-       }
-      }
-     }
-    }
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L89-L90">}}
   {{< /tab >}}
-  {{< tab header="Ruby" text=true >}}
-  {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L40-L41" >}}
+  {{< tab header="Ruby" >}}
+  {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L58-L60" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  const {Builder, By} = require('selenium-webdriver');
-
-  (async function example() {
-      let driver = await new Builder().forBrowser('chrome').build();
-      await driver.get('https://www.google.com');
-      await  driver.findElement(By.css('[name="q"]')).sendKeys("webElement");
-
-      // Get attribute of current active element
-      let attr = await driver.switchTo().activeElement().getAttribute("title");
-      console.log(`${attr}`)
-  })();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L72-L73">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-  import org.openqa.selenium.By
-  import org.openqa.selenium.chrome.ChromeDriver
-
-  fun main() {
-      val driver = ChromeDriver()
-      try {
-          driver.get("https://www.google.com")
-          driver.findElement(By.cssSelector("[name='q']")).sendKeys("webElement")
-
-          // Get attribute of current active element
-          val attr = driver.switchTo().activeElement().getAttribute("title")
-          print(attr)
-      } finally {
-          driver.quit()
-      }
-  }
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L76-L77">}}
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.ja.md
@@ -13,20 +13,7 @@ description: >
 Seleniumを使用する最も基本的な側面の1つは、操作する要素の参照を取得することです。 
 Seleniumは、要素を一意に識別するための多数の組み込み[ロケーター戦略]({{< ref "locators.md" >}})を提供します。 
 非常に高度なシナリオでロケーターを使用する方法はたくさんあります。 
-このドキュメントの目的のために、このHTMLスニペットについて考えてみましょう。
-
-```html
-<ol id="vegetables">
- <li class="potatoes">…
- <li class="onions">…
- <li class="tomatoes"><span>Tomato is a Vegetable</span>…
-</ol>
-<ul id="fruits">
-  <li class="bananas">…
-  <li class="apples">…
-  <li class="tomatoes"><span>Tomato is a Fruit</span>…
-</ul>
-```
+このドキュメントの目的のために、[Seleniumロケーターテストページ](https://www.selenium.dev/selenium/web/locators_tests/locators.html)を使用します。
 
 ## 最初に一致する要素
 
@@ -37,59 +24,54 @@ Seleniumは、要素を一意に識別するための多数の組み込み[ロ�
 
 ドライバーインスタンスで要素の検索メソッドが呼び出されると、提供されたロケーターと一致するDOMの最初の要素への参照が返されます。 
 この値は保存して、将来の要素アクションに使用できます。 
-上記のHTMLの例では、クラス名が "tomatoes" の要素が2つあるため、このメソッドは "vegetables" リストの要素を返します。
+Seleniumロケーターテストページには、クラス名が `information` の要素が2つあるため、このメソッドは最初のテキスト入力を返します。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement vegetable = driver.findElement(By.className("tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L22-L23">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L23">}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L7-L8">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-var vegetable = driver.FindElement(By.ClassName("tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L15-L16">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L10" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L10-L11" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const vegetable = await driver.findElement(By.className('tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L9-L10">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L19-L20">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
 
 ### DOMのサブセットの評価
 
-DOM全体で一意のロケーターを見つけるのではなく、検索を別の検索された要素のスコープに絞り込むと便利なことがよくあります。 
-上記の例では、クラス名が "トマト" の2つの要素があり、2番目の要素の参照を取得するのは少し困難です。
+DOM全体で一意のロケーターを見つけるのではなく、検索を別の検索された要素のスコープに絞り込むと便利なことがよくあります。
 
-1つの解決策は、目的の要素の祖先であり、不要な要素の祖先ではない一意の属性を持つ要素を見つけて、そのオブジェクトでfind要素を呼び出すことです。
+1つの解決策は、目的の要素の祖先を見つけて、そのオブジェクトでfind要素を呼び出すことです。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement fruits = driver.findElement(By.id("fruits"));
-WebElement fruit = fruits.findElement(By.className("tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L31-L33">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L28-L29">}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L14-L16">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IWebElement fruits = driver.FindElement(By.Id("fruits"));
-IWebElement fruit = fruits.FindElement(By.ClassName("tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L25-L27">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L14-L15" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L17-L19" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruits = await driver.findElement(By.id('fruits'));
-const fruit = fruits.findElement(By.className('tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L18-L20">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val fruits = driver.findElement(By.id("fruits"))
-val fruit = fruits.findElement(By.className("tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L27-L29">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -114,7 +96,7 @@ SearchContext shadowRoot = shadowHost.getShadowRoot();
 WebElement shadowContent = shadowRoot.findElement(By.cssSelector("#shadow_content"));
 {{< /tab >}}
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L47-L50">}}
+{{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L39-L42">}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var shadowHost = _driver.FindElement(By.CssSelector("#shadow_host"));
@@ -143,24 +125,24 @@ shadow_content = shadow_root.find_element(css: '#shadow_content')
 
 この例では、CSSセレクターを使用します。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L41-L42">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L34" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L22-L23">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-var fruit = driver.FindElement(By.CssSelector("#fruits .tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L36-L37">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L19" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L25-L26" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruit = await driver.findElement(By.css('#fruits .tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L28-L29">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L36-L37">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -170,26 +152,26 @@ val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
 最初の要素だけでなく、ロケーターに一致するすべての要素への参照を取得する必要があるユースケースがいくつかあります。 
 複数の要素の検索メソッドは、要素参照のコレクションを返します。 
 一致するものがない場合は、空のリストが返されます。 
-この場合、すべてのfruitsとvegetableのリストアイテムへの参照がコレクションに返されます。
+この場合、すべてのinput要素への参照がコレクションに返されます。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-List<WebElement> plants = driver.findElements(By.tagName("li"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L50-L51">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L39" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L29-L30">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L46-L47">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L23" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L32-L33" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const plants = await driver.findElements(By.tagName('li'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L37-L38">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val plants: List<WebElement> = driver.findElements(By.tagName("li"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L44-L45">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -197,82 +179,24 @@ val plants: List<WebElement> = driver.findElements(By.tagName("li"))
 多くの場合、要素のコレクションを取得しますが、特定の要素を操作したいので、コレクションを繰り返し処理して、
 必要な要素を特定する必要があります。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-List<WebElement> elements = driver.findElements(By.tagName("li"));
-
-for (WebElement element : elements) {
-    System.out.println("Paragraph text:" + element.getText());
-}
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L61-L64">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L62-L64" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L51-L53">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using OpenQA.Selenium;
-using OpenQA.Selenium.Firefox;
-using System.Collections.Generic;
-
-namespace FindElementsExample {
- class FindElementsExample {
-  public static void Main(string[] args) {
-   IWebDriver driver = new FirefoxDriver();
-   try {
-    // Navigate to Url
-    driver.Navigate().GoToUrl("https://example.com");
-
-    // Get all the elements available with tag name 'p'
-    IList < IWebElement > elements = driver.FindElements(By.TagName("p"));
-    foreach(IWebElement e in elements) {
-     System.Console.WriteLine(e.Text);
-    }
-
-   } finally {
-    driver.Quit();
-   }
-  }
- }
-}
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L58-L62">}}
   {{< /tab >}}
-   {{< tab header="Ruby" text=true >}}
-   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L28-L29" >}}
+   {{< tab header="Ruby" >}}
+   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L40-L42" >}}
    {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const {Builder, By} = require('selenium-webdriver');
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    try {
-        // Navigate to Url
-        await driver.get('https://www.example.com');
-
-        // Get all the elements available with tag 'p'
-        let elements = await driver.findElements(By.css('p'));
-        for(let e of elements) {
-            console.log(await e.getText());
-        }
-    }
-    finally {
-        await driver.quit();
-    }
-})();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L47-L50">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-import org.openqa.selenium.By
-import org.openqa.selenium.firefox.FirefoxDriver
-
-fun main() {
-    val driver = FirefoxDriver()
-    try {
-        driver.get("https://example.com")
-        // Get all the elements available with tag name 'p'
-        val elements = driver.findElements(By.tagName("p"))
-        for (element in elements) {
-            println("Paragraph text:" + element.text)
-        }
-    } finally {
-        driver.quit()
-    }
-}
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L53-L56">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -281,108 +205,24 @@ fun main() {
 これは、親要素のコンテキスト内で一致する子のWebElementのリストを見つけるために利用されます。 
 これを実現するために、親WebElementは'findElements'と連鎖して子要素にアクセスします。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-  import org.openqa.selenium.By;
-  import org.openqa.selenium.WebDriver;
-  import org.openqa.selenium.WebElement;
-  import org.openqa.selenium.chrome.ChromeDriver;
-  import java.util.List;
-
-  public class findElementsFromElement {
-      public static void main(String[] args) {
-          WebDriver driver = new ChromeDriver();
-          try {
-              driver.get("https://example.com");
-
-              // Get element with tag name 'div'
-              WebElement element = driver.findElement(By.tagName("div"));
-
-              // Get all the elements available with tag name 'p'
-              List<WebElement> elements = element.findElements(By.tagName("p"));
-              for (WebElement e : elements) {
-                  System.out.println(e.getText());
-              }
-          } finally {
-              driver.quit();
-          }
-      }
-  }
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L74-L78">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L75-L78" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L61-L64">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using OpenQA.Selenium;
-using OpenQA.Selenium.Chrome;
-using System.Collections.Generic;
-
-namespace FindElementsFromElement {
- class FindElementsFromElement {
-  public static void Main(string[] args) {
-   IWebDriver driver = new ChromeDriver();
-   try {
-    driver.Navigate().GoToUrl("https://example.com");
-
-    // Get element with tag name 'div'
-    IWebElement element = driver.FindElement(By.TagName("div"));
-
-    // Get all the elements available with tag name 'p'
-    IList < IWebElement > elements = element.FindElements(By.TagName("p"));
-    foreach(IWebElement e in elements) {
-     System.Console.WriteLine(e.Text);
-    }
-   } finally {
-    driver.Quit();
-   }
-  }
- }
-}
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L73-L78">}}
   {{< /tab >}}
-   {{< tab header="Ruby" text=true >}}
-   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L33-L35" >}}
+   {{< tab header="Ruby" >}}
+   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L48-L51" >}}
    {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  const {Builder, By} = require('selenium-webdriver');
-
-  (async function example() {
-      let driver = new Builder()
-          .forBrowser('chrome')
-          .build();
-
-      await driver.get('https://www.example.com');
-
-      // Get element with tag name 'div'
-      let element = driver.findElement(By.css("div"));
-
-      // Get all the elements available with tag name 'p'
-      let elements = await element.findElements(By.css("p"));
-      for(let e of elements) {
-          console.log(await e.getText());
-      }
-  })();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L59-L63">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-  import org.openqa.selenium.By
-  import org.openqa.selenium.chrome.ChromeDriver
-
-  fun main() {
-      val driver = ChromeDriver()
-      try {
-          driver.get("https://example.com")
-
-          // Get element with tag name 'div'
-          val element = driver.findElement(By.tagName("div"))
-
-          // Get all the elements available with tag name 'p'
-          val elements = element.findElements(By.tagName("p"))
-          for (e in elements) {
-              println(e.text)
-          }
-      } finally {
-          driver.quit()
-      }
-  }
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L64-L68">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -390,86 +230,24 @@ namespace FindElementsFromElement {
 
 これは、現在のブラウジングコンテキストでフォーカスを持っているDOM要素を追跡（または）検索するために使用されます。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-  import org.openqa.selenium.*;
-  import org.openqa.selenium.chrome.ChromeDriver;
-
-  public class activeElementTest {
-    public static void main(String[] args) {
-      WebDriver driver = new ChromeDriver();
-      try {
-        driver.get("http://www.google.com");
-        driver.findElement(By.cssSelector("[name='q']")).sendKeys("webElement");
-
-        // Get attribute of current active element
-        String attr = driver.switchTo().activeElement().getAttribute("title");
-        System.out.println(attr);
-      } finally {
-        driver.quit();
-      }
-    }
-  }
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L88-L89">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L89-L90" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L72-L73">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Chrome;
-
-    namespace ActiveElement {
-     class ActiveElement {
-      public static void Main(string[] args) {
-       IWebDriver driver = new ChromeDriver();
-       try {
-        // Navigate to Url
-        driver.Navigate().GoToUrl("https://www.google.com");
-        driver.FindElement(By.CssSelector("[name='q']")).SendKeys("webElement");
-
-        // Get attribute of current active element
-        string attr = driver.SwitchTo().ActiveElement().GetAttribute("title");
-        System.Console.WriteLine(attr);
-       } finally {
-        driver.Quit();
-       }
-      }
-     }
-    }
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L89-L90">}}
   {{< /tab >}}
-  {{< tab header="Ruby" text=true >}}
-  {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L40-L41" >}}
+  {{< tab header="Ruby" >}}
+  {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L58-L60" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  const {Builder, By} = require('selenium-webdriver');
-
-  (async function example() {
-      let driver = await new Builder().forBrowser('chrome').build();
-      await driver.get('https://www.google.com');
-      await  driver.findElement(By.css('[name="q"]')).sendKeys("webElement");
-
-      // Get attribute of current active element
-      let attr = await driver.switchTo().activeElement().getAttribute("title");
-      console.log(`${attr}`)
-  })();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L72-L73">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-  import org.openqa.selenium.By
-  import org.openqa.selenium.chrome.ChromeDriver
-
-  fun main() {
-      val driver = ChromeDriver()
-      try {
-          driver.get("https://www.google.com")
-          driver.findElement(By.cssSelector("[name='q']")).sendKeys("webElement")
-
-          // Get attribute of current active element
-          val attr = driver.switchTo().activeElement().getAttribute("title")
-          print(attr)
-      } finally {
-          driver.quit()
-      }
-  }
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L76-L77">}}
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.pt-br.md
@@ -13,21 +13,7 @@ description: >
 Um dos aspectos mais fundamentais do uso do Selenium é obter referências de elementos para trabalhar.
 O Selenium oferece várias [estratégias de localizador]({{< ref "locators.md" >}}) para identificar exclusivamente um elemento.
 Há muitas maneiras de usar os localizadores em cenários complexos. Para os propósitos desta documentação,
-vamos considerar este trecho de HTML:
-
-
-```html
-<ol id="vegetables">
- <li class="potatoes">…
- <li class="onions">…
- <li class="tomatoes"><span>O tomate é um vegetal</span>…
-</ol>
-<ul id="fruits">
-  <li class="bananas">…
-  <li class="apples">…
-  <li class="tomatoes"><span>O tomate é uma fruta</span>…
-</ul>
-```
+use a [página de teste de localizadores do Selenium](https://www.selenium.dev/selenium/web/locators_tests/locators.html).
 
 ## Primeiro Elemento correspondente
 Muitos localizadores irão corresponder a vários elementos na página.
@@ -37,61 +23,55 @@ primeiro elemento encontrado dentro de um determinado contexto.
 ### Avaliando o DOM inteiro
 Quando o metodo find element é chamado na instância do driver, ele
 retorna uma referência ao primeiro elemento no DOM que corresponde ao localizador fornecido.
-Esse valor pode ser guardado e usado para ações futuras do elemento. Em nosso exemplo HTML acima, existem
-dois elementos que têm um nome de classe de "tomatoes" então este método retornará o elemento na lista "vegetables".
+Esse valor pode ser guardado e usado para ações futuras do elemento. Na página de teste de localizadores do Selenium, existem
+dois elementos com o nome de classe `information`, então este método retorna o primeiro campo de texto.
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement vegetable = driver.findElement(By.className("tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L22-L23">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L23">}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L7-L8">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-var vegetable = driver.FindElement(By.ClassName("tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L15-L16">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L10" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L10-L11" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const vegetable = await driver.findElement(By.className('tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L9-L10">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L19-L20">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
 
 ### Avaliando um subconjunto do DOM
 Ao em vez de tentar encontrar um localizador unico no DOM inteiro, normalmente é útil restringir a busca ao escopo de outro elemento
-já localizado. No exemplo acima existem dois elementos com um nome de classe de "tomatoes" e
-é um pouco mais desafiador obter a referência para o segundo.
+já localizado.
 
-Uma possível solução seria localizar um elemento com um atributo único que seja um ancestral do elemento desejado e não um
-ancestral do elemento indesejado, então invoque o find element nesse objeto:
+Uma possível solução seria localizar um ancestral do elemento desejado, então invoque o find element nesse objeto:
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement fruits = driver.findElement(By.id("fruits"));
-WebElement fruit = fruits.findElement(By.className("tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L31-L33">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L28-L29">}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L14-L16">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IWebElement fruits = driver.FindElement(By.Id("fruits"));
-IWebElement fruit = fruits.FindElement(By.ClassName("tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L25-L27">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L14-L15" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L17-L19" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruits = await driver.findElement(By.id('fruits'));
-const fruit = fruits.findElement(By.className('tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L18-L20">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val fruits = driver.findElement(By.id("fruits"))
-val fruit = fruits.findElement(By.className("tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L27-L29">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -117,7 +97,7 @@ SearchContext shadowRoot = shadowHost.getShadowRoot();
 WebElement shadowContent = shadowRoot.findElement(By.cssSelector("#shadow_content"));
 {{< /tab >}}
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L47-L50">}}
+{{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L39-L42">}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var shadowHost = _driver.FindElement(By.CssSelector("#shadow_host"));
@@ -145,26 +125,26 @@ Para melhorar um pouco o desempenho, podemos usar CSS ou XPath para encontrar es
 Veja as [sugestões de estratégia do localizador]({{< ref "/documentation/test_practices/encouraged/locators" >}}) na nossa sessão de
 [Práticas de teste incentivadas]({{< ref "/documentation/test_practices/encouraged" >}}).
 
-Para esse exemplo, utilizaremos o CSS Selector:
+Para esse exemplo, utilizaremos um seletor CSS:
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L41-L42">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L34" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L22-L23">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-var fruit = driver.FindElement(By.CssSelector("#fruits .tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L36-L37">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L19" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L25-L26" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruit = await driver.findElement(By.css('#fruits .tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L28-L29">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L36-L37">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -173,26 +153,26 @@ val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
 Existem vários casos de uso para a necessidade de obter referências a todos os elementos que correspondem a um localizador, em vez
 do que apenas o primeiro. Os métodos plurais find elements retornam uma coleção de referências de elementos.
 Se não houver correspondências, uma lista vazia será retornada. Nesse caso,
-referências a todos os itens da lista de frutas e vegetais serão devolvidas em uma coleção.
+referências a todos os elementos input serão devolvidas em uma coleção.
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-List<WebElement> plants = driver.findElements(By.tagName("li"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L50-L51">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L39" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L29-L30">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L46-L47">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L23" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L32-L33" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const plants = await driver.findElements(By.tagName('li'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L37-L38">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val plants: List<WebElement> = driver.findElements(By.tagName("li"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L44-L45">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -201,82 +181,24 @@ Muitas vezes você obterá uma coleção de elementos, mas quer trabalhar apenas
 precisa iterar sobre a coleção e identificar o que você deseja.
 
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-List<WebElement> elements = driver.findElements(By.tagName("li"));
-
-for (WebElement element : elements) {
-    System.out.println("Paragraph text:" + element.getText());
-}
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L61-L64">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L62-L64" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L51-L53">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using OpenQA.Selenium;
-using OpenQA.Selenium.Firefox;
-using System.Collections.Generic;
-
-namespace FindElementsExample {
- class FindElementsExample {
-  public static void Main(string[] args) {
-   IWebDriver driver = new FirefoxDriver();
-   try {
-    // Navegar até a URL
-    driver.Navigate().GoToUrl("https://example.com");
-
-    // Obtém todos os elementos disponiveis com o nome da tag 'p'
-    IList < IWebElement > elements = driver.FindElements(By.TagName("p"));
-    foreach(IWebElement e in elements) {
-     System.Console.WriteLine(e.Text);
-    }
-
-   } finally {
-    driver.Quit();
-   }
-  }
- }
-}
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L58-L62">}}
   {{< /tab >}}
-   {{< tab header="Ruby" text=true >}}
-   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L28-L29" >}}
+   {{< tab header="Ruby" >}}
+   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L40-L42" >}}
    {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const {Builder, By} = require('selenium-webdriver');
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    try {
-        // Navegar até a URL
-        await driver.get('https://www.example.com');
-
-        // Obtém todos os elementos disponiveis com o nome da tag 'p'
-        let elements = await driver.findElements(By.css('p'));
-        for(let e of elements) {
-            console.log(await e.getText());
-        }
-    }
-    finally {
-        await driver.quit();
-    }
-})();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L47-L50">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-import org.openqa.selenium.By
-import org.openqa.selenium.firefox.FirefoxDriver
-
-fun main() {
-    val driver = FirefoxDriver()
-    try {
-        driver.get("https://example.com")
-        // Obtém todos os elementos disponiveis com o nome da tag 'p'
-        val elements = driver.findElements(By.tagName("p"))
-        for (element in elements) {
-            println("Paragraph text:" + element.text)
-        }
-    } finally {
-        driver.quit()
-    }
-}
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L53-L56">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -285,108 +207,24 @@ fun main() {
 Ele é usado para localizar a lista de WebElements filhos correspondentes dentro do contexto do elemento pai.
 Para realizar isso, o WebElement pai é encadeado com o 'findElements' para acessar seus elementos filhos.
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-  import org.openqa.selenium.By;
-  import org.openqa.selenium.WebDriver;
-  import org.openqa.selenium.WebElement;
-  import org.openqa.selenium.chrome.ChromeDriver;
-  import java.util.List;
-
-  public class findElementsFromElement {
-      public static void main(String[] args) {
-          WebDriver driver = new ChromeDriver();
-          try {
-              driver.get("https://example.com");
-
-              // Obtém o elemento com o nome da tag 'div'
-              WebElement element = driver.findElement(By.tagName("div"));
-
-              // Obtém todos os elementos disponiveis com o nome da tag 'p'
-              List<WebElement> elements = element.findElements(By.tagName("p"));
-              for (WebElement e : elements) {
-                  System.out.println(e.getText());
-              }
-          } finally {
-              driver.quit();
-          }
-      }
-  }
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L74-L78">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L75-L78" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L61-L64">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using OpenQA.Selenium;
-using OpenQA.Selenium.Chrome;
-using System.Collections.Generic;
-
-namespace FindElementsFromElement {
- class FindElementsFromElement {
-  public static void Main(string[] args) {
-   IWebDriver driver = new ChromeDriver();
-   try {
-    driver.Navigate().GoToUrl("https://example.com");
-
-    // Obtém o elemento com o nome da tag 'div'
-    IWebElement element = driver.FindElement(By.TagName("div"));
-
-    // Obtém todos os elementos disponíveis com o nome da tag 'p'
-    IList < IWebElement > elements = element.FindElements(By.TagName("p"));
-    foreach(IWebElement e in elements) {
-     System.Console.WriteLine(e.Text);
-    }
-   } finally {
-    driver.Quit();
-   }
-  }
- }
-}
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L73-L78">}}
   {{< /tab >}}
-   {{< tab header="Ruby" text=true >}}
-   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L33-L35" >}}
+   {{< tab header="Ruby" >}}
+   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L48-L51" >}}
    {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  const {Builder, By} = require('selenium-webdriver');
-
-  (async function example() {
-      let driver = new Builder()
-          .forBrowser('chrome')
-          .build();
-
-      await driver.get('https://www.example.com');
-
-      //  Obtém o elemento com o nome da tag 'div'
-      let element = driver.findElement(By.css("div"));
-
-      // Obtém todos os elementos disponíveis com o nome da tag 'p'
-      let elements = await element.findElements(By.css("p"));
-      for(let e of elements) {
-          console.log(await e.getText());
-      }
-  })();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L59-L63">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-  import org.openqa.selenium.By
-  import org.openqa.selenium.chrome.ChromeDriver
-
-  fun main() {
-      val driver = ChromeDriver()
-      try {
-          driver.get("https://example.com")
-
-           // Obtém o elemento com o nome da tag 'div'
-          val element = driver.findElement(By.tagName("div"))
-
-          // Obtém todos os elementos disponíveis com o nome da tag 'p'
-          val elements = element.findElements(By.tagName("p"))
-          for (e in elements) {
-              println(e.text)
-          }
-      } finally {
-          driver.quit()
-      }
-  }
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L64-L68">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -394,86 +232,24 @@ namespace FindElementsFromElement {
 
 Ele é usado para rastrear (ou) encontrar um elemento DOM que tem o foco no contexto de navegação atual.
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-  import org.openqa.selenium.*;
-  import org.openqa.selenium.chrome.ChromeDriver;
-
-  public class activeElementTest {
-    public static void main(String[] args) {
-      WebDriver driver = new ChromeDriver();
-      try {
-        driver.get("http://www.google.com");
-        driver.findElement(By.cssSelector("[name='q']")).sendKeys("webElement");
-
-        // Obter atributo do elemento atualmente ativo
-        String attr = driver.switchTo().activeElement().getAttribute("title");
-        System.out.println(attr);
-      } finally {
-        driver.quit();
-      }
-    }
-  }
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L88-L89">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L89-L90" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L72-L73">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Chrome;
-
-    namespace ActiveElement {
-     class ActiveElement {
-      public static void Main(string[] args) {
-       IWebDriver driver = new ChromeDriver();
-       try {
-        // Navegar até a URL
-        driver.Navigate().GoToUrl("https://www.google.com");
-        driver.FindElement(By.CssSelector("[name='q']")).SendKeys("webElement");
-
-        // Obter atributo do elemento atualmente ativo
-        string attr = driver.SwitchTo().ActiveElement().GetAttribute("title");
-        System.Console.WriteLine(attr);
-       } finally {
-        driver.Quit();
-       }
-      }
-     }
-    }
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L89-L90">}}
   {{< /tab >}}
-  {{< tab header="Ruby" text=true >}}
-  {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L40-L41" >}}
+  {{< tab header="Ruby" >}}
+  {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L58-L60" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  const {Builder, By} = require('selenium-webdriver');
-
-  (async function example() {
-      let driver = await new Builder().forBrowser('chrome').build();
-      await driver.get('https://www.google.com');
-      await  driver.findElement(By.css('[name="q"]')).sendKeys("webElement");
-
-      // Obter atributo do elemento atualmente ativo
-      let attr = await driver.switchTo().activeElement().getAttribute("title");
-      console.log(`${attr}`)
-  })();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L72-L73">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-  import org.openqa.selenium.By
-  import org.openqa.selenium.chrome.ChromeDriver
-
-  fun main() {
-      val driver = ChromeDriver()
-      try {
-          driver.get("https://www.google.com")
-          driver.findElement(By.cssSelector("[name='q']")).sendKeys("webElement")
-
-          // Obter atributo do elemento atualmente ativo
-          val attr = driver.switchTo().activeElement().getAttribute("title")
-          print(attr)
-      } finally {
-          driver.quit()
-      }
-  }
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L76-L77">}}
   {{< /tab >}}
 {{< /tabpane >}}
 

--- a/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
+++ b/website_and_docs/content/documentation/webdriver/elements/finders.zh-cn.md
@@ -14,20 +14,7 @@ description: >
 使用 Selenium 最基本的特点之一是获取可用于操作的元素引用。
 Selenium 提供了许多内置的 [定位策略]({{< ref "locators.md" >}})，用于唯一标识元素。
 在更复杂的场景中，可以用多种方式使用这些定位器。为了本篇文档的目的，
-我们来考虑下面的 HTML 片段：
-
-```html
-<ol id="vegetables">
- <li class="potatoes">…
- <li class="onions">…
- <li class="tomatoes"><span>Tomato is a Vegetable</span>…
-</ol>
-<ul id="fruits">
-  <li class="bananas">…
-  <li class="apples">…
-  <li class="tomatoes"><span>Tomato is a Fruit</span>…
-</ul>
-```
+请使用 [Selenium 定位器测试页面](https://www.selenium.dev/selenium/web/locators_tests/locators.html)。
 
 ## 第一个匹配的元素
 
@@ -39,27 +26,27 @@ Selenium 提供了许多内置的 [定位策略]({{< ref "locators.md" >}})，�
 当在 driver 实例上调用 find element 方法时，
 它会返回 DOM 中与所提供定位器匹配的第一个元素的引用。
 该引用可以被保存并用于后续的元素操作。
-在上面的示例 HTML 中，有两个 class 名称为 "tomatoes" 的元素，
-因此此方法会返回位于 "vegetables" 列表中的那个元素。
+在 Selenium 定位器测试页面上，有两个 class 名称为 `information` 的元素，
+因此此方法会返回第一个文本输入框。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement vegetable = driver.findElement(By.className("tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L22-L23">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L23">}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L7-L8">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-var vegetable = driver.FindElement(By.ClassName("tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L15-L16">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L10" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L10-L11" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const vegetable = await driver.findElement(By.className('tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L9-L10">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L19-L20">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -69,35 +56,28 @@ val vegetable: WebElement = driver.findElement(By.className("tomatoes"))
 
 与其在整个 DOM 中寻找唯一的定位器，
 通常更有用的是将搜索范围缩小到另一个已定位元素的作用域内。
-在上面的示例中，有两个 class 名为 "tomatoes" 的元素，
-因此要获取第二个元素的引用会更具挑战性。
 
-一种解决办法是先定位一个具有唯一属性的元素，
-该元素是目标元素的祖先但不是非目标元素的祖先，
+一种解决办法是先定位目标元素的祖先，
 然后在该对象上调用 `find element`：
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement fruits = driver.findElement(By.id("fruits"));
-WebElement fruit = fruits.findElement(By.className("tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L31-L33">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L28-L29">}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L14-L16">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IWebElement fruits = driver.FindElement(By.Id("fruits"));
-IWebElement fruit = fruits.FindElement(By.ClassName("tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L25-L27">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L14-L15" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L17-L19" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruits = await driver.findElement(By.id('fruits'));
-const fruit = fruits.findElement(By.className('tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L18-L20">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val fruits = driver.findElement(By.id("fruits"))
-val fruit = fruits.findElement(By.className("tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L27-L29">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -121,7 +101,7 @@ SearchContext shadowRoot = shadowHost.getShadowRoot();
 WebElement shadowContent = shadowRoot.findElement(By.cssSelector("#shadow_content"));
 {{< /tab >}}
 {{< tab header="Python" text=true >}}
-{{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L47-L50">}}
+{{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L39-L42">}}
 {{< /tab >}}
 {{< tab header="CSharp" >}}
 var shadowHost = _driver.FindElement(By.CssSelector("#shadow_host"));
@@ -152,24 +132,24 @@ shadow_content = shadow_root.find_element(css: '#shadow_content')
 
 在本例中，我们将使用 CSS 选择器：
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-WebElement fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L41-L42">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L34" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L22-L23">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-var fruit = driver.FindElement(By.CssSelector("#fruits .tomatoes"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L36-L37">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L19" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L25-L26" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const fruit = await driver.findElement(By.css('#fruits .tomatoes'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L28-L29">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L36-L37">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -179,26 +159,26 @@ val fruit = driver.findElement(By.cssSelector("#fruits .tomatoes"))
 
 在某些情况下，需要获取与定位器匹配的所有元素的引用，而不是仅获取第一个。
 复数形式的 `find elements` 方法会返回一组元素引用。如果没有匹配项，则返回空列表。
-在本例中，将返回所有水果和蔬菜列表项的引用集合。
+在本例中，将返回所有 input 元素的引用集合。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-List<WebElement> plants = driver.findElements(By.tagName("li"));
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L50-L51">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L39" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L29-L30">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-IReadOnlyList<IWebElement> plants = driver.FindElements(By.TagName("li"));
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L46-L47">}}
   {{< /tab >}}
-{{< tab header="Ruby" text=true >}}
-{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L23" >}}
+{{< tab header="Ruby" >}}
+{{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L32-L33" >}}
 {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const plants = await driver.findElements(By.tagName('li'));
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L37-L38">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-val plants: List<WebElement> = driver.findElements(By.tagName("li"))
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L44-L45">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -207,82 +187,24 @@ val plants: List<WebElement> = driver.findElements(By.tagName("li"))
 这意味着需要遍历该集合并找到目标元素。
 
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-List<WebElement> elements = driver.findElements(By.tagName("li"));
-
-for (WebElement element : elements) {
-    System.out.println("Paragraph text:" + element.getText());
-}
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L61-L64">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L62-L64" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L51-L53">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using OpenQA.Selenium;
-using OpenQA.Selenium.Firefox;
-using System.Collections.Generic;
-
-namespace FindElementsExample {
- class FindElementsExample {
-  public static void Main(string[] args) {
-   IWebDriver driver = new FirefoxDriver();
-   try {
-    // Navigate to Url
-    driver.Navigate().GoToUrl("https://example.com");
-
-    // Get all the elements available with tag name 'p'
-    IList < IWebElement > elements = driver.FindElements(By.TagName("p"));
-    foreach(IWebElement e in elements) {
-     System.Console.WriteLine(e.Text);
-    }
-
-   } finally {
-    driver.Quit();
-   }
-  }
- }
-}
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L58-L62">}}
   {{< /tab >}}
-   {{< tab header="Ruby" text=true >}}
-   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L28-L29" >}}
+   {{< tab header="Ruby" >}}
+   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L40-L42" >}}
    {{< /tab >}}
   {{< tab header="JavaScript" >}}
-const {Builder, By} = require('selenium-webdriver');
-(async function example() {
-    let driver = await new Builder().forBrowser('firefox').build();
-    try {
-        // Navigate to Url
-        await driver.get('https://www.example.com');
-
-        // Get all the elements available with tag 'p'
-        let elements = await driver.findElements(By.css('p'));
-        for(let e of elements) {
-            console.log(await e.getText());
-        }
-    }
-    finally {
-        await driver.quit();
-    }
-})();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L47-L50">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-import org.openqa.selenium.By
-import org.openqa.selenium.firefox.FirefoxDriver
-
-fun main() {
-    val driver = FirefoxDriver()
-    try {
-        driver.get("https://example.com")
-        // Get all the elements available with tag name 'p'
-        val elements = driver.findElements(By.tagName("p"))
-        for (element in elements) {
-            println("Paragraph text:" + element.text)
-        }
-    } finally {
-        driver.quit()
-    }
-}
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L53-L56">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -291,108 +213,24 @@ fun main() {
 用于在父元素的上下文中查找匹配的子 WebElement 列表。
 为此，可在父 WebElement 上链式调用 `findElements` 来访问子元素。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-  import org.openqa.selenium.By;
-  import org.openqa.selenium.WebDriver;
-  import org.openqa.selenium.WebElement;
-  import org.openqa.selenium.chrome.ChromeDriver;
-  import java.util.List;
-
-  public class findElementsFromElement {
-      public static void main(String[] args) {
-          WebDriver driver = new ChromeDriver();
-          try {
-              driver.get("https://example.com");
-
-              // Get element with tag name 'div'
-              WebElement element = driver.findElement(By.tagName("div"));
-
-              // Get all the elements available with tag name 'p'
-              List<WebElement> elements = element.findElements(By.tagName("p"));
-              for (WebElement e : elements) {
-                  System.out.println(e.getText());
-              }
-          } finally {
-              driver.quit();
-          }
-      }
-  }
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L74-L78">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L75-L78" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L61-L64">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-using OpenQA.Selenium;
-using OpenQA.Selenium.Chrome;
-using System.Collections.Generic;
-
-namespace FindElementsFromElement {
- class FindElementsFromElement {
-  public static void Main(string[] args) {
-   IWebDriver driver = new ChromeDriver();
-   try {
-    driver.Navigate().GoToUrl("https://example.com");
-
-    // Get element with tag name 'div'
-    IWebElement element = driver.FindElement(By.TagName("div"));
-
-    // Get all the elements available with tag name 'p'
-    IList < IWebElement > elements = element.FindElements(By.TagName("p"));
-    foreach(IWebElement e in elements) {
-     System.Console.WriteLine(e.Text);
-    }
-   } finally {
-    driver.Quit();
-   }
-  }
- }
-}
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L73-L78">}}
   {{< /tab >}}
-   {{< tab header="Ruby" text=true >}}
-   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L33-L35" >}}
+   {{< tab header="Ruby" >}}
+   {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L48-L51" >}}
    {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  const {Builder, By} = require('selenium-webdriver');
-
-  (async function example() {
-      let driver = new Builder()
-          .forBrowser('chrome')
-          .build();
-
-      await driver.get('https://www.example.com');
-
-      // Get element with tag name 'div'
-      let element = driver.findElement(By.css("div"));
-
-      // Get all the elements available with tag name 'p'
-      let elements = await element.findElements(By.css("p"));
-      for(let e of elements) {
-          console.log(await e.getText());
-      }
-  })();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L59-L63">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-  import org.openqa.selenium.By
-  import org.openqa.selenium.chrome.ChromeDriver
-
-  fun main() {
-      val driver = ChromeDriver()
-      try {
-          driver.get("https://example.com")
-
-          // Get element with tag name 'div'
-          val element = driver.findElement(By.tagName("div"))
-
-          // Get all the elements available with tag name 'p'
-          val elements = element.findElements(By.tagName("p"))
-          for (e in elements) {
-              println(e.text)
-          }
-      } finally {
-          driver.quit()
-      }
-  }
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L64-L68">}}
   {{< /tab >}}
 {{< /tabpane >}}
 
@@ -400,86 +238,24 @@ namespace FindElementsFromElement {
 
 用于跟踪或查找当前浏览上下文中具有焦点的 DOM 元素。
 
-{{< tabpane langEqualsHeader=true >}}
+{{< tabpane langEqualsHeader=true text=true >}}
   {{< tab header="Java" >}}
-  import org.openqa.selenium.*;
-  import org.openqa.selenium.chrome.ChromeDriver;
-
-  public class activeElementTest {
-    public static void main(String[] args) {
-      WebDriver driver = new ChromeDriver();
-      try {
-        driver.get("http://www.google.com");
-        driver.findElement(By.cssSelector("[name='q']")).sendKeys("webElement");
-
-        // Get attribute of current active element
-        String attr = driver.switchTo().activeElement().getAttribute("title");
-        System.out.println(attr);
-      } finally {
-        driver.quit();
-      }
-    }
-  }
+  {{< gh-codeblock path="/examples/java/src/test/java/dev/selenium/elements/FindersTest.java#L88-L89">}}
   {{< /tab >}}
-  {{< tab header="Python" text=true >}}
-  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L89-L90" >}}
+  {{< tab header="Python" >}}
+  {{< gh-codeblock path="/examples/python/tests/elements/test_finders.py#L72-L73">}}
   {{< /tab >}}
   {{< tab header="CSharp" >}}
-    using OpenQA.Selenium;
-    using OpenQA.Selenium.Chrome;
-
-    namespace ActiveElement {
-     class ActiveElement {
-      public static void Main(string[] args) {
-       IWebDriver driver = new ChromeDriver();
-       try {
-        // Navigate to Url
-        driver.Navigate().GoToUrl("https://www.google.com");
-        driver.FindElement(By.CssSelector("[name='q']")).SendKeys("webElement");
-
-        // Get attribute of current active element
-        string attr = driver.SwitchTo().ActiveElement().GetAttribute("title");
-        System.Console.WriteLine(attr);
-       } finally {
-        driver.Quit();
-       }
-      }
-     }
-    }
+  {{< gh-codeblock path="/examples/dotnet/SeleniumDocs/Elements/FindersTest.cs#L89-L90">}}
   {{< /tab >}}
-  {{< tab header="Ruby" text=true >}}
-  {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L40-L41" >}}
+  {{< tab header="Ruby" >}}
+  {{< gh-codeblock path="/examples/ruby/spec/elements/finders_spec.rb#L58-L60" >}}
   {{< /tab >}}
   {{< tab header="JavaScript" >}}
-  const {Builder, By} = require('selenium-webdriver');
-
-  (async function example() {
-      let driver = await new Builder().forBrowser('chrome').build();
-      await driver.get('https://www.google.com');
-      await  driver.findElement(By.css('[name="q"]')).sendKeys("webElement");
-
-      // Get attribute of current active element
-      let attr = await driver.switchTo().activeElement().getAttribute("title");
-      console.log(`${attr}`)
-  })();
+  {{< gh-codeblock path="/examples/javascript/test/elements/finders.spec.js#L72-L73">}}
   {{< /tab >}}
   {{< tab header="Kotlin" >}}
-  import org.openqa.selenium.By
-  import org.openqa.selenium.chrome.ChromeDriver
-
-  fun main() {
-      val driver = ChromeDriver()
-      try {
-          driver.get("https://www.google.com")
-          driver.findElement(By.cssSelector("[name='q']")).sendKeys("webElement")
-
-          // Get attribute of current active element
-          val attr = driver.switchTo().activeElement().getAttribute("title")
-          print(attr)
-      } finally {
-          driver.quit()
-      }
-  }
+  {{< gh-codeblock path="/examples/kotlin/src/test/kotlin/dev/selenium/elements/FindersTest.kt#L76-L77">}}
   {{< /tab >}}
 {{< /tabpane >}}
 


### PR DESCRIPTION
**Thanks for contributing to the Selenium site and documentation!**
**A PR well described will help maintainers to review and merge it quickly**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines.
Avoid large PRs, and help reviewers by making them as simple and short as possible.

### Description

Replaces the Finders doc's illustrative, non-executable inline HTML fixture with Selenium's
hosted [locator test page](https://www.selenium.dev/selenium/web/locators_tests/locators.html),
and moves every language's example (Java, Python, C#, Ruby, JavaScript, Kotlin) into the
`examples/` directory as real, assertion-bearing, CI-runnable tests referenced via
`gh-codeblock`, matching the site's documented "Creating/Moving Examples" workflow. Updates the
ja/pt-br/zh-cn translations to match.

Credit to `@Kasturi2004` for the original idea and attempt at this in #2776 (replacing the
inline HTML snippet with the hosted locator page). This PR builds on that starting point: it
fixes a bug the original introduced (the "Find Elements From Element" section printed
`getText()`/`.text` on `<input>` elements, which is always empty — now reads the `value`
attribute), and completes the migration for the languages that were left as inline,
untested snippets (Java, C#, JavaScript, Kotlin), which #2776 did not get to.

### Motivation and Context

The prior HTML snippet couldn't be executed, so the example tests for it were marked
skip/illustrative-only. Using the hosted test page makes every language's Finder examples
concrete, runnable, and verified in CI, consistent with the rest of the site's example
conventions.

### Types of changes

- [x] Change to the site (I have double-checked the Netlify deployment, and my changes look good)
- [x] Code example added (and I also added the example to all translated languages)
- [ ] Improved translation
- [ ] Added new translation (and I also added a notice to each document missing translation)

### Checklist

- [x] I have read the [**contributing**](https://selenium.dev/documentation/en/contributing/) document.
- [x] I have used [hugo](https://gohugo.io/) to render the site/docs locally and I am sure it works.

### Test plan

- `mvn test -Dtest=FindersTest` in `examples/java` and `examples/kotlin`: 7/7 passing.
- `dotnet test --filter FullyQualifiedName~FindersTest` in `examples/dotnet/SeleniumDocs`: 7/7 passing.
- `pytest tests/elements/test_finders.py` in `examples/python`: 8/8 passing.
- `bundle exec rspec spec/elements/finders_spec.rb` + `bundle exec rubocop` in `examples/ruby`: 7/7 passing, no lint offenses.
- `npx mocha test/elements/finders.spec.js` in `examples/javascript`: 7/7 passing.
- `./build-site.sh`: builds clean for all four locales (en, ja, pt-br, zh-cn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfNGQbess9DUXE21PrFEzc